### PR TITLE
Add touch swipe support for timeline scrubbing during playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,14 @@ Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value 
 - **Explaining variables:** Extract complex expressions into named variables rather than inlining them.
 - **Comments:** Explain _why_, never _what_. Code should be self-explanatory; comments document intent and reasoning.
 
+## Bug Fixes
+
+When fixing a bug, always write a failing test that demonstrates the bug **before** implementing the fix. This confirms the test correctly captures the bug and ensures the fix is verified by the test rather than assumed correct.
+
+1. Write a unit or e2e test that reproduces the bug and confirm it fails
+2. Implement the fix
+3. Confirm the previously failing test now passes
+
 ## Testing
 
 Vitest + React Testing Library. Test setup (`setupTests.ts`) globally mocks:

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -1,0 +1,139 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-10s.wav');
+
+/**
+ * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
+ */
+async function uploadAudioFile(
+  page: import('@playwright/test').Page,
+  filePath: string,
+) {
+  const fileInput = page.locator('.project-page-header input[type="file"]');
+  await fileInput.setInputFiles(filePath);
+}
+
+/**
+ * Simulates a horizontal touch-swipe gesture on the timeline using CDP.
+ * This mirrors what a real user does when dragging the timeline with their finger.
+ */
+async function swipeTimeline(
+  page: import('@playwright/test').Page,
+  deltaX: number,
+) {
+  const timeline = page.locator('.scrubber__timeline');
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error('Timeline not visible');
+
+  const startX = Math.round(box.x + box.width / 2);
+  const startY = Math.round(box.y + box.height / 2);
+  const endX = startX - deltaX;
+  const steps = 5;
+
+  const client = await page.context().newCDPSession(page);
+
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: startX, y: startY }],
+  });
+
+  for (let i = 1; i <= steps; i++) {
+    const currentX = Math.round(startX + ((endX - startX) * i) / steps);
+    await page.waitForTimeout(20);
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: currentX, y: startY }],
+    });
+  }
+
+  await page.waitForTimeout(20);
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  });
+
+  await client.detach();
+}
+
+test.describe('Swipe to scrub timeline during playback', () => {
+  test.use({ hasTouch: true });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/project');
+    await uploadAudioFile(page, LONG_AUDIO);
+    await expect(page.locator('.timeline__waveform')).toBeVisible();
+
+    // Dismiss the fullscreen overlay that appears on touch-capable devices
+    const dismissButton = page.getByText('Dismiss');
+    if (await dismissButton.isVisible()) {
+      await dismissButton.click();
+    }
+    await expect(page.locator('.fullscreen__overlay')).not.toBeVisible();
+  });
+
+  test('swiping the timeline during playback pauses, then resumes at new position', async ({
+    page,
+  }) => {
+    // Start playback
+    await page.getByTitle('Play').click();
+    await expect(page.getByTitle('Pause')).toBeVisible();
+
+    // Let playback advance briefly
+    await page.waitForTimeout(300);
+
+    // User swipes the timeline with a touch gesture while playing
+    await swipeTimeline(page, 400);
+
+    // Playback should pause during the swipe
+    await expect(page.getByTitle('Play')).toBeVisible();
+
+    // Wait for the 200ms debounce to complete and playback to resume
+    await page.waitForTimeout(400);
+
+    // Playback should resume at the new position
+    await expect(page.getByTitle('Pause')).toBeVisible();
+  });
+
+  test('swiping the timeline while paused does not auto-resume', async ({
+    page,
+  }) => {
+    // Ensure we are paused
+    await expect(page.getByTitle('Play')).toBeVisible();
+
+    // Swipe the timeline while paused
+    await swipeTimeline(page, 300);
+
+    // Wait for debounce
+    await page.waitForTimeout(400);
+
+    // Should still be paused — no auto-resume when not playing
+    await expect(page.getByTitle('Play')).toBeVisible();
+  });
+
+  test('cursor loses playing class when swipe pauses playback', async ({
+    page,
+  }) => {
+    const cursor = page.locator('.cursor');
+
+    // Start playback
+    await page.getByTitle('Play').click();
+    await expect(cursor).toHaveClass(/cursor--is-playing/);
+
+    // Swipe to pause
+    await swipeTimeline(page, 400);
+
+    // Cursor should lose the playing class while paused
+    await expect(cursor).not.toHaveClass(/cursor--is-playing/);
+
+    // Wait for debounce and resume
+    await page.waitForTimeout(400);
+
+    // Cursor should regain the playing class
+    await expect(cursor).toHaveClass(/cursor--is-playing/);
+  });
+});

--- a/src/components/workstation/Scrubber.tsx
+++ b/src/components/workstation/Scrubber.tsx
@@ -130,6 +130,11 @@ const Scrubber = (props: ScrubberProps) => {
     debouncedSetTransportTime();
   };
 
+  const handleTouchMove = () => {
+    pauseForUserScroll();
+    debouncedSetTransportTime();
+  };
+
   const handleScroll = () => {
     if (isProgrammaticScrollRef.current) {
       isProgrammaticScrollRef.current = false;
@@ -188,6 +193,7 @@ const Scrubber = (props: ScrubberProps) => {
         onClick={togglePlayback}
         onScroll={handleScroll}
         onWheel={handleWheel}
+        onTouchMove={handleTouchMove}
       >
         {props.children}
       </div>


### PR DESCRIPTION
## Summary
This PR adds support for touch-based timeline scrubbing (swiping) during audio playback. Users can now swipe horizontally on the timeline to seek to a new position, with playback automatically pausing during the swipe and resuming at the new position.

## Key Changes
- **Scrubber component**: Added `onTouchMove` handler that pauses playback and updates the transport time when the user swipes the timeline
- **E2E tests**: Added comprehensive test suite (`swipe-playback.spec.ts`) with three test cases:
  - Swiping during playback pauses and then resumes at the new position
  - Swiping while paused does not auto-resume playback
  - Cursor loses the "playing" class during swipe and regains it after resume

## Implementation Details
- The `handleTouchMove` handler reuses existing logic (`pauseForUserScroll` and `debouncedSetTransportTime`) to maintain consistency with scroll/wheel-based scrubbing
- Touch events are simulated in tests using Playwright's CDP (Chrome DevTools Protocol) to accurately mirror real user touch gestures
- A 200ms debounce is applied before resuming playback to allow the user to complete their interaction
- The implementation respects the existing playback state: only resumes if playback was active before the swipe

https://claude.ai/code/session_01AUNf35XZBAvsFDi8abtXnD