### PR TITLE
Migrate mute/solo state from Redux to signals

### DIFF
--- a/src/components/project/projectPageReducer.ts
+++ b/src/components/project/projectPageReducer.ts
@@ -14,8 +14,6 @@ export type Track = {
   color: TrackColor;
   fileName: string;
   index: number;
-  mute: boolean;
-  solo: boolean;
 };
 
 export type TrackColor = {
@@ -34,8 +32,6 @@ export const COLOR_PALETTE: TrackColor[] = [
 
 export const ADD_TRACK = 'ADD_TRACK';
 export const MOVE_TRACK = 'MOVE_TRACK';
-export const SET_TRACK_MUTE = 'SET_TRACK_MUTE';
-export const SET_TRACK_SOLO = 'SET_TRACK_SOLO';
 
 export function projectReducer(
   state: ProjectState,
@@ -54,10 +50,6 @@ export function projectReducer(
       };
     case MOVE_TRACK:
       return { ...state, tracks: moveTrack(state.tracks, payload) };
-    case SET_TRACK_MUTE:
-      return { ...state, tracks: setTrackMute(state.tracks, payload) };
-    case SET_TRACK_SOLO:
-      return { ...state, tracks: setTrackSolo(state.tracks, payload) };
     default:
       throw new Error();
   }
@@ -73,8 +65,6 @@ function createTrack(
     fileName,
     trackId,
     index,
-    mute: false,
-    solo: false,
   };
 }
 
@@ -83,16 +73,4 @@ function moveTrack(tracks: Track[], { fromIndex, toIndex }: any): Track[] {
   const [removed] = updatedTracks.splice(fromIndex, 1);
   updatedTracks.splice(toIndex, 0, removed);
   return updatedTracks.map((track, i) => ({ ...track, index: i }));
-}
-
-function setTrackMute(tracks: Track[], { id, mute }: any): Track[] {
-  return tracks.map((track) =>
-    track.trackId === id ? { ...track, mute } : track,
-  );
-}
-
-function setTrackSolo(tracks: Track[], { id, solo }: any): Track[] {
-  return tracks.map((track) =>
-    track.trackId === id ? { ...track, solo } : track,
-  );
 }

--- a/src/components/workstation/Mixer.tsx
+++ b/src/components/workstation/Mixer.tsx
@@ -12,23 +12,23 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import React from 'react';
+import { mutedTracks as mutedTracksSignal } from '../../signals/trackSignals';
 import { MOVE_TRACK, Track, TrackId } from '../project/projectPageReducer';
 import useProjectDispatch from '../project/useProjectDispatch';
 import Channel from './Channel';
 import './Mixer.css';
 
 type MixerProps = {
-  mutedTracks: TrackId[];
   tracks: Track[];
 };
 
-const Mixer = (mixerProps: MixerProps) => {
-  const { tracks } = mixerProps;
+const Mixer = ({ tracks }: MixerProps) => {
   const projectDispatch = useProjectDispatch();
   const sensors = useSensors(useSensor(PointerSensor));
 
   const reversedTracks = tracks.slice().reverse();
   const reversedIds = reversedTracks.map((t) => t.trackId);
+  const mutedTracks = mutedTracksSignal.value;
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -53,7 +53,7 @@ const Mixer = (mixerProps: MixerProps) => {
             <SortableChannelItem
               key={track.trackId}
               track={track}
-              isMuted={mixerProps.mutedTracks.includes(track.trackId)}
+              isMuted={mutedTracks.includes(track.trackId)}
             />
           ))}
         </div>

--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { useBrowserSupport } from '../../browserSupport';
+import { mutedTracks as mutedTracksSignal } from '../../signals/trackSignals';
 import { Track, TrackId } from '../project/projectPageReducer';
 import Spectrogram from './Spectrogram';
 import './Timeline.css';
@@ -8,14 +9,12 @@ import Waveform from './Waveform';
 
 type TimelineProps = {
   focusedTracks: TrackId[];
-  mutedTracks: TrackId[];
   pixelsPerSecond: number;
   tracks: Track[];
 };
 
 const Timeline = ({
   focusedTracks,
-  mutedTracks,
   pixelsPerSecond,
   tracks,
 }: TimelineProps) => {
@@ -31,6 +30,7 @@ const Timeline = ({
   }, []); // make sure effect only triggers once, on component mount
 
   const browserSupport = useBrowserSupport();
+  const mutedTracks = mutedTracksSignal.value;
 
   return (
     <div ref={containerRef} className="timeline">
@@ -39,7 +39,7 @@ const Timeline = ({
           const timelineWaveformClass = getTimelineWaveformClass(
             track,
             mutedTracks,
-            focusedTracks
+            focusedTracks,
           );
           return (
             <div key={track.trackId} className={timelineWaveformClass}>
@@ -69,7 +69,7 @@ const MemoizedWaveform = React.memo(Waveform);
 function getTimelineWaveformClass(
   track: Track,
   mutedTracks: TrackId[],
-  focusedTracks: TrackId[]
+  focusedTracks: TrackId[],
 ) {
   const isMuted = mutedTracks.includes(track.trackId);
   const isForeground = focusedTracks.includes(track.trackId);

--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -15,7 +15,6 @@ import {
   useDropzoneDragActive,
   useMicrophone,
   useMixerHeight,
-  useMutedTracks,
   usePlaybackControl,
   useSpacebarPlaybackToggle,
   useTotalTime,
@@ -37,7 +36,6 @@ const Workstation = (props: WorkstationProps) => {
     isMixerOpen,
     isPlaying,
     isRecording,
-    mutedTracks,
     pixelsPerSecond,
     transportTime,
   } = state;
@@ -52,7 +50,6 @@ const Workstation = (props: WorkstationProps) => {
 
   const trackIds = useMemo(() => tracks.map((t) => t.trackId), [tracks]);
   useAudioBridge(trackIds);
-  useMutedTracks(tracks, dispatch);
   usePlaybackControl(isPlaying, transportTime);
   useSpacebarPlaybackToggle(dispatch);
   useTotalTime(tracks, dispatch);
@@ -70,12 +67,11 @@ const Workstation = (props: WorkstationProps) => {
     () => (
       <Timeline
         focusedTracks={focusedTracks}
-        mutedTracks={mutedTracks}
         pixelsPerSecond={pixelsPerSecond}
         tracks={tracks}
       />
     ),
-    [focusedTracks, mutedTracks, pixelsPerSecond, tracks],
+    [focusedTracks, pixelsPerSecond, tracks],
   );
 
   const memoizedScrubberTimeline = useMemo(
@@ -112,7 +108,7 @@ const Workstation = (props: WorkstationProps) => {
             )}
           </div>
           <div ref={mixerContainerRef} className={editorMixerClass}>
-            <MemoizedMixer mutedTracks={mutedTracks} tracks={tracks} />
+            <MemoizedMixer tracks={tracks} />
           </div>
           <div className={editorDropzoneClass}>
             <MemoizedDropzone

--- a/src/components/workstation/__tests__/Mixer.test.tsx
+++ b/src/components/workstation/__tests__/Mixer.test.tsx
@@ -34,7 +34,7 @@ afterEach(() => {
 });
 
 it('renders without crashing with empty tracks', () => {
-  render(<Mixer tracks={[]} mutedTracks={[]} />);
+  render(<Mixer tracks={[]} />);
 });
 
 it('renders a channel for each track', () => {
@@ -47,24 +47,24 @@ it('renders a channel for each track', () => {
     mockTrack({ trackId: 'track-3', index: 2 }),
   ];
 
-  const { getAllByTitle } = render(<Mixer tracks={tracks} mutedTracks={[]} />);
+  const { getAllByTitle } = render(<Mixer tracks={tracks} />);
 
   // Each channel renders a Mute button
   const muteButtons = getAllByTitle('Mute');
   expect(muteButtons).toHaveLength(3);
 });
 
-it('passes correct isMuted prop based on mutedTracks', () => {
+it('marks channel as muted via mute signal', () => {
   TrackSignalStore.create('track-1');
   TrackSignalStore.create('track-2');
+  TrackSignalStore.get('track-1')!.mute.value = true;
+
   const tracks = [
     mockTrack({ trackId: 'track-1', index: 0 }),
     mockTrack({ trackId: 'track-2', index: 1 }),
   ];
 
-  const { container } = render(
-    <Mixer tracks={tracks} mutedTracks={['track-1']} />,
-  );
+  const { container } = render(<Mixer tracks={tracks} />);
 
   // The muted channel should have the inverted class
   const channels = container.querySelectorAll('.channel');

--- a/src/components/workstation/__tests__/Workstation.test.tsx
+++ b/src/components/workstation/__tests__/Workstation.test.tsx
@@ -7,7 +7,6 @@ import Workstation from '../Workstation';
 import {
   useDropzoneDragActive,
   useMixerHeight,
-  useMutedTracks,
   usePlaybackControl,
   useSpacebarPlaybackToggle,
   useTotalTime,
@@ -75,7 +74,6 @@ it('uses workstation effect hooks', () => {
   expect(useAudioBridge).toHaveBeenCalled();
   expect(useDropzoneDragActive).toHaveBeenCalled();
   expect(useMixerHeight).toHaveBeenCalled();
-  expect(useMutedTracks).toHaveBeenCalled();
   expect(usePlaybackControl).toHaveBeenCalled();
   expect(useSpacebarPlaybackToggle).toHaveBeenCalled();
   expect(useTotalTime).toHaveBeenCalled();
@@ -93,7 +91,6 @@ function mockWorkstationEffects() {
       drawerContainerRef: { current: null },
       drawerHeight: 0,
     })),
-    useMutedTracks: vi.fn(),
     usePlaybackControl: vi.fn(),
     useSpacebarPlaybackToggle: vi.fn(),
     useTotalTime: vi.fn(),

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -1,13 +1,11 @@
 import { fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
-import { mockTrack } from '../../../testUtils';
 import {
-  useMutedTracks,
   usePlaybackControl,
   useSpacebarPlaybackToggle,
 } from '../workstationEffects';
-import { SET_MUTED_TRACKS, TOGGLE_PLAYBACK } from '../workstationReducer';
+import { TOGGLE_PLAYBACK } from '../workstationReducer';
 
 const { audioServiceMock } = vi.hoisted(() => {
   const mock = {
@@ -29,19 +27,6 @@ vi.mock('../../../services/AudioService', () => ({
 }));
 
 const mockDispatch = vi.fn();
-
-it('computes muted tracks', () => {
-  const tracks = [
-    mockTrack({ id: 1, mute: true, solo: false }),
-    mockTrack({ id: 2, mute: false, solo: true }),
-    mockTrack({ id: 3, mute: true, solo: true }),
-    mockTrack({ id: 4, mute: false, solo: false }),
-  ];
-
-  renderHook(() => useMutedTracks(tracks, mockDispatch));
-
-  expect(mockDispatch).toHaveBeenLastCalledWith([SET_MUTED_TRACKS, []]);
-});
 
 it('toggles playback with spacebar', () => {
   renderHook(() => useSpacebarPlaybackToggle(mockDispatch));

--- a/src/components/workstation/__tests__/workstationReducer.test.ts
+++ b/src/components/workstation/__tests__/workstationReducer.test.ts
@@ -1,5 +1,4 @@
 import {
-  SET_MUTED_TRACKS,
   SET_TOTAL_TIME,
   SET_TRACK_FOCUS,
   SET_TRACK_UNFOCUS,
@@ -20,31 +19,10 @@ const defaultState: WorkstationState = {
   isMixerOpen: false,
   isPlaying: false,
   isRecording: false,
-  mutedTracks: [],
   pixelsPerSecond: 200,
   totalTime: 0,
   transportTime: 0,
 };
-
-it('bails out of dispatch when muted tracks are unchanged', () => {
-  const previousState = { ...defaultState, mutedTracks: [] };
-  const action: WorkstationAction = [SET_MUTED_TRACKS, []];
-
-  const currentState = workstationReducer(previousState, action);
-
-  expect(Object.is(previousState.mutedTracks, currentState.mutedTracks)).toBe(
-    true,
-  );
-});
-
-it('updates muted tracks when they differ', () => {
-  const previousState = { ...defaultState, mutedTracks: ['a'] };
-  const action: WorkstationAction = [SET_MUTED_TRACKS, ['a', 'b']];
-
-  const currentState = workstationReducer(previousState, action);
-
-  expect(currentState.mutedTracks).toEqual(['a', 'b']);
-});
 
 it('stops and rewinds playback', () => {
   const action: WorkstationAction = [STOP_AND_REWIND_PLAYBACK];

--- a/src/components/workstation/useWorkstationReducer.tsx
+++ b/src/components/workstation/useWorkstationReducer.tsx
@@ -10,7 +10,6 @@ const initialState: WorkstationState = {
   isMixerOpen: false,
   isPlaying: false,
   isRecording: false,
-  mutedTracks: [],
   pixelsPerSecond: 200,
   totalTime: 0,
   transportTime: 0,
@@ -18,7 +17,7 @@ const initialState: WorkstationState = {
 
 const useWorkstationReducer = (): [
   WorkstationState,
-  React.Dispatch<WorkstationAction>
+  React.Dispatch<WorkstationAction>,
 ] => {
   return useReducer(workstationReducer, initialState);
 };

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -6,22 +6,10 @@ import message from '../message';
 import { ADD_TRACK, Track } from '../project/projectPageReducer';
 import useProjectDispatch from '../project/useProjectDispatch';
 import {
-  SET_MUTED_TRACKS,
   SET_TOTAL_TIME,
   TOGGLE_PLAYBACK,
   WorkstationAction,
 } from './workstationReducer';
-
-export const useMutedTracks = (
-  tracks: Track[],
-  dispatch: React.Dispatch<WorkstationAction>,
-) => {
-  const audioService = useAudioService();
-  useEffect(() => {
-    const mutedTracks = audioService.mixer.getMutedChannels();
-    dispatch([SET_MUTED_TRACKS, mutedTracks]);
-  }, [tracks]); // audioService and dispatch never changes, and can safely be omitted from dependencies
-};
 
 export const useSpacebarPlaybackToggle = (
   dispatch: React.Dispatch<WorkstationAction>,

--- a/src/components/workstation/workstationReducer.ts
+++ b/src/components/workstation/workstationReducer.ts
@@ -5,7 +5,6 @@ export type WorkstationState = {
   isMixerOpen: boolean;
   isPlaying: boolean;
   isRecording: boolean;
-  mutedTracks: TrackId[];
   pixelsPerSecond: number;
   totalTime: number;
   transportTime: number;
@@ -13,7 +12,6 @@ export type WorkstationState = {
 
 export type WorkstationAction = [string, any?];
 
-export const SET_MUTED_TRACKS = 'SET_MUTED_TRACKS';
 export const SET_TRACK_FOCUS = 'SET_TRACK_FOCUS';
 export const SET_TRACK_UNFOCUS = 'SET_TRACK_UNFOCUS';
 export const SET_TOTAL_TIME = 'SET_TOTAL_TIME';
@@ -30,11 +28,6 @@ export function workstationReducer(
   [type, payload]: WorkstationAction,
 ): WorkstationState {
   switch (type) {
-    case SET_MUTED_TRACKS:
-      return {
-        ...state,
-        mutedTracks: setMutedTracksOrBail(state.mutedTracks, payload),
-      };
     case SET_TRACK_FOCUS:
       return {
         ...state,
@@ -71,20 +64,6 @@ export function workstationReducer(
     default:
       throw new Error();
   }
-}
-
-function setMutedTracksOrBail(
-  previousMutedTracks: TrackId[],
-  currentMutedTracks: TrackId[],
-) {
-  const hasEqualLength =
-    previousMutedTracks.length === currentMutedTracks.length;
-  const isArrayEqual =
-    hasEqualLength &&
-    previousMutedTracks.every(
-      (value, index) => value === currentMutedTracks[index],
-    );
-  return isArrayEqual ? previousMutedTracks : currentMutedTracks;
 }
 
 function setTrackFocus(focusedTracks: TrackId[], focusedTrackId: TrackId) {

--- a/src/hooks/useAudioBridge.ts
+++ b/src/hooks/useAudioBridge.ts
@@ -17,12 +17,20 @@ export function useAudioBridge(trackIds: TrackId[]): void {
       const channel = audioService.mixer.retrieveChannel(trackId);
       if (!channel) continue;
 
-      const dispose = effect(() => {
+      const disposeVolume = effect(() => {
         const volume = trackSignals.volume.value;
         channel.volume = volume;
       });
 
-      disposers.push(dispose);
+      const disposeMute = effect(() => {
+        channel.mute = trackSignals.mute.value;
+      });
+
+      const disposeSolo = effect(() => {
+        channel.solo = trackSignals.solo.value;
+      });
+
+      disposers.push(disposeVolume, disposeMute, disposeSolo);
     }
 
     return () => {

--- a/src/signals/__tests__/trackSignals.test.ts
+++ b/src/signals/__tests__/trackSignals.test.ts
@@ -1,4 +1,4 @@
-import { TrackSignalStore } from '../trackSignals';
+import { mutedTracks, TrackSignalStore } from '../trackSignals';
 import { resetAllSignals } from './testUtils';
 
 afterEach(() => {
@@ -98,5 +98,88 @@ describe('TrackSignalStore', () => {
 
       expect(signals.solo.value).toBe(true);
     });
+  });
+});
+
+describe('mutedTracks computed signal', () => {
+  it('returns empty array when no tracks exist', () => {
+    expect(mutedTracks.value).toEqual([]);
+  });
+
+  it('returns empty array when no tracks are muted or soloed', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+
+    expect(mutedTracks.value).toEqual([]);
+  });
+
+  it('includes muted tracks', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+    TrackSignalStore.get('track-1')!.mute.value = true;
+
+    expect(mutedTracks.value).toEqual(['track-1']);
+  });
+
+  it('mutes non-solo tracks when any track is soloed', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+    TrackSignalStore.create('track-3');
+    TrackSignalStore.get('track-1')!.solo.value = true;
+
+    expect(mutedTracks.value).toEqual(['track-2', 'track-3']);
+  });
+
+  it('mutes a track that is both muted and soloed', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+    TrackSignalStore.get('track-1')!.mute.value = true;
+    TrackSignalStore.get('track-1')!.solo.value = true;
+
+    // track-1 is muted (mute overrides solo), track-2 is muted (no solo)
+    expect(mutedTracks.value).toEqual(['track-1', 'track-2']);
+  });
+
+  it('handles multiple soloed tracks', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+    TrackSignalStore.create('track-3');
+    TrackSignalStore.get('track-1')!.solo.value = true;
+    TrackSignalStore.get('track-2')!.solo.value = true;
+
+    // Only track-3 is muted (not soloed while others are)
+    expect(mutedTracks.value).toEqual(['track-3']);
+  });
+
+  it('updates when track signals change', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.create('track-2');
+
+    expect(mutedTracks.value).toEqual([]);
+
+    TrackSignalStore.get('track-1')!.mute.value = true;
+
+    expect(mutedTracks.value).toEqual(['track-1']);
+
+    TrackSignalStore.get('track-1')!.mute.value = false;
+
+    expect(mutedTracks.value).toEqual([]);
+  });
+
+  it('updates when tracks are added or removed', () => {
+    TrackSignalStore.create('track-1');
+    TrackSignalStore.get('track-1')!.solo.value = true;
+
+    // Only track-1 is soloed, no other tracks to mute
+    expect(mutedTracks.value).toEqual([]);
+
+    TrackSignalStore.create('track-2');
+
+    // Now track-2 should be muted (not soloed while track-1 is)
+    expect(mutedTracks.value).toEqual(['track-2']);
+
+    TrackSignalStore.dispose('track-2');
+
+    expect(mutedTracks.value).toEqual([]);
   });
 });

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -19,8 +19,6 @@ export function mockTrack(trackProps: any = {}): Track {
     },
     trackId: 0,
     index: 0,
-    mute: false,
-    solo: false,
     ...trackProps,
   };
 }


### PR DESCRIPTION
## Summary
This PR migrates track mute and solo state management from Redux to Preact signals, eliminating Redux actions and reducer logic while introducing a computed `mutedTracks` signal that reactively determines which tracks should be muted based on mute and solo states.

## Key Changes

- **Removed Redux state management**: Deleted `SET_TRACK_MUTE` and `SET_TRACK_SOLO` actions and their reducer implementations from `projectPageReducer.ts`
- **Removed mute/solo from Track type**: These properties are no longer stored in the Redux Track object
- **Removed workstation Redux state**: Deleted `mutedTracks` array and `SET_MUTED_TRACKS` action from `workstationReducer.ts`
- **Created `mutedTracks` computed signal**: Added a new computed signal in `trackSignals.ts` that automatically calculates which tracks should be muted based on:
  - Explicit mute state on individual tracks
  - Solo state: when any track is soloed, all non-soloed tracks are muted (mute takes precedence over solo)
- **Updated Channel component**: Changed mute/solo button handlers to directly update track signals instead of dispatching Redux actions
- **Updated audio bridge**: Extended `useAudioBridge` hook to sync mute and solo signals to the audio service (previously only synced volume)
- **Updated Mixer and Timeline**: Changed to read `mutedTracks` from the computed signal instead of receiving it as a prop
- **Removed `useMutedTracks` hook**: Deleted the effect hook that computed muted tracks from Redux state

## Implementation Details

- The `mutedTracks` computed signal uses a `storeVersion` signal to track store membership changes (track creation/disposal), ensuring the computed signal re-evaluates when tracks are added or removed
- Mute state takes precedence over solo state: a muted track remains muted even if it's soloed
- All mute/solo state changes now flow through signals, providing reactive updates throughout the application without Redux dispatch overhead

https://claude.ai/code/session_01H2SxFQGszj3NQghrRhe3Em