### PR TITLE
docs(CLAUDE.md): add CLI gotchas from session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ gh pr create --repo vsandvold/mawimbi ...
 
 The main branch is `master`.
 
+`Read` only works on files — passing a directory path returns `EISDIR`. Use `Glob` to explore directory contents instead.
+
 Prettier runs automatically on pre-commit via Husky + lint-staged (ESLint --fix + prettier --write on staged TS/TSX files).
 
 ## Tech Stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,14 +203,3 @@ Vitest + React Testing Library. Test setup (`setupTests.ts`) globally mocks:
 
 `clearMocks: true` in `vite.config.ts` resets mock call counts between tests.
 
-### E2E tests with touch emulation
-
-When using `test.use({ hasTouch: true })`, the browser reports touch support and `browserSupport.touchEvents` becomes `true`. This triggers the fullscreen overlay in `Fullscreen.tsx`, which covers the entire page and intercepts all pointer events. Always dismiss it in `beforeEach` before interacting with the page:
-
-```ts
-const dismissButton = page.getByText('Dismiss');
-if (await dismissButton.isVisible()) {
-  await dismissButton.click();
-}
-await expect(page.locator('.fullscreen__overlay')).not.toBeVisible();
-```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,15 @@ To run a single test file:
 npm test -- src/path/to/File.test.tsx
 ```
 
+### GitHub CLI
+
+The git remote uses a local proxy URL, so `gh` cannot infer the repo from the remote. Always pass `--repo vsandvold/mawimbi` explicitly:
+
+```bash
+gh issue view 19 --repo vsandvold/mawimbi
+gh pr create --repo vsandvold/mawimbi ...
+```
+
 Prettier runs automatically on pre-commit via Husky + lint-staged (ESLint --fix + prettier --write on staged TS/TSX files).
 
 ## Tech Stack
@@ -193,3 +202,15 @@ Vitest + React Testing Library. Test setup (`setupTests.ts`) globally mocks:
 - `react-router-dom` — mock `useNavigate` and `useLocation`
 
 `clearMocks: true` in `vite.config.ts` resets mock call counts between tests.
+
+### E2E tests with touch emulation
+
+When using `test.use({ hasTouch: true })`, the browser reports touch support and `browserSupport.touchEvents` becomes `true`. This triggers the fullscreen overlay in `Fullscreen.tsx`, which covers the entire page and intercepts all pointer events. Always dismiss it in `beforeEach` before interacting with the page:
+
+```ts
+const dismissButton = page.getByText('Dismiss');
+if (await dismissButton.isVisible()) {
+  await dismissButton.click();
+}
+await expect(page.locator('.fullscreen__overlay')).not.toBeVisible();
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,7 @@ gh issue view 19 --repo vsandvold/mawimbi
 gh pr create --repo vsandvold/mawimbi ...
 ```
 
-### Git branch and push rules
-
-- `master` is protected — direct pushes return 403. Always work on a `claude/` branch and open a PR.
-- Use `git checkout <branch>` to switch to an existing branch. `git checkout -b` fails if the branch already exists.
+The main branch is `master`.
 
 Prettier runs automatically on pre-commit via Husky + lint-staged (ESLint --fix + prettier --write on staged TS/TSX files).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@ gh issue view 19 --repo vsandvold/mawimbi
 gh pr create --repo vsandvold/mawimbi ...
 ```
 
+### Git branch and push rules
+
+- `master` is protected — direct pushes return 403. Always work on a `claude/` branch and open a PR.
+- Use `git checkout <branch>` to switch to an existing branch. `git checkout -b` fails if the branch already exists.
+
 Prettier runs automatically on pre-commit via Husky + lint-staged (ESLint --fix + prettier --write on staged TS/TSX files).
 
 ## Tech Stack


### PR DESCRIPTION
## Summary

- Always pass `--repo vsandvold/mawimbi` to `gh` commands (local proxy remote prevents automatic repo inference)
- Note that the main branch is `master`
- Note that `Read` cannot be used on directories (`EISDIR`)

https://claude.ai/code/session_01AUNf35XZBAvsFDi8abtXnD