### PR TITLE
Add includeCoAuthoredBy configuration option

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "includeCoAuthoredBy": false,
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
Added a new configuration option `includeCoAuthoredBy` to the Claude settings, defaulting to `false`.

## Changes
- Added `"includeCoAuthoredBy": false` to `.claude/settings.json` configuration file

## Details
This new setting allows users to control whether co-authored-by information should be included in generated content. The option is disabled by default to maintain backward compatibility with existing workflows.

https://claude.ai/code/session_01TDMixgNkosGy1BmHC4yNaX