### PR TITLE
Refactor hooks and components for better separation of concerns

### DIFF
--- a/src/components/dropzone/Dropzone.tsx
+++ b/src/components/dropzone/Dropzone.tsx
@@ -1,44 +1,18 @@
 import { UploadOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
 import classNames from 'classnames';
-import React, { useEffect } from 'react';
-import { useDropzone } from 'react-dropzone';
+import React from 'react';
 import './Dropzone.css';
 
 type DropzoneProps = {
-  setIsDragActive(isDragActive: boolean): void;
-  setRootProps(rootProps: any): void;
-  uploadFile(file: File): void;
+  isDragActive: boolean;
+  isDragAccept: boolean;
+  isDragReject: boolean;
+  inputProps: React.InputHTMLAttributes<HTMLInputElement>;
 };
 
 const Dropzone = (props: DropzoneProps) => {
-  const { setIsDragActive, setRootProps, uploadFile } = props;
-
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useDropzone({
-    accept: { 'audio/*': [] },
-    multiple: true,
-    noClick: true,
-    noKeyboard: true,
-  });
-
-  useEffect(() => {
-    setIsDragActive(isDragActive);
-  }, [setIsDragActive, isDragActive]);
-
-  useEffect(() => {
-    setRootProps(getRootProps());
-  }, [setRootProps, getRootProps]);
-
-  useEffect(() => {
-    acceptedFiles.forEach(uploadFile);
-  }, [acceptedFiles, uploadFile]);
+  const { isDragActive, isDragAccept, isDragReject, inputProps } = props;
 
   const dropzoneClass = classNames('dropzone', {
     'dropzone--active': isDragActive,
@@ -50,7 +24,7 @@ const Dropzone = (props: DropzoneProps) => {
 
   return (
     <div className={dropzoneClass}>
-      <input {...getInputProps()} />
+      <input {...inputProps} />
       <div className="dropzone__content">
         <Text>
           <UploadOutlined className="upload-icon" />

--- a/src/components/dropzone/useFileDropzone.ts
+++ b/src/components/dropzone/useFileDropzone.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+export function useFileDropzone(uploadFile: (file: File) => void) {
+  const {
+    acceptedFiles,
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    accept: { 'audio/*': [] },
+    multiple: true,
+    noClick: true,
+    noKeyboard: true,
+  });
+
+  useEffect(() => {
+    acceptedFiles.forEach(uploadFile);
+  }, [acceptedFiles, uploadFile]);
+
+  return {
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+    rootProps: getRootProps(),
+    inputProps: getInputProps(),
+  };
+}

--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -6,10 +6,9 @@ import {
 import { Button, Slider } from 'antd';
 import classNames from 'classnames';
 import React from 'react';
-import { debouncedUnfocusTrack, focusTrack } from '../../signals/focusSignals';
-import { TrackSignalStore } from '../../signals/trackSignals';
 import { Track } from '../project/projectPageReducer';
 import './Channel.css';
+import { useChannelControls } from './useChannelControls';
 
 type ChannelProps = {
   dragHandleProps?: Record<string, unknown>;
@@ -17,35 +16,13 @@ type ChannelProps = {
   track: Track;
 };
 
-const DEFAULT_VOLUME = 100;
+const PERCENT_DIVISOR = 100;
 
 const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
   const { trackId, color } = track;
 
-  const trackSignals = TrackSignalStore.get(trackId);
-  const volume = trackSignals?.volume.value ?? DEFAULT_VOLUME;
-  const mute = trackSignals?.mute.value ?? false;
-  const solo = trackSignals?.solo.value ?? false;
-
-  const updateVolume = (value: number) => {
-    if (trackSignals) {
-      trackSignals.volume.value = value;
-    }
-    focusTrack(trackId);
-    debouncedUnfocusTrack(trackId);
-  };
-
-  const updateMute = () => {
-    if (trackSignals) {
-      trackSignals.mute.value = !mute;
-    }
-  };
-
-  const updateSolo = () => {
-    if (trackSignals) {
-      trackSignals.solo.value = !solo;
-    }
-  };
+  const { volume, mute, solo, updateVolume, updateMute, updateSolo } =
+    useChannelControls(trackId);
 
   const { r, g, b } = color;
   const channelOpacity = isMuted ? 0 : convertToOpacity(volume);
@@ -108,7 +85,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
 };
 
 function convertToOpacity(value: number): number {
-  return parseFloat((value / 100).toFixed(2));
+  return parseFloat((value / PERCENT_DIVISOR).toFixed(2));
 }
 
 export default Channel;

--- a/src/components/workstation/Spectrogram.tsx
+++ b/src/components/workstation/Spectrogram.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useAudioService } from '../../hooks/useAudioService';
+import { useTrackVolume } from '../../hooks/useTrackVolume';
 import OfflineAnalyser from '../../services/OfflineAnalyser';
-import { TrackSignalStore } from '../../signals/trackSignals';
 import { Track, TrackColor } from '../project/projectPageReducer';
 import './Spectrogram.css';
 
@@ -55,11 +55,10 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
   const containerWidth = canvasWidth * widthFactor;
   const containerHeight = canvasHeight * heightPixelRatio;
 
-  const DEFAULT_VOLUME = 100;
-  const volume = TrackSignalStore.get(trackId)?.volume.value ?? DEFAULT_VOLUME;
+  const { opacity } = useTrackVolume(trackId);
 
   const containerStyles = {
-    opacity: convertToOpacity(volume),
+    opacity,
     width: containerWidth,
   };
 
@@ -78,10 +77,6 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
     </div>
   );
 };
-
-function convertToOpacity(value: number): string {
-  return (value / 100).toFixed(2);
-}
 
 class SpectrogramCanvasRenderer {
   private canvasContext: CanvasRenderingContext2D | null;

--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import { useLayoutEffect, useRef, useState } from 'react';
 import { useBrowserSupport } from '../../browserSupport';
+import { useContainerHeight } from '../../hooks/useContainerHeight';
 import { focusedTracks as focusedTracksSignal } from '../../signals/focusSignals';
 import { mutedTracks as mutedTracksSignal } from '../../signals/trackSignals';
 import { Track, TrackId } from '../project/projectPageReducer';
@@ -14,16 +14,7 @@ type TimelineProps = {
 };
 
 const Timeline = ({ pixelsPerSecond, tracks }: TimelineProps) => {
-  const [height, setHeight] = useState(0);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    if (containerRef.current) {
-      const { height } = containerRef.current.getBoundingClientRect();
-      setHeight(height);
-    }
-  }, []); // make sure effect only triggers once, on component mount
+  const { containerRef, height } = useContainerHeight();
 
   const browserSupport = useBrowserSupport();
   const focusedTracks = focusedTracksSignal.value;

--- a/src/components/workstation/Waveform.tsx
+++ b/src/components/workstation/Waveform.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import WaveSurfer from 'wavesurfer.js';
 import { useAudioService } from '../../hooks/useAudioService';
-import { TrackSignalStore } from '../../signals/trackSignals';
+import { useTrackVolume } from '../../hooks/useTrackVolume';
 import { Track } from '../project/projectPageReducer';
 
 type WaveformProps = {
@@ -9,8 +9,6 @@ type WaveformProps = {
   pixelsPerSecond: number;
   track: Track;
 };
-
-const DEFAULT_VOLUME = 100;
 
 const Waveform = ({ height, pixelsPerSecond, track }: WaveformProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -42,14 +40,9 @@ const Waveform = ({ height, pixelsPerSecond, track }: WaveformProps) => {
     };
   }, [trackId, color, height, pixelsPerSecond]);
 
-  const volume = TrackSignalStore.get(trackId)?.volume.value ?? DEFAULT_VOLUME;
-  const opacity = convertToOpacity(volume);
+  const { opacity } = useTrackVolume(trackId);
 
   return <div ref={containerRef} style={{ opacity }} />;
 };
-
-function convertToOpacity(value: number): string {
-  return (value / 100).toFixed(2);
-}
 
 export default Waveform;

--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -4,6 +4,7 @@ import { useAudioBridge } from '../../hooks/useAudioBridge';
 import { useTransportBridge } from '../../hooks/useTransportBridge';
 import { pixelsPerSecond as pixelsPerSecondSignal } from '../../signals/workstationSignals';
 import Dropzone from '../dropzone/Dropzone';
+import { useFileDropzone } from '../dropzone/useFileDropzone';
 import { Track } from '../project/projectPageReducer';
 import EmptyTimeline from './EmptyTimeline';
 import Mixer from './Mixer';
@@ -12,7 +13,6 @@ import Timeline from './Timeline';
 import Toolbar from './Toolbar';
 import './Workstation.css';
 import {
-  useDropzoneDragActive,
   useMicrophone,
   useMixerHeight,
   useSpacebarPlaybackToggle,
@@ -34,12 +34,8 @@ const Workstation = (props: WorkstationProps) => {
   const pixelsPerSecond = pixelsPerSecondSignal.value;
 
   const { mixerContainerRef, mixerHeight } = useMixerHeight();
-  const {
-    isDragActive,
-    setIsDragActive,
-    dropzoneRootProps,
-    setDropzoneRootProps,
-  } = useDropzoneDragActive();
+  const { isDragActive, isDragAccept, isDragReject, rootProps, inputProps } =
+    useFileDropzone(uploadFile);
 
   const trackIds = tracks.map((t) => t.trackId);
   useAudioBridge(trackIds);
@@ -61,7 +57,7 @@ const Workstation = (props: WorkstationProps) => {
 
   return (
     <div className="workstation">
-      <div className="editor" {...dropzoneRootProps}>
+      <div className="editor" {...rootProps}>
         <div className="editor__timeline">
           {hasTracks ? (
             <Scrubber
@@ -80,9 +76,10 @@ const Workstation = (props: WorkstationProps) => {
         </div>
         <div className={editorDropzoneClass}>
           <Dropzone
-            setIsDragActive={setIsDragActive}
-            setRootProps={setDropzoneRootProps}
-            uploadFile={uploadFile}
+            isDragActive={isDragActive}
+            isDragAccept={isDragAccept}
+            isDragReject={isDragReject}
+            inputProps={inputProps}
           />
         </div>
       </div>

--- a/src/components/workstation/__tests__/Workstation.test.tsx
+++ b/src/components/workstation/__tests__/Workstation.test.tsx
@@ -1,12 +1,12 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
+import { useFileDropzone } from '../../dropzone/useFileDropzone';
 import { useAudioBridge } from '../../../hooks/useAudioBridge';
 import { useTransportBridge } from '../../../hooks/useTransportBridge';
 import { mockTrack } from '../../../testUtils';
 import Workstation from '../Workstation';
 import {
-  useDropzoneDragActive,
   useMixerHeight,
   useSpacebarPlaybackToggle,
   useTotalTime,
@@ -32,6 +32,16 @@ vi.mock('../../../hooks/useTransportBridge', () => ({
 }));
 
 vi.mock('../workstationEffects', () => mockWorkstationEffects());
+
+vi.mock('../../dropzone/useFileDropzone', () => ({
+  useFileDropzone: vi.fn(() => ({
+    isDragActive: false,
+    isDragAccept: false,
+    isDragReject: false,
+    rootProps: {},
+    inputProps: {},
+  })),
+}));
 
 const defaultProps = {
   tracks: [],
@@ -77,7 +87,7 @@ it('uses workstation effect hooks', () => {
 
   expect(useAudioBridge).toHaveBeenCalled();
   expect(useTransportBridge).toHaveBeenCalled();
-  expect(useDropzoneDragActive).toHaveBeenCalled();
+  expect(useFileDropzone).toHaveBeenCalled();
   expect(useMixerHeight).toHaveBeenCalled();
   expect(useSpacebarPlaybackToggle).toHaveBeenCalled();
   expect(useTotalTime).toHaveBeenCalled();
@@ -85,15 +95,9 @@ it('uses workstation effect hooks', () => {
 
 function mockWorkstationEffects() {
   return {
-    useDropzoneDragActive: vi.fn(() => ({
-      isDragActive: false,
-      setIsDragActive: vi.fn(),
-      dropzoneRootProps: {},
-      setDropzoneRootProps: vi.fn(),
-    })),
     useMixerHeight: vi.fn(() => ({
-      drawerContainerRef: { current: null },
-      drawerHeight: 0,
+      mixerContainerRef: { current: null },
+      mixerHeight: 0,
     })),
     useSpacebarPlaybackToggle: vi.fn(),
     useTotalTime: vi.fn(),

--- a/src/components/workstation/useChannelControls.ts
+++ b/src/components/workstation/useChannelControls.ts
@@ -1,0 +1,34 @@
+import { debouncedUnfocusTrack, focusTrack } from '../../signals/focusSignals';
+import { TrackSignalStore } from '../../signals/trackSignals';
+import { type TrackId } from '../project/projectPageReducer';
+
+const DEFAULT_VOLUME = 100;
+
+export function useChannelControls(trackId: TrackId) {
+  const trackSignals = TrackSignalStore.get(trackId);
+  const volume = trackSignals?.volume.value ?? DEFAULT_VOLUME;
+  const mute = trackSignals?.mute.value ?? false;
+  const solo = trackSignals?.solo.value ?? false;
+
+  const updateVolume = (value: number) => {
+    if (trackSignals) {
+      trackSignals.volume.value = value;
+    }
+    focusTrack(trackId);
+    debouncedUnfocusTrack(trackId);
+  };
+
+  const updateMute = () => {
+    if (trackSignals) {
+      trackSignals.mute.value = !mute;
+    }
+  };
+
+  const updateSolo = () => {
+    if (trackSignals) {
+      trackSignals.solo.value = !solo;
+    }
+  };
+
+  return { volume, mute, solo, updateVolume, updateMute, updateSolo };
+}

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { useAudioService } from '../../hooks/useAudioService';
+import { useContainerHeight } from '../../hooks/useContainerHeight';
 import useKeypress from '../../hooks/useKeypress';
 import { TrackSignalStore } from '../../signals/trackSignals';
 import {
@@ -61,31 +62,11 @@ export const useMicrophone = (isRecording: boolean) => {
 };
 
 export const useMixerHeight = () => {
-  const mixerContainerRef = useRef<HTMLDivElement>(null);
-  const [mixerHeight, setMixerHeight] = useState(0);
-
-  useLayoutEffect(() => {
-    if (mixerContainerRef.current) {
-      // TODO: or use clientHeight?
-      const height = mixerContainerRef.current.offsetHeight;
-      setMixerHeight(height);
-    }
-  }, []); // make sure effect only triggers once, on component mount
+  const { containerRef: mixerContainerRef, height: mixerHeight } =
+    useContainerHeight();
 
   return {
     mixerContainerRef,
     mixerHeight,
-  };
-};
-
-export const useDropzoneDragActive = () => {
-  const [isDragActive, setIsDragActive] = useState(false);
-  const [dropzoneRootProps, setDropzoneRootProps] = useState({});
-
-  return {
-    isDragActive,
-    setIsDragActive,
-    dropzoneRootProps,
-    setDropzoneRootProps,
   };
 };

--- a/src/hooks/useContainerHeight.ts
+++ b/src/hooks/useContainerHeight.ts
@@ -1,0 +1,15 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+export function useContainerHeight() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (containerRef.current) {
+      const { height } = containerRef.current.getBoundingClientRect();
+      setHeight(height);
+    }
+  }, []); // measure once on mount
+
+  return { containerRef, height };
+}

--- a/src/hooks/useTrackVolume.ts
+++ b/src/hooks/useTrackVolume.ts
@@ -1,0 +1,16 @@
+import { TrackSignalStore } from '../signals/trackSignals';
+import { type TrackId } from '../components/project/projectPageReducer';
+
+const DEFAULT_VOLUME = 100;
+const PERCENT_DIVISOR = 100;
+
+export function useTrackVolume(trackId: TrackId) {
+  const volume = TrackSignalStore.get(trackId)?.volume.value ?? DEFAULT_VOLUME;
+  const opacity = convertToOpacity(volume);
+
+  return { volume, opacity };
+}
+
+function convertToOpacity(value: number): string {
+  return (value / PERCENT_DIVISOR).toFixed(2);
+}


### PR DESCRIPTION
## Summary
This PR refactors several components and utilities to improve code organization and reusability by extracting logic into custom hooks and simplifying component prop interfaces.

## Key Changes

- **Dropzone refactoring**: Extracted `useFileDropzone` hook to handle all dropzone logic (drag state, file acceptance, input props). Simplified `Dropzone` component to be a pure presentational component that receives state as props instead of managing it internally.

- **Channel controls extraction**: Created `useChannelControls` hook to encapsulate volume, mute, and solo state management logic, reducing complexity in the `Channel` component.

- **Container height measurement**: Extracted `useContainerHeight` hook to provide reusable logic for measuring element dimensions on mount. Updated `Timeline` and `useMixerHeight` to use this new hook.

- **Track volume utility**: Created `useTrackVolume` hook to centralize volume-to-opacity conversion logic, eliminating duplicate `convertToOpacity` functions across `Waveform` and `Spectrogram` components.

- **Workstation effects cleanup**: Removed `useDropzoneDragActive` hook and replaced its usage with the new `useFileDropzone` hook, simplifying the workstation effects module.

- **Minor improvements**: Updated `PERCENT_DIVISOR` constant naming in `Channel` component for clarity.

## Notable Implementation Details

- The `useFileDropzone` hook maintains the same dropzone configuration (audio files only, multiple uploads, no click/keyboard triggers) while exposing a cleaner API.
- The `useContainerHeight` hook uses `getBoundingClientRect()` instead of `offsetHeight` for more reliable dimension measurement.
- All extracted hooks follow consistent patterns for state management and side effects.
- Test mocks were updated to reflect the new hook structure in `Workstation.test.tsx`.

https://claude.ai/code/session_01DdNazu5KEVHAfR22q7JJCz