### PR TITLE
Add e2e testing and automated Netlify deployment to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,30 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,27 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ci, e2e]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Netlify
+        run: npx netlify-cli deploy --dir=dist --prod
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm test -- --run && npm run build"
+  command = "npm run build"
   publish = "dist"
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build"
+  command = "npm test -- --run && npm run build"
   publish = "dist"
 
 [[redirects]]


### PR DESCRIPTION
## Summary
This PR enhances the CI/CD pipeline by adding end-to-end testing with Playwright and automated deployment to Netlify on the master branch.

## Key Changes
- **E2E Testing Job**: Added a new `e2e` workflow job that:
  - Installs Playwright with Chromium browser dependencies
  - Runs e2e tests via `npm run test:e2e`
  - Uploads Playwright test reports as artifacts for 30 days retention

- **Deployment Job**: Added a new `deploy` workflow job that:
  - Runs only on the master branch (`if: github.ref == 'refs/heads/master'`)
  - Depends on both `ci` and `e2e` jobs passing before deployment
  - Builds the project and deploys to Netlify using the Netlify CLI
  - Uses `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` secrets for authentication

## Implementation Details
- The e2e job runs on Ubuntu latest with Node 22 and uses npm caching for faster builds
- Playwright is installed with system dependencies (`--with-deps`) to ensure Chromium runs properly in the CI environment
- The deploy job only triggers on master branch pushes, preventing accidental deployments from feature branches
- Test artifacts are retained for 30 days to allow for debugging failed test runs
- Both new jobs follow the same dependency installation and Node setup patterns as the existing `ci` job

https://claude.ai/code/session_0121xLCTpm9Hj135XYJAePFo