### PR TITLE
Add signal-based state management for tracks and transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@eslint/js": "^9.0.0",
+        "@preact/signals-react": "^3.9.0",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
@@ -47,7 +48,8 @@
         "wavesurfer.js": "^7.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.56.0"
+        "@playwright/test": "^1.56.0",
+        "babel-plugin-react-compiler": "^1.0.0"
       },
       "engines": {
         "node": ">=22"
@@ -1255,6 +1257,33 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
+      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@preact/signals-react": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-react/-/signals-react-3.9.0.tgz",
+      "integrity": "sha512-C0Qn4AiAYEAHbg7/UEMgdJd+GNDnP/OxI1tk+8WDco9QFIh4gbW+r9V2K4M6OAB6A/ztHW/uZ8/kwBnxNSB94g==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.13.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -3065,6 +3094,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/balanced-match": {
@@ -8168,6 +8207,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@eslint/js": "^9.0.0",
+    "@preact/signals-react": "^3.9.0",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
@@ -81,6 +82,7 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@playwright/test": "^1.56.0"
+    "@playwright/test": "^1.56.0",
+    "babel-plugin-react-compiler": "^1.0.0"
   }
 }

--- a/src/signals/__tests__/focusSignals.test.ts
+++ b/src/signals/__tests__/focusSignals.test.ts
@@ -1,0 +1,70 @@
+import {
+  focusedTracks,
+  focusTrack,
+  unfocusTrack,
+  resetFocusSignals,
+} from '../focusSignals';
+
+afterEach(() => {
+  resetFocusSignals();
+});
+
+describe('focusSignals', () => {
+  describe('initial values', () => {
+    it('has empty focusedTracks', () => {
+      expect(focusedTracks.value).toEqual([]);
+    });
+  });
+
+  describe('focusTrack', () => {
+    it('adds a track to focusedTracks', () => {
+      focusTrack('track-1');
+
+      expect(focusedTracks.value).toEqual(['track-1']);
+    });
+
+    it('adds multiple tracks', () => {
+      focusTrack('track-1');
+      focusTrack('track-2');
+
+      expect(focusedTracks.value).toEqual(['track-1', 'track-2']);
+    });
+
+    it('does not add duplicate tracks', () => {
+      focusTrack('track-1');
+      focusTrack('track-1');
+
+      expect(focusedTracks.value).toEqual(['track-1']);
+    });
+  });
+
+  describe('unfocusTrack', () => {
+    it('removes a track from focusedTracks', () => {
+      focusTrack('track-1');
+      focusTrack('track-2');
+
+      unfocusTrack('track-1');
+
+      expect(focusedTracks.value).toEqual(['track-2']);
+    });
+
+    it('handles unfocusing a track that is not focused', () => {
+      focusTrack('track-1');
+
+      unfocusTrack('track-2');
+
+      expect(focusedTracks.value).toEqual(['track-1']);
+    });
+  });
+
+  describe('resetFocusSignals', () => {
+    it('clears all focused tracks', () => {
+      focusTrack('track-1');
+      focusTrack('track-2');
+
+      resetFocusSignals();
+
+      expect(focusedTracks.value).toEqual([]);
+    });
+  });
+});

--- a/src/signals/__tests__/testUtils.ts
+++ b/src/signals/__tests__/testUtils.ts
@@ -1,0 +1,9 @@
+import { TrackSignalStore } from '../trackSignals';
+import { resetTransportSignals } from '../transportSignals';
+import { resetFocusSignals } from '../focusSignals';
+
+export function resetAllSignals(): void {
+  TrackSignalStore.reset();
+  resetTransportSignals();
+  resetFocusSignals();
+}

--- a/src/signals/__tests__/trackSignals.test.ts
+++ b/src/signals/__tests__/trackSignals.test.ts
@@ -1,0 +1,102 @@
+import { TrackSignalStore } from '../trackSignals';
+import { resetAllSignals } from './testUtils';
+
+afterEach(() => {
+  resetAllSignals();
+});
+
+describe('TrackSignalStore', () => {
+  describe('create', () => {
+    it('creates signals with default values', () => {
+      const signals = TrackSignalStore.create('track-1');
+
+      expect(signals.volume.value).toBe(100);
+      expect(signals.mute.value).toBe(false);
+      expect(signals.solo.value).toBe(false);
+    });
+
+    it('stores the signals so they can be retrieved', () => {
+      TrackSignalStore.create('track-1');
+
+      const retrieved = TrackSignalStore.get('track-1');
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.volume.value).toBe(100);
+    });
+  });
+
+  describe('get', () => {
+    it('returns undefined for unknown track', () => {
+      expect(TrackSignalStore.get('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('dispose', () => {
+    it('removes the signals for a track', () => {
+      TrackSignalStore.create('track-1');
+
+      TrackSignalStore.dispose('track-1');
+
+      expect(TrackSignalStore.get('track-1')).toBeUndefined();
+    });
+
+    it('does not affect other tracks', () => {
+      TrackSignalStore.create('track-1');
+      TrackSignalStore.create('track-2');
+
+      TrackSignalStore.dispose('track-1');
+
+      expect(TrackSignalStore.get('track-2')).toBeDefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all track signals', () => {
+      TrackSignalStore.create('track-1');
+      TrackSignalStore.create('track-2');
+
+      TrackSignalStore.reset();
+
+      expect(TrackSignalStore.get('track-1')).toBeUndefined();
+      expect(TrackSignalStore.get('track-2')).toBeUndefined();
+    });
+  });
+
+  describe('keys', () => {
+    it('returns all track ids', () => {
+      TrackSignalStore.create('track-1');
+      TrackSignalStore.create('track-2');
+
+      const ids = Array.from(TrackSignalStore.keys());
+
+      expect(ids).toEqual(['track-1', 'track-2']);
+    });
+  });
+
+  describe('signal reactivity', () => {
+    it('allows updating volume', () => {
+      const signals = TrackSignalStore.create('track-1');
+
+      signals.volume.value = 75;
+
+      expect(signals.volume.value).toBe(75);
+      expect(TrackSignalStore.get('track-1')!.volume.value).toBe(75);
+    });
+
+    it('allows toggling mute', () => {
+      const signals = TrackSignalStore.create('track-1');
+
+      signals.mute.value = true;
+
+      expect(signals.mute.value).toBe(true);
+    });
+
+    it('allows toggling solo', () => {
+      const signals = TrackSignalStore.create('track-1');
+
+      signals.solo.value = true;
+
+      expect(signals.solo.value).toBe(true);
+    });
+  });
+});

--- a/src/signals/__tests__/transportSignals.test.ts
+++ b/src/signals/__tests__/transportSignals.test.ts
@@ -1,0 +1,60 @@
+import {
+  transportTime,
+  isPlaying,
+  loudness,
+  resetTransportSignals,
+} from '../transportSignals';
+
+afterEach(() => {
+  resetTransportSignals();
+});
+
+describe('transportSignals', () => {
+  describe('initial values', () => {
+    it('has transportTime at 0', () => {
+      expect(transportTime.value).toBe(0);
+    });
+
+    it('has isPlaying as false', () => {
+      expect(isPlaying.value).toBe(false);
+    });
+
+    it('has loudness at 0', () => {
+      expect(loudness.value).toBe(0);
+    });
+  });
+
+  describe('signal updates', () => {
+    it('allows updating transportTime', () => {
+      transportTime.value = 42.5;
+
+      expect(transportTime.value).toBe(42.5);
+    });
+
+    it('allows toggling isPlaying', () => {
+      isPlaying.value = true;
+
+      expect(isPlaying.value).toBe(true);
+    });
+
+    it('allows updating loudness', () => {
+      loudness.value = -12;
+
+      expect(loudness.value).toBe(-12);
+    });
+  });
+
+  describe('resetTransportSignals', () => {
+    it('resets all transport signals to defaults', () => {
+      transportTime.value = 99;
+      isPlaying.value = true;
+      loudness.value = -6;
+
+      resetTransportSignals();
+
+      expect(transportTime.value).toBe(0);
+      expect(isPlaying.value).toBe(false);
+      expect(loudness.value).toBe(0);
+    });
+  });
+});

--- a/src/signals/focusSignals.ts
+++ b/src/signals/focusSignals.ts
@@ -1,0 +1,18 @@
+import { signal } from '@preact/signals-react';
+import { type TrackId } from '../components/project/projectPageReducer';
+
+export const focusedTracks = signal<TrackId[]>([]);
+
+export function focusTrack(trackId: TrackId): void {
+  if (!focusedTracks.value.includes(trackId)) {
+    focusedTracks.value = [...focusedTracks.value, trackId];
+  }
+}
+
+export function unfocusTrack(trackId: TrackId): void {
+  focusedTracks.value = focusedTracks.value.filter((id) => id !== trackId);
+}
+
+export function resetFocusSignals(): void {
+  focusedTracks.value = [];
+}

--- a/src/signals/trackSignals.ts
+++ b/src/signals/trackSignals.ts
@@ -1,0 +1,40 @@
+import { signal, type Signal } from '@preact/signals-react';
+import { type TrackId } from '../components/project/projectPageReducer';
+
+const DEFAULT_VOLUME = 100;
+
+export type TrackSignals = {
+  volume: Signal<number>;
+  mute: Signal<boolean>;
+  solo: Signal<boolean>;
+};
+
+const store = new Map<TrackId, TrackSignals>();
+
+function create(trackId: TrackId): TrackSignals {
+  const signals: TrackSignals = {
+    volume: signal(DEFAULT_VOLUME),
+    mute: signal(false),
+    solo: signal(false),
+  };
+  store.set(trackId, signals);
+  return signals;
+}
+
+function get(trackId: TrackId): TrackSignals | undefined {
+  return store.get(trackId);
+}
+
+function dispose(trackId: TrackId): void {
+  store.delete(trackId);
+}
+
+function reset(): void {
+  store.clear();
+}
+
+function keys(): IterableIterator<TrackId> {
+  return store.keys();
+}
+
+export const TrackSignalStore = { create, get, dispose, reset, keys };

--- a/src/signals/transportSignals.ts
+++ b/src/signals/transportSignals.ts
@@ -1,0 +1,11 @@
+import { signal } from '@preact/signals-react';
+
+export const transportTime = signal(0);
+export const isPlaying = signal(false);
+export const loudness = signal(0);
+
+export function resetTransportSignals(): void {
+  transportTime.value = 0;
+  isPlaying.value = false;
+  loudness.value = 0;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,20 @@ import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 export default defineConfig({
-  plugins: [react(), svgr()],
+  plugins: [
+    react({
+      babel: {
+        plugins: [['babel-plugin-react-compiler', { target: '19' }]],
+      },
+    }),
+    svgr(),
+  ],
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
This PR introduces a reactive state management system using Preact Signals for managing track properties, focus state, and transport controls. This provides a foundation for reactive UI updates across the application.

## Key Changes
- **TrackSignalStore**: New store for managing per-track signals (volume, mute, solo) with create, get, dispose, and reset operations
- **focusSignals**: New module for managing which tracks are currently focused, with focusTrack/unfocusTrack operations
- **transportSignals**: New module for managing global transport state (playTime, isPlaying, loudness)
- **Test utilities**: Added comprehensive test suites for all signal modules and a shared `resetAllSignals()` utility for test cleanup
- **Vite config**: Enabled React Compiler plugin and added COOP/COEP headers for SharedArrayBuffer support
- **Dependencies**: Added `@preact/signals-react` and `babel-plugin-react-compiler` for signal-based reactivity

## Implementation Details
- All signals use Preact Signals for fine-grained reactivity without full component re-renders
- TrackSignalStore uses a Map-based approach for efficient per-track signal management
- Focus and transport signals are global singletons with reset functions for test isolation
- Default values: volume=100, mute=false, solo=false, transportTime=0, isPlaying=false, loudness=0

https://claude.ai/code/session_011LxMXjPSHa86mwbWW6zBqg