### PR TITLE
Upgrade Ant Design to v5 and fix slider styling

### DIFF
--- a/src/components/workstation/Channel.css
+++ b/src/components/workstation/Channel.css
@@ -106,20 +106,20 @@
   }
 }
 
-/* Channel slider */
-.channel-slider .ant-slider-handle {
+/* Channel slider (antd v5: visible handle is ::after pseudo-element) */
+.channel-slider .ant-slider-handle::after {
   background-color: rgba(0, 0, 0, 0.9);
-  border-color: rgba(0, 0, 0, 0);
+  box-shadow: none;
 }
 
-.channel-slider .ant-slider-handle:focus,
-.channel-slider .ant-slider-handle.ant-tooltip-open {
+.channel-slider .ant-slider-handle:focus::after,
+.channel-slider .ant-slider-handle.ant-tooltip-open::after {
   background-color: rgba(0, 0, 0, 1);
   box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.12);
 }
 
-.channel-slider.ant-slider:hover .ant-slider-handle:not(.ant-tooltip-open) {
-  border-color: rgba(0, 0, 0, 0);
+.channel-slider.ant-slider:hover
+  .ant-slider-handle:not(.ant-tooltip-open)::after {
   box-shadow: 0 0 0 5px rgba(0, 0, 0, 0.12);
 }
 
@@ -133,21 +133,20 @@
   background-color: rgba(0, 0, 0, 0.65);
 }
 
-.channel--inverted .channel-slider .ant-slider-handle {
+.channel--inverted .channel-slider .ant-slider-handle::after {
   background-color: rgba(255, 255, 255, 0.9);
-  border-color: rgba(255, 255, 255, 0);
+  box-shadow: none;
 }
 
-.channel--inverted .channel-slider .ant-slider-handle:focus,
-.channel--inverted .channel-slider .ant-slider-handle.ant-tooltip-open {
+.channel--inverted .channel-slider .ant-slider-handle:focus::after,
+.channel--inverted .channel-slider .ant-slider-handle.ant-tooltip-open::after {
   background-color: rgba(255, 255, 255, 1);
   box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.12);
 }
 
 .channel--inverted
   .channel-slider.ant-slider:hover
-  .ant-slider-handle:not(.ant-tooltip-open) {
-  border-color: rgba(255, 255, 255, 0);
+  .ant-slider-handle:not(.ant-tooltip-open)::after {
   box-shadow: 0 0 0 5px rgba(255, 255, 255, 0.12);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,11 @@
+@layer antd;
+
 body {
   height: 100vh;
   width: 100vw;
+  margin: 0;
+  background-color: #000;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 #root {
@@ -17,17 +22,6 @@ html {
   --error-color: #ff4d4f;
 }
 
-@media (max-width: 768px) {
-  /* Override header extra styling for mobile devices in portrait mode. */
-  .ant-page-header-heading-extra {
-    display: initial;
-    float: right;
-    clear: initial;
-    width: initial;
-    padding-top: 0;
-  }
-}
-
 @media (hover: hover) and (pointer: fine) {
   /* Style scrollbar on desktop devices only. */
   html {
@@ -37,7 +31,7 @@ html {
 
   div {
     scrollbar-width: thin;
-    scrollbar-color: dark;
+    scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
   }
 
   div::-webkit-scrollbar {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { StyleProvider } from '@ant-design/cssinjs';
 import { App as AntApp, ConfigProvider, message, theme } from 'antd';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
@@ -13,13 +14,15 @@ AudioService.startAudio()
 
 const root = createRoot(document.getElementById('root')!);
 root.render(
-  <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
-    <AntApp>
-      <BrowserSupportProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </BrowserSupportProvider>
-    </AntApp>
-  </ConfigProvider>,
+  <StyleProvider layer>
+    <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }}>
+      <AntApp>
+        <BrowserSupportProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </BrowserSupportProvider>
+      </AntApp>
+    </ConfigProvider>
+  </StyleProvider>,
 );


### PR DESCRIPTION
## Summary
This PR upgrades the application to be compatible with Ant Design v5, addressing breaking changes in the slider component styling and CSS-in-JS handling.

## Key Changes
- **Slider handle styling**: Updated `.ant-slider-handle` selectors to target the `::after` pseudo-element, which is now the visible handle in Ant Design v5
  - Replaced `border-color` properties with `box-shadow: none` for consistency
  - Updated all related focus and hover states for both normal and inverted channel sliders
  
- **CSS-in-JS layer support**: Wrapped the app with `StyleProvider` from `@ant-design/cssinjs` and added `@layer antd` declaration to properly handle CSS cascade in v5

- **Global styles cleanup**: 
  - Added explicit `margin: 0`, `background-color`, and `color` to body element
  - Removed obsolete mobile media query for `ant-page-header-heading-extra` (no longer needed in v5)
  - Updated scrollbar color to use CSS variables for better maintainability

## Implementation Details
The main breaking change addressed is Ant Design v5's redesign of the slider handle as a pseudo-element (`::after`), requiring all styling to target this pseudo-element rather than the element itself. The `StyleProvider` wrapper ensures proper CSS layer ordering and prevents style conflicts with the new CSS-in-JS system.

https://claude.ai/code/session_01E746wVT4iWRH6NkxwMesRc