### PR TITLE
fix: pause playback on swipe and rewind cleanly at end of track

### DIFF
--- a/src/components/workstation/Scrubber.tsx
+++ b/src/components/workstation/Scrubber.tsx
@@ -89,7 +89,7 @@ const Scrubber = (props: ScrubberProps) => {
             timelineScrollRef.current.clientWidth >=
           timelineScrollRef.current.scrollWidth;
         if (isEndOfScroll) {
-          dispatch([STOP_PLAYBACK]);
+          dispatch([STOP_AND_REWIND_PLAYBACK]);
         }
       }
     }
@@ -140,6 +140,7 @@ const Scrubber = (props: ScrubberProps) => {
       toggleRewindButton(timelineScrollRef.current.scrollLeft);
     }
 
+    pauseForUserScroll();
     debouncedSetTransportTime();
   };
 

--- a/src/components/workstation/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/__tests__/Scrubber.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import Scrubber from '../Scrubber';
 import { WorkstationDispatch } from '../useWorkstationDispatch';
-import { STOP_AND_REWIND_PLAYBACK } from '../workstationReducer';
+import { STOP_AND_REWIND_PLAYBACK, STOP_PLAYBACK } from '../workstationReducer';
 
 const mockDispatch = vi.fn();
 
@@ -53,6 +53,32 @@ it('stops and rewinds playback when rewind button is clicked', () => {
 
   expect(mockDispatch).toHaveBeenCalledTimes(1);
   expect(mockDispatch).toHaveBeenCalledWith([STOP_AND_REWIND_PLAYBACK]);
+});
+
+it('pauses playback when timeline is scrolled while playing', () => {
+  const { container } = render(
+    <WorkstationDispatch.Provider value={mockDispatch}>
+      <Scrubber {...{ ...defaultProps, isPlaying: true }} />
+    </WorkstationDispatch.Provider>,
+  );
+
+  const timeline = container.querySelector('.scrubber__timeline')!;
+  fireEvent.scroll(timeline);
+
+  expect(mockDispatch).toHaveBeenCalledWith([STOP_PLAYBACK]);
+});
+
+it('does not pause playback when timeline is scrolled while paused', () => {
+  const { container } = render(
+    <WorkstationDispatch.Provider value={mockDispatch}>
+      <Scrubber {...{ ...defaultProps, isPlaying: false }} />
+    </WorkstationDispatch.Provider>,
+  );
+
+  const timeline = container.querySelector('.scrubber__timeline')!;
+  fireEvent.scroll(timeline);
+
+  expect(mockDispatch).not.toHaveBeenCalledWith([STOP_PLAYBACK]);
 });
 
 it('transforms timeline vertical scale when drawer is open', () => {


### PR DESCRIPTION
- handleScroll now calls pauseForUserScroll() so touch/pointer swipe
  events pause playback (and set shouldResumeRef) just like wheel events;
  without this the animation loop kept overriding the user's swipe position
- stopPlaybackIfEndOfScroll now dispatches STOP_AND_REWIND_PLAYBACK instead
  of STOP_PLAYBACK, atomically resetting both isPlaying and transportTime to
  a clean state; the old code left transportTime stale so usePlaybackControl
  seeked Tone.js to the wrong position, causing the race condition between
  the play/pause button and rewind button at end of track
- Add unit tests covering scroll-while-playing pauses and scroll-while-paused
  does not auto-pause

https://claude.ai/code/session_01Rry63WqLWa2KpztN1SQQDr