### PR TITLE
Focus track on volume slider interaction

### DIFF
--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -24,6 +24,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
     volume,
     mute,
     solo,
+    startFocus,
     updateVolume,
     commitVolume,
     updateMute,
@@ -67,7 +68,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
           onClick={updateMute}
         />
       </div>
-      <div className="channel__volume">
+      <div className="channel__volume" onPointerDown={startFocus}>
         <Slider
           className="channel-slider"
           defaultValue={volume}

--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
+import { focusedTracks } from '../../../signals/focusSignals';
 import { TrackSignalStore } from '../../../signals/trackSignals';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
@@ -157,4 +158,13 @@ it('reads volume from signal store', () => {
 
   // Volume is read from signal, not from track props
   expect(signals.volume.value).toBe(100);
+});
+
+it('focuses track when volume slider is clicked without moving', () => {
+  const { container } = render(<Channel {...defaultProps} />);
+
+  const volumeSlider = container.querySelector('.channel__volume')!;
+  fireEvent.pointerDown(volumeSlider);
+
+  expect(focusedTracks.value).toContain('track-1');
 });

--- a/src/components/workstation/useChannelControls.ts
+++ b/src/components/workstation/useChannelControls.ts
@@ -16,12 +16,16 @@ export function useChannelControls(trackId: TrackId) {
   const mute = trackSignals?.mute.value ?? false;
   const solo = trackSignals?.solo.value ?? false;
 
+  const startFocus = () => {
+    focusTrack(trackId);
+    cancelDebouncedUnfocusTrack(trackId);
+  };
+
   const updateVolume = (value: number) => {
     if (trackSignals) {
       trackSignals.volume.value = value;
     }
-    focusTrack(trackId);
-    cancelDebouncedUnfocusTrack(trackId);
+    startFocus();
   };
 
   const commitVolume = () => {
@@ -44,6 +48,7 @@ export function useChannelControls(trackId: TrackId) {
     volume,
     mute,
     solo,
+    startFocus,
     updateVolume,
     commitVolume,
     updateMute,


### PR DESCRIPTION
## Summary
This PR adds track focus functionality when the volume slider is interacted with, improving the UX by automatically focusing a track when its volume control is engaged.

## Key Changes
- Extracted focus logic into a new `startFocus()` function in `useChannelControls` hook that:
  - Calls `focusTrack(trackId)` to focus the track
  - Calls `cancelDebouncedUnfocusTrack(trackId)` to prevent auto-unfocus
- Updated `updateVolume()` to use the new `startFocus()` function instead of duplicating focus logic
- Added `onPointerDown` handler to the volume slider container that triggers `startFocus()` on pointer interaction
- Exported `startFocus` from the hook for use in the Channel component
- Added test case to verify track focus occurs when volume slider is clicked without moving

## Implementation Details
The focus is triggered on `pointerDown` event at the container level rather than within the slider's change handler, allowing the track to be focused immediately upon interaction regardless of whether the slider value actually changes. This provides better UX feedback when users click on the volume control.

https://claude.ai/code/session_018jCPxQvUBeffMSoumKEuqD