### PR TITLE
Migrate track focus state from reducer to signals

### DIFF
--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -6,12 +6,10 @@ import {
 import { Button, Slider } from 'antd';
 import classNames from 'classnames';
 import React from 'react';
-import useDebounced from '../../hooks/useDebounced';
+import { debouncedUnfocusTrack, focusTrack } from '../../signals/focusSignals';
 import { TrackSignalStore } from '../../signals/trackSignals';
 import { Track } from '../project/projectPageReducer';
 import './Channel.css';
-import useWorkstationDispatch from './useWorkstationDispatch';
-import { SET_TRACK_FOCUS, SET_TRACK_UNFOCUS } from './workstationReducer';
 
 type ChannelProps = {
   dragHandleProps?: Record<string, unknown>;
@@ -22,8 +20,6 @@ type ChannelProps = {
 const DEFAULT_VOLUME = 100;
 
 const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
-  const workstationDispatch = useWorkstationDispatch();
-
   const { trackId, color } = track;
 
   const trackSignals = TrackSignalStore.get(trackId);
@@ -35,14 +31,9 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
     if (trackSignals) {
       trackSignals.volume.value = value;
     }
-    workstationDispatch([SET_TRACK_FOCUS, trackId]);
-    debouncedUnfocusTrack();
+    focusTrack(trackId);
+    debouncedUnfocusTrack(trackId);
   };
-
-  const unfocusTrack = () => {
-    workstationDispatch([SET_TRACK_UNFOCUS, trackId]);
-  };
-  const debouncedUnfocusTrack = useDebounced(unfocusTrack, { timeoutMs: 250 });
 
   const updateMute = () => {
     if (trackSignals) {

--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { useBrowserSupport } from '../../browserSupport';
+import { focusedTracks as focusedTracksSignal } from '../../signals/focusSignals';
 import { mutedTracks as mutedTracksSignal } from '../../signals/trackSignals';
 import { Track, TrackId } from '../project/projectPageReducer';
 import Spectrogram from './Spectrogram';
@@ -8,16 +9,11 @@ import './Timeline.css';
 import Waveform from './Waveform';
 
 type TimelineProps = {
-  focusedTracks: TrackId[];
   pixelsPerSecond: number;
   tracks: Track[];
 };
 
-const Timeline = ({
-  focusedTracks,
-  pixelsPerSecond,
-  tracks,
-}: TimelineProps) => {
+const Timeline = ({ pixelsPerSecond, tracks }: TimelineProps) => {
   const [height, setHeight] = useState(0);
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -30,6 +26,7 @@ const Timeline = ({
   }, []); // make sure effect only triggers once, on component mount
 
   const browserSupport = useBrowserSupport();
+  const focusedTracks = focusedTracksSignal.value;
   const mutedTracks = mutedTracksSignal.value;
 
   return (

--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -31,7 +31,7 @@ const Workstation = (props: WorkstationProps) => {
   const { tracks, uploadFile } = props;
   const hasTracks = tracks.length > 0;
 
-  const { focusedTracks, isMixerOpen, isRecording, pixelsPerSecond } = state;
+  const { isMixerOpen, isRecording, pixelsPerSecond } = state;
 
   const { mixerContainerRef, mixerHeight } = useMixerHeight();
   const {
@@ -57,14 +57,8 @@ const Workstation = (props: WorkstationProps) => {
   });
 
   const memoizedTimeline = useMemo(
-    () => (
-      <Timeline
-        focusedTracks={focusedTracks}
-        pixelsPerSecond={pixelsPerSecond}
-        tracks={tracks}
-      />
-    ),
-    [focusedTracks, pixelsPerSecond, tracks],
+    () => <Timeline pixelsPerSecond={pixelsPerSecond} tracks={tracks} />,
+    [pixelsPerSecond, tracks],
   );
 
   const memoizedScrubberTimeline = useMemo(

--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -6,8 +6,6 @@ import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
 import Channel from '../Channel';
 
-const mockWorkstationDispatch = vi.fn();
-
 vi.mock('../../../hooks/useAudioService', () => ({
   useAudioService: () => ({
     mixer: {
@@ -19,10 +17,6 @@ vi.mock('../../../hooks/useAudioService', () => ({
       }),
     },
   }),
-}));
-
-vi.mock('../useWorkstationDispatch', () => ({
-  default: () => mockWorkstationDispatch,
 }));
 
 beforeEach(() => {

--- a/src/components/workstation/__tests__/workstationReducer.test.ts
+++ b/src/components/workstation/__tests__/workstationReducer.test.ts
@@ -1,6 +1,4 @@
 import {
-  SET_TRACK_FOCUS,
-  SET_TRACK_UNFOCUS,
   TOGGLE_MIXER,
   TOGGLE_RECORDING,
   workstationReducer,
@@ -8,7 +6,6 @@ import {
 } from '../workstationReducer';
 
 const defaultState: WorkstationState = {
-  focusedTracks: [],
   isMixerOpen: false,
   isRecording: false,
   pixelsPerSecond: 200,
@@ -43,32 +40,6 @@ describe('TOGGLE_RECORDING', () => {
     const result = workstationReducer(state, [TOGGLE_RECORDING]);
 
     expect(result.isRecording).toBe(false);
-  });
-});
-
-describe('SET_TRACK_FOCUS', () => {
-  it('adds track to focused list', () => {
-    const result = workstationReducer(defaultState, [SET_TRACK_FOCUS, 'a']);
-
-    expect(result.focusedTracks).toEqual(['a']);
-  });
-
-  it('does not duplicate already focused track', () => {
-    const state = { ...defaultState, focusedTracks: ['a'] };
-
-    const result = workstationReducer(state, [SET_TRACK_FOCUS, 'a']);
-
-    expect(result.focusedTracks).toEqual(['a']);
-  });
-});
-
-describe('SET_TRACK_UNFOCUS', () => {
-  it('removes track from focused list', () => {
-    const state = { ...defaultState, focusedTracks: ['a', 'b'] };
-
-    const result = workstationReducer(state, [SET_TRACK_UNFOCUS, 'a']);
-
-    expect(result.focusedTracks).toEqual(['b']);
   });
 });
 

--- a/src/components/workstation/useWorkstationReducer.tsx
+++ b/src/components/workstation/useWorkstationReducer.tsx
@@ -6,7 +6,6 @@ import {
 } from './workstationReducer';
 
 const initialState: WorkstationState = {
-  focusedTracks: [],
   isMixerOpen: false,
   isRecording: false,
   pixelsPerSecond: 200,

--- a/src/components/workstation/workstationReducer.ts
+++ b/src/components/workstation/workstationReducer.ts
@@ -1,7 +1,4 @@
-import { TrackId } from '../project/projectPageReducer';
-
 export type WorkstationState = {
-  focusedTracks: TrackId[];
   isMixerOpen: boolean;
   isRecording: boolean;
   pixelsPerSecond: number;
@@ -9,26 +6,14 @@ export type WorkstationState = {
 
 export type WorkstationAction = [string, any?];
 
-export const SET_TRACK_FOCUS = 'SET_TRACK_FOCUS';
-export const SET_TRACK_UNFOCUS = 'SET_TRACK_UNFOCUS';
 export const TOGGLE_MIXER = 'TOGGLE_MIXER';
 export const TOGGLE_RECORDING = 'TOGGLE_RECORDING';
 
 export function workstationReducer(
   state: WorkstationState,
-  [type, payload]: WorkstationAction,
+  [type]: WorkstationAction,
 ): WorkstationState {
   switch (type) {
-    case SET_TRACK_FOCUS:
-      return {
-        ...state,
-        focusedTracks: setTrackFocus(state.focusedTracks, payload),
-      };
-    case SET_TRACK_UNFOCUS:
-      return {
-        ...state,
-        focusedTracks: setTrackUnfocus(state.focusedTracks, payload),
-      };
     case TOGGLE_MIXER:
       return { ...state, isMixerOpen: !state.isMixerOpen };
     case TOGGLE_RECORDING:
@@ -36,14 +21,4 @@ export function workstationReducer(
     default:
       throw new Error();
   }
-}
-
-function setTrackFocus(focusedTracks: TrackId[], focusedTrackId: TrackId) {
-  return focusedTracks.includes(focusedTrackId)
-    ? focusedTracks
-    : [...focusedTracks, focusedTrackId];
-}
-
-function setTrackUnfocus(focusedTracks: TrackId[], unfocusedTrackId: TrackId) {
-  return focusedTracks.filter((trackId) => trackId !== unfocusedTrackId);
 }

--- a/src/signals/__tests__/focusSignals.test.ts
+++ b/src/signals/__tests__/focusSignals.test.ts
@@ -1,4 +1,6 @@
+import { vi } from 'vitest';
 import {
+  debouncedUnfocusTrack,
   focusedTracks,
   focusTrack,
   unfocusTrack,
@@ -57,6 +59,63 @@ describe('focusSignals', () => {
     });
   });
 
+  describe('debouncedUnfocusTrack', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('unfocuses track after 250ms', () => {
+      focusTrack('track-1');
+
+      debouncedUnfocusTrack('track-1');
+
+      expect(focusedTracks.value).toEqual(['track-1']);
+
+      vi.advanceTimersByTime(250);
+
+      expect(focusedTracks.value).toEqual([]);
+    });
+
+    it('resets debounce timer on repeated calls', () => {
+      focusTrack('track-1');
+
+      debouncedUnfocusTrack('track-1');
+      vi.advanceTimersByTime(200);
+
+      debouncedUnfocusTrack('track-1');
+      vi.advanceTimersByTime(200);
+
+      // Should still be focused — second call reset the timer
+      expect(focusedTracks.value).toEqual(['track-1']);
+
+      vi.advanceTimersByTime(50);
+
+      expect(focusedTracks.value).toEqual([]);
+    });
+
+    it('handles independent debounce timers per track', () => {
+      focusTrack('track-1');
+      focusTrack('track-2');
+
+      debouncedUnfocusTrack('track-1');
+      vi.advanceTimersByTime(100);
+
+      debouncedUnfocusTrack('track-2');
+      vi.advanceTimersByTime(150);
+
+      // track-1 should be unfocused (250ms elapsed), track-2 still focused
+      expect(focusedTracks.value).toEqual(['track-2']);
+
+      vi.advanceTimersByTime(100);
+
+      expect(focusedTracks.value).toEqual([]);
+    });
+  });
+
   describe('resetFocusSignals', () => {
     it('clears all focused tracks', () => {
       focusTrack('track-1');
@@ -65,6 +124,23 @@ describe('focusSignals', () => {
       resetFocusSignals();
 
       expect(focusedTracks.value).toEqual([]);
+    });
+
+    it('clears pending debounce timers', () => {
+      vi.useFakeTimers();
+
+      focusTrack('track-1');
+      debouncedUnfocusTrack('track-1');
+
+      resetFocusSignals();
+      focusTrack('track-1');
+
+      vi.advanceTimersByTime(250);
+
+      // Timer should have been cleared by reset, so track stays focused
+      expect(focusedTracks.value).toEqual(['track-1']);
+
+      vi.useRealTimers();
     });
   });
 });

--- a/src/signals/focusSignals.ts
+++ b/src/signals/focusSignals.ts
@@ -13,6 +13,23 @@ export function unfocusTrack(trackId: TrackId): void {
   focusedTracks.value = focusedTracks.value.filter((id) => id !== trackId);
 }
 
+const UNFOCUS_DEBOUNCE_MS = 250;
+const unfocusTimers = new Map<TrackId, number>();
+
+export function debouncedUnfocusTrack(trackId: TrackId): void {
+  const existing = unfocusTimers.get(trackId);
+  if (existing) {
+    clearTimeout(existing);
+  }
+  const timerId = window.setTimeout(() => {
+    unfocusTrack(trackId);
+    unfocusTimers.delete(trackId);
+  }, UNFOCUS_DEBOUNCE_MS);
+  unfocusTimers.set(trackId, timerId);
+}
+
 export function resetFocusSignals(): void {
   focusedTracks.value = [];
+  unfocusTimers.forEach((timerId) => clearTimeout(timerId));
+  unfocusTimers.clear();
 }


### PR DESCRIPTION
## Summary
Refactored track focus management by migrating state from the workstation reducer to Vue signals, enabling debounced unfocus behavior and simplifying component logic.

## Key Changes
- **Removed focus state from workstation reducer**: Deleted `focusedTracks` from `WorkstationState` and removed `SET_TRACK_FOCUS` and `SET_TRACK_UNFOCUS` actions
- **Implemented debounced unfocus in signals**: Added `debouncedUnfocusTrack()` function to `focusSignals.ts` with 250ms debounce delay and per-track timer management
- **Updated `resetFocusSignals()`**: Now clears pending debounce timers in addition to clearing focused tracks
- **Simplified Channel component**: Replaced reducer dispatch calls with direct signal function calls (`focusTrack()` and `debouncedUnfocusTrack()`)
- **Updated Timeline component**: Now reads `focusedTracks` directly from the signal instead of receiving it as a prop
- **Added comprehensive tests**: New test suite for `debouncedUnfocusTrack()` covering debounce timing, timer reset behavior, and per-track independence

## Implementation Details
- Debounce timers are stored in a `Map<TrackId, number>` to support independent timers per track
- Calling `debouncedUnfocusTrack()` on the same track clears the previous timer before setting a new one
- `resetFocusSignals()` properly cleans up all pending timers to prevent stale callbacks
- Removed dependency on `useDebounced` hook and `useWorkstationDispatch` from Channel component

https://claude.ai/code/session_01EmNejdnc7gA5uecSby7qfm