### PR TITLE
Fix AntApp wrapper height to fill full viewport

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,11 @@ body {
   height: 100%;
 }
 
+/* AntApp renders a div wrapper that must also fill the full height */
+.ant-app {
+  height: 100%;
+}
+
 /* TODO: move common styling here */
 html {
   --body-background: #000;


### PR DESCRIPTION
## Summary
Added CSS rule to ensure the AntApp wrapper div fills the full height of its container, maintaining consistent layout behavior with the existing body and html height styling.

## Changes
- Added `.ant-app { height: 100%; }` CSS rule to match the full-height layout pattern already established for body and html elements
- This ensures the Ant Design App component wrapper properly fills the available vertical space

## Details
The AntApp component renders a div wrapper that was not inheriting the full-height styling applied to parent elements. This fix aligns the wrapper's height behavior with the existing CSS conventions in the codebase, preventing potential layout issues where the wrapper might not expand to fill its container.

https://claude.ai/code/session_01UQ4bf7BUtLoXtV9nRfJiNi