### PR TITLE
Fix mixer channel drag-and-drop collision detection

### DIFF
--- a/e2e/mixer-reorder.spec.ts
+++ b/e2e/mixer-reorder.spec.ts
@@ -1,0 +1,120 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
+const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-long.wav');
+
+// Time to wait after the mixer opens so its 300 ms slide-in transition has
+// fully settled before @dnd-kit measures droppable rects.
+const MIXER_ANIMATION_MS = 350;
+
+/**
+ * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
+ */
+async function uploadAudioFile(
+  page: import('@playwright/test').Page,
+  filePath: string,
+) {
+  const fileInput = page.locator('.project-page-header input[type="file"]');
+  await fileInput.setInputFiles(filePath);
+}
+
+/**
+ * Drags an element's centre to another element's centre using pointer events,
+ * which is what @dnd-kit's PointerSensor requires.
+ */
+async function dragTo(
+  page: import('@playwright/test').Page,
+  source: import('@playwright/test').Locator,
+  target: import('@playwright/test').Locator,
+) {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+  if (!sourceBox || !targetBox) throw new Error('Element not visible');
+
+  const startX = sourceBox.x + sourceBox.width / 2;
+  const startY = sourceBox.y + sourceBox.height / 2;
+  const endX = targetBox.x + targetBox.width / 2;
+  const endY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Move a tiny bit first to activate the PointerSensor
+  await page.mouse.move(startX, startY + 5);
+  // Then move to the target in steps to trigger collision detection
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.mouse.up();
+}
+
+test.describe('Mixer channel reordering', () => {
+  test.beforeEach(async ({ page }) => {
+    // Pin Math.random so track colours are deterministic across runs.
+    await page.addInitScript(() => {
+      Math.random = () => 0;
+    });
+    await page.goto('/project');
+
+    // Upload two tracks
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await uploadAudioFile(page, LONG_AUDIO);
+    await expect(page.locator('.timeline__waveform')).toHaveCount(2);
+
+    // Open the mixer and wait for the 300 ms slide-in animation to finish so
+    // @dnd-kit can measure accurate droppable rects.
+    await page.getByTitle('Show mixer').click();
+    await expect(page.locator('.channel')).toHaveCount(2);
+    await page.waitForTimeout(MIXER_ANIMATION_MS);
+  });
+
+  test('dragging a channel downward reorders tracks in the mixer', async ({
+    page,
+  }) => {
+    // With Math.random = () => 0, nextColorId starts at 0.
+    // Track 1 (SHORT_AUDIO, added first):  COLOR_PALETTE[0] = rgb(77, 238, 234)
+    // Track 2 (LONG_AUDIO, added second):  COLOR_PALETTE[1] = rgb(116, 238, 21)
+    // Mixer shows tracks in reverse order, so Track 2 is first (top) and
+    // Track 1 is second (bottom).
+    const channels = page.locator('.channel');
+    const colorBefore = await channels
+      .first()
+      .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+
+    // Drag the top channel's handle down to the bottom channel's handle.
+    const handles = page.locator('.channel__move');
+    await dragTo(page, handles.first(), handles.last());
+
+    // After dragging, the first channel should now have the other colour.
+    await expect(async () => {
+      const colorAfter = await channels
+        .first()
+        .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+      expect(colorAfter).not.toBe(colorBefore);
+    }).toPass({ timeout: 2000 });
+  });
+
+  test('dragging a channel upward reorders tracks in the mixer', async ({
+    page,
+  }) => {
+    const channels = page.locator('.channel');
+    const colorBefore = await channels
+      .first()
+      .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+
+    // Drag the bottom channel's handle up to the top channel's handle.
+    const handles = page.locator('.channel__move');
+    await dragTo(page, handles.last(), handles.first());
+
+    // The top channel's colour should change because a different track is now
+    // at that position.
+    await expect(async () => {
+      const colorAfter = await channels
+        .first()
+        .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+      expect(colorAfter).not.toBe(colorBefore);
+    }).toPass({ timeout: 2000 });
+  });
+});

--- a/src/components/workstation/Mixer.tsx
+++ b/src/components/workstation/Mixer.tsx
@@ -2,6 +2,7 @@ import {
   DndContext,
   DragEndEvent,
   PointerSensor,
+  closestCenter,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -43,7 +44,16 @@ const Mixer = (mixerProps: MixerProps) => {
   }
 
   return (
-    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+    // closestCenter is required so the dragged strip follows the pointer
+    // immediately. The default rectIntersection returns no `over` until the
+    // active rect overlaps another channel (~21 px), which prevents
+    // useSortable from applying any transform to the active item — making it
+    // appear frozen until it suddenly jumps into position.
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
       <SortableContext
         items={reversedIds}
         strategy={verticalListSortingStrategy}


### PR DESCRIPTION
## Summary
Fixed an issue where dragging mixer channels appeared frozen until suddenly jumping into position. The problem was caused by the default collision detection algorithm not providing feedback until significant overlap occurred.

## Changes
- **Mixer.tsx**: Updated `DndContext` to use `closestCenter` collision detection instead of the default `rectIntersection`
  - The default algorithm required ~21px overlap before registering a collision, preventing visual feedback during drag
  - `closestCenter` provides immediate feedback as the dragged item follows the pointer
  - Added explanatory comment documenting why this change was necessary

- **mixer-reorder.spec.ts**: Added comprehensive end-to-end tests for mixer channel reordering
  - Tests dragging channels downward and upward
  - Verifies track reordering by checking visual changes (background colors)
  - Includes helper functions for file upload and pointer-based drag operations compatible with @dnd-kit's PointerSensor
  - Accounts for mixer slide-in animation timing to ensure accurate collision detection measurements

## Implementation Details
The `closestCenter` collision detection algorithm measures distance from the dragged item's center to other droppable centers, providing immediate visual feedback as items are repositioned. This creates a more responsive user experience compared to the overlap-based approach.

https://claude.ai/code/session_01XYehziVxDbC9V2zFFpmyCu