### PR TITLE
Add real-time loudness-driven scrubber cursor pulsation

### DIFF
--- a/src/components/workstation/Scrubber.css
+++ b/src/components/workstation/Scrubber.css
@@ -58,13 +58,18 @@
 }
 
 .cursor {
+  --loudness: 0;
   height: 100%;
   width: 1px;
   background-color: rgba(255, 255, 255, 0.65);
-  transition: background-color 0.3s, box-shadow 0.15s;
+  transition:
+    background-color 0.3s,
+    box-shadow 0.05s ease-out;
 }
 
 .cursor--is-playing {
   background-color: rgba(255, 255, 255, 1);
-  box-shadow: -2px 0 4px 1px #fffa;
+  box-shadow: calc(-2px - 4px * var(--loudness)) 0
+    calc(4px + 8px * var(--loudness)) calc(1px + 2px * var(--loudness))
+    rgba(255, 255, 255, calc(0.5 + 0.5 * var(--loudness)));
 }

--- a/src/components/workstation/Scrubber.tsx
+++ b/src/components/workstation/Scrubber.tsx
@@ -49,6 +49,7 @@ const Scrubber = (props: ScrubberProps) => {
   };
 
   const timelineScrollRef = useRef<HTMLDivElement>(null);
+  const cursorRef = useRef<HTMLDivElement>(null);
   const isProgrammaticScrollRef = useRef(false);
   const shouldResumeRef = useRef(false);
 
@@ -82,6 +83,12 @@ const Scrubber = (props: ScrubberProps) => {
       setScrollPosition(transportTime);
     }
 
+    function updateLoudness() {
+      // Writes loudness directly to a CSS custom property via ref to avoid React re-renders
+      const loudness = audioService.mixer.getLoudness();
+      cursorRef.current?.style.setProperty('--loudness', String(loudness));
+    }
+
     function stopPlaybackIfEndOfScroll() {
       if (timelineScrollRef.current) {
         const isEndOfScroll =
@@ -95,8 +102,9 @@ const Scrubber = (props: ScrubberProps) => {
     }
 
     updateScrollPosition();
+    updateLoudness();
     stopPlaybackIfEndOfScroll();
-  }, [setScrollPosition]); // audioService, dispatch, and shouldResumeRef never change, and can safely be omitted from dependencies
+  }, [setScrollPosition]); // audioService, dispatch, cursorRef, and shouldResumeRef never change, and can safely be omitted from dependencies
 
   useAnimation(animateScrollCallback, {
     isActive: isPlaying,
@@ -201,7 +209,7 @@ const Scrubber = (props: ScrubberProps) => {
         <div className="shade"></div>
       </div>
       <div className="scrubber__cursor" style={timelineScaleStyle}>
-        <div className={cursorClass}></div>
+        <div ref={cursorRef} className={cursorClass}></div>
       </div>
       <div className={rewindButtonClass} style={rewindButtonTranslateStyle}>
         <Button

--- a/src/services/__tests__/Mixer.test.ts
+++ b/src/services/__tests__/Mixer.test.ts
@@ -8,6 +8,58 @@ beforeEach(() => {
   mixer = new Mixer();
 });
 
+describe('constructor', () => {
+  it('creates a Tone.Meter with normalRange and smoothing', () => {
+    expect(Tone.Meter).toHaveBeenCalledWith({
+      normalRange: true,
+      smoothing: 0.8,
+    });
+  });
+
+  it('connects Tone.Destination to the meter', () => {
+    const destination = vi.mocked(Tone.getDestination).mock.results[0].value;
+    expect(destination.connect).toHaveBeenCalled();
+  });
+});
+
+describe('getLoudness', () => {
+  it('returns 0 when meter value is 0', () => {
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    meterInstance.getValue.mockReturnValue(0);
+
+    expect(mixer.getLoudness()).toBe(0);
+  });
+
+  it('returns 1 when meter value is 1', () => {
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    meterInstance.getValue.mockReturnValue(1);
+
+    expect(mixer.getLoudness()).toBe(1);
+  });
+
+  it('applies power curve to meter value', () => {
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    meterInstance.getValue.mockReturnValue(0.5);
+
+    const expected = Math.pow(0.5, 0.6);
+    expect(mixer.getLoudness()).toBeCloseTo(expected);
+  });
+
+  it('clamps negative meter values to 0', () => {
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    meterInstance.getValue.mockReturnValue(-0.5);
+
+    expect(mixer.getLoudness()).toBe(0);
+  });
+
+  it('returns 0 when meter returns an array', () => {
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    meterInstance.getValue.mockReturnValue([0.5, 0.6] as any);
+
+    expect(mixer.getLoudness()).toBe(0);
+  });
+});
+
 describe('createChannel', () => {
   it('creates a Tone.Player synced to transport', () => {
     const audioBuffer = {} as AudioBuffer;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -36,6 +36,7 @@ vi.mock('tone', () => {
       state: 'stopped',
     },
     start: vi.fn().mockResolvedValue(undefined),
+    getDestination: vi.fn().mockReturnValue(makeNode()),
     context: { decodeAudioData: vi.fn().mockResolvedValue({}) },
   };
 });


### PR DESCRIPTION
## Summary

- Add a `Tone.Meter` to `Mixer` connected to `Tone.Destination` for real-time RMS loudness reading of master audio output
- Expose `Mixer.getLoudness()` returning a normalised 0–1 value with a power curve (exponent 0.6) for perceptual linearity
- Drive the scrubber cursor glow via a `--loudness` CSS custom property, updated each animation frame during playback (bypasses React re-renders for performance)
- Update `.cursor--is-playing` box-shadow to scale spread, blur, and opacity proportionally to loudness

Closes #98

## Test plan

- [x] `Mixer` unit tests: verify `Tone.Meter` creation with correct options, `Tone.Destination` connection, loudness values at 0/1/mid-range, negative clamping, and array return handling
- [x] `Scrubber` unit tests: verify `--loudness` CSS variable is set on cursor during playback and not set when stopped
- [x] Full test suite passes (172 tests)
- [x] ESLint passes (no new warnings)
- [x] TypeScript + Vite build succeeds

https://claude.ai/code/session_01QLo31ebQVCXfESJY7EotvL