### PR TITLE
Add end-to-end tests with Playwright

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,8 +8,11 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 
-echo "Installing npm dependencies..."
-npm install
+# Only install if node_modules is missing or package-lock.json has changed
+if [ ! -d node_modules ] || [ package-lock.json -nt node_modules ]; then
+  echo "Installing npm dependencies..."
+  npm install
+fi
 
 # Install Netlify CLI if not present
 if ! type netlify &>/dev/null; then

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -27,8 +27,8 @@ if ! type gh &>/dev/null; then
   apt-get update -q && apt-get install -y gh
 fi
 
-# Install Playwright browsers if not present
-if ! playwright show-browsers 2>/dev/null | grep -q chromium; then
+# Install Playwright browsers if not present (uses project's @playwright/test version)
+if ! npx playwright show-browsers 2>/dev/null | grep -q chromium; then
   echo "Installing Playwright Chromium..."
   npx playwright install --with-deps chromium
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,29 +8,37 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 
+# Run npm ci and system tool installs in parallel — they are independent
 echo "Installing npm dependencies..."
-npm ci
+npm ci &
+NPM_PID=$!
 
 # Install Netlify CLI if not present
 if ! type netlify &>/dev/null; then
   echo "Installing netlify-cli..."
-  npm install -g netlify-cli
+  npm install -g netlify-cli &
 fi
 
 # Install GitHub CLI if not present
 if ! type gh &>/dev/null; then
   echo "Installing gh CLI..."
-  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-  apt-get update -q && apt-get install -y gh
+  (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update -q && apt-get install -y gh) &
 fi
 
-# Install Playwright browsers if not present (uses project's @playwright/test version)
+# Wait for all parallel jobs before proceeding
+wait $NPM_PID
+
+# Install Playwright browsers if not present (requires node_modules from npm ci)
 if ! npx playwright show-browsers 2>/dev/null | grep -q chromium; then
   echo "Installing Playwright Chromium..."
   npx playwright install --with-deps chromium
 fi
+
+# Wait for any remaining background jobs (netlify, gh)
+wait
 
 echo "Session start hook complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,11 +8,8 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 
-# Only install if node_modules is missing or package-lock.json has changed
-if [ ! -d node_modules ] || [ package-lock.json -nt node_modules ]; then
-  echo "Installing npm dependencies..."
-  npm install
-fi
+echo "Installing npm dependencies..."
+npm ci
 
 # Install Netlify CLI if not present
 if ! type netlify &>/dev/null; then

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
 
 # production
 /build

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('displays the Mawimbi title', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Mawimbi' })).toBeVisible();
+  });
+
+  test('displays the Create Project button', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: 'Create Project' })
+    ).toBeVisible();
+  });
+
+  test('navigates to the project page when Create Project is clicked', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await expect(page).toHaveURL('/project');
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('shows a 404 message for unknown routes', async ({ page }) => {
+    await page.goto('/unknown-route');
+    await expect(page.getByText('/unknown-route')).toBeVisible();
+  });
+
+  test('home page is accessible at root path', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('heading', { name: 'Mawimbi' })).toBeVisible();
+  });
+
+  test('project page is accessible at /project', async ({ page }) => {
+    await page.goto('/project');
+    await expect(page).toHaveURL('/project');
+    await expect(
+      page.getByText('Start recording, or upload some audio files')
+    ).toBeVisible();
+  });
+});

--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Project page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/project');
+  });
+
+  test.describe('header', () => {
+    test('displays a back button', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Back' })).toBeVisible();
+    });
+
+    test('back button navigates to the home page', async ({ page }) => {
+      // Navigate from home so there is history to go back to
+      await page.goto('/');
+      await page.getByRole('button', { name: 'Create Project' }).click();
+      await expect(page).toHaveURL('/project');
+      await page.getByRole('button', { name: 'Back' }).click();
+      await expect(page).toHaveURL('/');
+    });
+
+    test('displays an upload button', async ({ page }) => {
+      await expect(page.getByText('Upload files')).toBeVisible();
+    });
+
+    test('displays an overflow menu button', async ({ page }) => {
+      const overflowButton = page.locator('.overflow-button');
+      await expect(overflowButton).toBeVisible();
+    });
+  });
+
+  test.describe('empty timeline', () => {
+    test('shows empty state message when no tracks are loaded', async ({
+      page,
+    }) => {
+      await expect(
+        page.getByText('Start recording, or upload some audio files')
+      ).toBeVisible();
+    });
+
+    test('shows drop files instruction on desktop', async ({ page }) => {
+      await expect(
+        page.getByText('Drop files here, or use the upload button above')
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('toolbar', () => {
+    test('play button is disabled when no tracks are loaded', async ({
+      page,
+    }) => {
+      const playButton = page.getByTitle('Play');
+      await expect(playButton).toBeDisabled();
+    });
+
+    test('mixer button is disabled when no tracks are loaded', async ({
+      page,
+    }) => {
+      const mixerButton = page.getByTitle('Show mixer');
+      await expect(mixerButton).toBeDisabled();
+    });
+
+    test('record button is enabled when no tracks are loaded', async ({
+      page,
+    }) => {
+      const recordButton = page.getByTitle('Record');
+      await expect(recordButton).toBeEnabled();
+    });
+  });
+});
+
+test.describe('Project page overflow menu', () => {
+  test('shows fullscreen option when overflow menu is opened', async ({
+    page,
+  }) => {
+    await page.goto('/project');
+    await page.locator('.overflow-button').click();
+    await expect(page.getByText('Enter Full Screen')).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
         "vitest": "^1.6.0",
         "wavesurfer.js": "^7.0.0"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.56.1"
+      },
       "engines": {
         "node": ">=22"
       }
@@ -1236,6 +1239,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -6076,6 +6095,53 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "preview": "vite preview",
     "lint": "eslint src",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "coverage": "vitest run --coverage",
     "prepare": "husky"
   },
@@ -77,5 +78,8 @@
   },
   "prettier": {
     "singleQuote": true
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     clearMocks: true,
+    exclude: ['**/node_modules/**', 'e2e/**'],
     server: {
       deps: {
         inline: ['tone'],


### PR DESCRIPTION
## Summary
This PR introduces comprehensive end-to-end testing using Playwright, covering the main user flows of the Mawimbi audio application.

## Key Changes
- **Added Playwright configuration** (`playwright.config.ts`) with:
  - Base URL pointing to local dev server (http://localhost:5173)
  - Chromium browser testing
  - HTML reporter for test results
  - Automatic web server startup during test runs
  - CI-optimized settings (retries, workers, trace collection)

- **Added E2E test suites**:
  - `e2e/home.spec.ts` - Tests home page rendering and navigation to project creation
  - `e2e/project.spec.ts` - Tests project page header, empty state, toolbar, and overflow menu functionality
  - `e2e/navigation.spec.ts` - Tests routing and 404 handling

- **Updated package.json**:
  - Added `@playwright/test` as a dev dependency
  - Added `test:e2e` npm script to run Playwright tests

- **Updated build scripts** (`.claude/hooks/session-start.sh`):
  - Changed `npm install` to `npm ci` for more reliable CI environments
  - Updated Playwright browser installation to use `npx playwright` for consistency

- **Updated .gitignore**:
  - Added `/test-results` and `/playwright-report` directories

## Notable Implementation Details
- Tests use semantic queries (getByRole, getByText) for better maintainability
- Tests verify both UI visibility and navigation behavior
- Toolbar tests validate button states (enabled/disabled) based on application state
- Configuration supports both local development and CI environments with appropriate parallelization settings

https://claude.ai/code/session_0195QWNjN71a3Ufb7kKz3YDr