### PR TITLE
Add volume commit handler to prevent premature track unfocus

### DIFF
--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -20,8 +20,15 @@ const PERCENT_DIVISOR = 100;
 const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
   const { trackId, color } = track;
 
-  const { volume, mute, solo, updateVolume, updateMute, updateSolo } =
-    useChannelControls(trackId);
+  const {
+    volume,
+    mute,
+    solo,
+    updateVolume,
+    commitVolume,
+    updateMute,
+    updateSolo,
+  } = useChannelControls(trackId);
 
   const { r, g, b } = color;
   const channelOpacity = isMuted ? 0 : convertToOpacity(volume);
@@ -67,6 +74,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
           min={0}
           max={100}
           onChange={updateVolume}
+          onChangeComplete={commitVolume}
         />
       </div>
       <div className="channel__move" {...dragHandleProps}>

--- a/src/components/workstation/__tests__/useChannelControls.test.ts
+++ b/src/components/workstation/__tests__/useChannelControls.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { focusedTracks } from '../../../signals/focusSignals';
+import { TrackSignalStore } from '../../../signals/trackSignals';
+import { resetAllSignals } from '../../../signals/__tests__/testUtils';
+import { useChannelControls } from '../useChannelControls';
+
+vi.mock('../../../hooks/useAudioService', () => ({
+  useAudioService: () => ({
+    mixer: {
+      retrieveChannel: vi.fn().mockReturnValue({
+        mute: false,
+        solo: false,
+        volume: 100,
+        dispose: vi.fn(),
+      }),
+    },
+  }),
+}));
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+beforeEach(() => {
+  TrackSignalStore.create('track-1');
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  resetAllSignals();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+describe('useChannelControls', () => {
+  describe('updateVolume', () => {
+    it('focuses track while volume is being changed', () => {
+      const { result } = renderHook(() => useChannelControls('track-1'));
+
+      result.current.updateVolume(80);
+
+      expect(focusedTracks.value).toContain('track-1');
+    });
+
+    it('keeps track focused after volume stops changing', () => {
+      const { result } = renderHook(() => useChannelControls('track-1'));
+
+      result.current.updateVolume(80);
+
+      vi.advanceTimersByTime(250);
+
+      expect(focusedTracks.value).toContain('track-1');
+    });
+  });
+
+  describe('commitVolume', () => {
+    it('unfocuses track after debounce period', () => {
+      const { result } = renderHook(() => useChannelControls('track-1'));
+
+      result.current.updateVolume(80);
+      result.current.commitVolume();
+
+      vi.advanceTimersByTime(250);
+
+      expect(focusedTracks.value).not.toContain('track-1');
+    });
+  });
+});

--- a/src/components/workstation/useChannelControls.ts
+++ b/src/components/workstation/useChannelControls.ts
@@ -1,5 +1,9 @@
 import { useSignals } from '@preact/signals-react/runtime';
-import { debouncedUnfocusTrack, focusTrack } from '../../signals/focusSignals';
+import {
+  cancelDebouncedUnfocusTrack,
+  debouncedUnfocusTrack,
+  focusTrack,
+} from '../../signals/focusSignals';
 import { TrackSignalStore } from '../../signals/trackSignals';
 import { type TrackId } from '../project/projectPageReducer';
 
@@ -17,6 +21,10 @@ export function useChannelControls(trackId: TrackId) {
       trackSignals.volume.value = value;
     }
     focusTrack(trackId);
+    cancelDebouncedUnfocusTrack(trackId);
+  };
+
+  const commitVolume = () => {
     debouncedUnfocusTrack(trackId);
   };
 
@@ -32,5 +40,13 @@ export function useChannelControls(trackId: TrackId) {
     }
   };
 
-  return { volume, mute, solo, updateVolume, updateMute, updateSolo };
+  return {
+    volume,
+    mute,
+    solo,
+    updateVolume,
+    commitVolume,
+    updateMute,
+    updateSolo,
+  };
 }

--- a/src/signals/__tests__/focusSignals.test.ts
+++ b/src/signals/__tests__/focusSignals.test.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import {
+  cancelDebouncedUnfocusTrack,
   debouncedUnfocusTrack,
   focusedTracks,
   focusTrack,
@@ -113,6 +114,35 @@ describe('focusSignals', () => {
       vi.advanceTimersByTime(100);
 
       expect(focusedTracks.value).toEqual([]);
+    });
+  });
+
+  describe('cancelDebouncedUnfocusTrack', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('cancels a pending debounced unfocus', () => {
+      focusTrack('track-1');
+      debouncedUnfocusTrack('track-1');
+
+      cancelDebouncedUnfocusTrack('track-1');
+
+      vi.advanceTimersByTime(250);
+
+      expect(focusedTracks.value).toEqual(['track-1']);
+    });
+
+    it('handles canceling when no debounce is pending', () => {
+      focusTrack('track-1');
+
+      cancelDebouncedUnfocusTrack('track-1');
+
+      expect(focusedTracks.value).toEqual(['track-1']);
     });
   });
 

--- a/src/signals/focusSignals.ts
+++ b/src/signals/focusSignals.ts
@@ -28,6 +28,14 @@ export function debouncedUnfocusTrack(trackId: TrackId): void {
   unfocusTimers.set(trackId, timerId);
 }
 
+export function cancelDebouncedUnfocusTrack(trackId: TrackId): void {
+  const existing = unfocusTimers.get(trackId);
+  if (existing) {
+    clearTimeout(existing);
+    unfocusTimers.delete(trackId);
+  }
+}
+
 export function resetFocusSignals(): void {
   focusedTracks.value = [];
   unfocusTimers.forEach((timerId) => clearTimeout(timerId));


### PR DESCRIPTION
## Summary
This PR improves the track focus behavior when adjusting channel volume by separating the volume update and commit operations. Previously, tracks would unfocus immediately after volume changes completed. Now, tracks remain focused until the user explicitly finishes adjusting the volume.

## Key Changes
- **Added `cancelDebouncedUnfocusTrack` function** to `focusSignals.ts` that cancels pending unfocus operations for a track
- **Split volume control logic** in `useChannelControls` hook:
  - `updateVolume` now cancels any pending unfocus when volume changes begin
  - New `commitVolume` method triggers the debounced unfocus when volume adjustment is complete
- **Updated Channel component** to call `commitVolume` on the slider's `onChangeComplete` event
- **Added comprehensive tests** for the new `cancelDebouncedUnfocusTrack` function and `useChannelControls` behavior

## Implementation Details
- The `unfocusTimers` Map in `focusSignals.ts` now properly manages timer lifecycle with the new cancel function
- The volume slider now has two distinct phases: active adjustment (track stays focused) and completion (track unfocuses after debounce)
- This prevents the track from losing focus while the user is still interacting with the volume control

https://claude.ai/code/session_01JRzfdx2Qqfn9DjgHS1iXvH