### PR TITLE
Add loudness normalization to automatically adjust track volumes

### DIFF
--- a/src/components/project/projectPageEffects.ts
+++ b/src/components/project/projectPageEffects.ts
@@ -22,8 +22,8 @@ export const useUploadFile = (dispatch: React.Dispatch<ProjectAction>) => {
         const arrayBuffer = reader.result as ArrayBuffer;
         audioService
           .createTrack(arrayBuffer)
-          .then((trackId) => {
-            TrackSignalStore.create(trackId);
+          .then(({ trackId, initialVolume }) => {
+            TrackSignalStore.create(trackId, initialVolume);
             dispatch([ADD_TRACK, { trackId, fileName }]);
             msg.success(fileName);
           })
@@ -53,12 +53,18 @@ export const useTrackSideEffects = (tracks: Track[]) => {
     for (const track of tracks) {
       if (!prevIds.has(track.trackId)) {
         if (!TrackSignalStore.get(track.trackId)) {
-          TrackSignalStore.create(track.trackId);
+          const initialVolume = audioService.retrieveInitialVolume(
+            track.trackId,
+          );
+          TrackSignalStore.create(track.trackId, initialVolume);
         }
         if (!audioService.mixer.retrieveChannel(track.trackId)) {
           const buffer = audioService.retrieveAudioBuffer(track.trackId);
           if (buffer) {
-            audioService.mixer.createChannel(track.trackId, buffer);
+            const normGainDb = audioService.retrieveNormalizationGainDb(
+              track.trackId,
+            );
+            audioService.mixer.createChannel(track.trackId, buffer, normGainDb);
           }
         }
       }

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -44,8 +44,9 @@ export const useMicrophone = (isRecording: boolean) => {
       }
       try {
         const arrayBuffer = await audioService.stopRecording();
-        const trackId = await audioService.createTrack(arrayBuffer);
-        TrackSignalStore.create(trackId);
+        const { trackId, initialVolume } =
+          await audioService.createTrack(arrayBuffer);
+        TrackSignalStore.create(trackId, initialVolume);
         projectDispatch([ADD_TRACK, { trackId, fileName: 'New Track' }]);
         audioService.microphone.close();
         msg.success('Recording stopped');

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -1,5 +1,6 @@
 import * as Tone from 'tone';
 import { v4 as uuidv4 } from 'uuid';
+import { LoudnessNormalizer } from './LoudnessNormalizer';
 import MicrophoneUserMedia from './MicrophoneUserMedia';
 import Mixer from './Mixer';
 
@@ -17,10 +18,17 @@ function startAudioContext(this: AudioContextStarter, event: Event): void {
   window.removeEventListener('click', startAudioContext);
 }
 
+export type TrackCreationResult = {
+  trackId: string;
+  initialVolume: number;
+};
+
 type AudioSource = {
   id: string;
   audioBuffer: AudioBuffer;
   blobUrl: string;
+  normalizationGainDb: number;
+  initialVolume: number;
 };
 
 class AudioService {
@@ -55,18 +63,24 @@ class AudioService {
     });
   }
 
-  async createTrack(arrayBuffer: ArrayBuffer): Promise<string> {
+  async createTrack(arrayBuffer: ArrayBuffer): Promise<TrackCreationResult> {
     const audioBuffer = await Tone.context.decodeAudioData(arrayBuffer);
     const trackId = uuidv4();
     const blob = new Blob([arrayBuffer], { type: 'audio/*' });
     const blobUrl = URL.createObjectURL(blob);
-    this.mixer.createChannel(trackId, audioBuffer);
+    const normalizationGainDb =
+      LoudnessNormalizer.calculateNormalizationGain(audioBuffer);
+    const initialVolume =
+      LoudnessNormalizer.gainToInitialVolume(normalizationGainDb);
+    this.mixer.createChannel(trackId, audioBuffer, normalizationGainDb);
     this.audioSourceRepository.add({
       id: trackId,
       audioBuffer,
       blobUrl,
+      normalizationGainDb,
+      initialVolume,
     });
-    return trackId;
+    return { trackId, initialVolume };
   }
 
   retrieveAudioBuffer(trackId: string): AudioBuffer | undefined {
@@ -75,6 +89,14 @@ class AudioService {
 
   retrieveBlobUrl(trackId: string): string | undefined {
     return this.audioSourceRepository.get(trackId)?.blobUrl;
+  }
+
+  retrieveNormalizationGainDb(trackId: string): number {
+    return this.audioSourceRepository.get(trackId)?.normalizationGainDb ?? 0;
+  }
+
+  retrieveInitialVolume(trackId: string): number | undefined {
+    return this.audioSourceRepository.get(trackId)?.initialVolume;
   }
 
   startPlayback(transportTime?: number): void {

--- a/src/services/LoudnessNormalizer.ts
+++ b/src/services/LoudnessNormalizer.ts
@@ -1,0 +1,58 @@
+// Target RMS in linear scale (~-14 dBFS)
+const TARGET_RMS = 0.2;
+
+// Tracks below this RMS are treated as silence and not normalized
+const SILENCE_THRESHOLD = 0.001;
+
+// Slider range boundaries
+const MIN_VOLUME = 0;
+const MAX_VOLUME = 100;
+
+// Slider-to-dB formula constant: slider maps [0, 100] via 20*ln((v+1)/SLIDER_SCALE)
+const SLIDER_SCALE = 101;
+
+function calculateRms(audioBuffer: AudioBuffer): number {
+  const numChannels = audioBuffer.numberOfChannels;
+  const length = audioBuffer.length;
+
+  if (length === 0) return 0;
+
+  let sumSquares = 0;
+  for (let ch = 0; ch < numChannels; ch++) {
+    const channelData = audioBuffer.getChannelData(ch);
+    for (let i = 0; i < length; i++) {
+      sumSquares += channelData[i] * channelData[i];
+    }
+  }
+
+  const meanSquare = sumSquares / (numChannels * length);
+  return Math.sqrt(meanSquare);
+}
+
+function calculateNormalizationGain(audioBuffer: AudioBuffer): number {
+  const rms = calculateRms(audioBuffer);
+
+  if (rms < SILENCE_THRESHOLD) return 0;
+
+  const gainLinear = TARGET_RMS / rms;
+  // Convert to standard dB: 20 * log10(gain)
+  return 20 * Math.log10(gainLinear);
+}
+
+function gainToInitialVolume(normalizationGainDb: number): number {
+  // Invert the slider-to-dB formula to find the slider position where
+  // sliderDb + normalizationGainDb = 0 dB (original loudness).
+  //
+  // sliderDb = 20 * ln((v + 1) / 101)
+  // Setting sliderDb = -normalizationGainDb:
+  //   ln((v + 1) / 101) = -normalizationGainDb / 20
+  //   v = 101 * exp(-normalizationGainDb / 20) - 1
+  const volume = SLIDER_SCALE * Math.exp(-normalizationGainDb / 20) - 1;
+  return Math.round(Math.min(MAX_VOLUME, Math.max(MIN_VOLUME, volume)));
+}
+
+export const LoudnessNormalizer = {
+  calculateRms,
+  calculateNormalizationGain,
+  gainToInitialVolume,
+};

--- a/src/services/Mixer.ts
+++ b/src/services/Mixer.ts
@@ -19,11 +19,17 @@ class Mixer {
     return Math.pow(clamped, POWER_CURVE_EXPONENT);
   }
 
-  createChannel(trackId: string, audioBuffer: AudioBuffer): void {
+  createChannel(
+    trackId: string,
+    audioBuffer: AudioBuffer,
+    normalizationGainDb = 0,
+  ): void {
     const player = new Tone.Player(audioBuffer).sync().start(0);
     const channel = new Tone.Channel().toDestination();
     player.chain(channel);
-    this.audioChannelRepository.add(new AudioChannel(trackId, channel));
+    this.audioChannelRepository.add(
+      new AudioChannel(trackId, channel, normalizationGainDb),
+    );
   }
 
   retrieveChannel(trackId: string): AudioChannel | undefined {
@@ -62,10 +68,12 @@ class Mixer {
 export class AudioChannel {
   id: string;
   private channel: Tone.Channel;
+  private normalizationGainDb: number;
 
-  constructor(id: string, channel: Tone.Channel) {
+  constructor(id: string, channel: Tone.Channel, normalizationGainDb = 0) {
     this.id = id;
     this.channel = channel;
+    this.normalizationGainDb = normalizationGainDb;
   }
 
   dispose(): void {
@@ -89,7 +97,8 @@ export class AudioChannel {
   }
 
   set volume(volume: number) {
-    this.channel.volume.rampTo(this.convertToDecibel(volume), 0.1);
+    const sliderDb = this.convertToDecibel(volume);
+    this.channel.volume.rampTo(sliderDb + this.normalizationGainDb, 0.1);
   }
 
   private convertToDecibel(value: number): number {

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -7,6 +7,18 @@ if (typeof URL.createObjectURL === 'undefined') {
   URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
 }
 
+function mockAudioBuffer(overrides: Partial<AudioBuffer> = {}): AudioBuffer {
+  const channelData = new Float32Array(100).fill(0.2);
+  return {
+    numberOfChannels: 1,
+    length: 100,
+    sampleRate: 44100,
+    duration: 100 / 44100,
+    getChannelData: vi.fn().mockReturnValue(channelData),
+    ...overrides,
+  } as unknown as AudioBuffer;
+}
+
 // Reset singleton between tests
 let audioService: AudioService;
 
@@ -14,6 +26,7 @@ beforeEach(() => {
   // Reset singleton between tests
   Object.assign(AudioService, { instance: undefined });
   audioService = AudioService.getInstance();
+  vi.mocked(Tone.context.decodeAudioData).mockResolvedValue(mockAudioBuffer());
 });
 
 describe('singleton', () => {
@@ -25,29 +38,35 @@ describe('singleton', () => {
 });
 
 describe('createTrack', () => {
-  it('decodes audio data and returns a track ID', async () => {
+  it('decodes audio data and returns a track ID and initial volume', async () => {
     const arrayBuffer = new ArrayBuffer(16);
 
-    const trackId = await audioService.createTrack(arrayBuffer);
+    const { trackId, initialVolume } =
+      await audioService.createTrack(arrayBuffer);
 
     expect(Tone.context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
     expect(trackId).toBeDefined();
     expect(typeof trackId).toBe('string');
+    expect(typeof initialVolume).toBe('number');
   });
 
-  it('creates a mixer channel for the track', async () => {
+  it('creates a mixer channel with normalization gain', async () => {
     const createChannelSpy = vi.spyOn(audioService.mixer, 'createChannel');
     const arrayBuffer = new ArrayBuffer(16);
 
-    const trackId = await audioService.createTrack(arrayBuffer);
+    const { trackId } = await audioService.createTrack(arrayBuffer);
 
-    expect(createChannelSpy).toHaveBeenCalledWith(trackId, expect.anything());
+    expect(createChannelSpy).toHaveBeenCalledWith(
+      trackId,
+      expect.anything(),
+      expect.any(Number),
+    );
   });
 
   it('stores the blob URL for the track', async () => {
     const arrayBuffer = new ArrayBuffer(16);
 
-    const trackId = await audioService.createTrack(arrayBuffer);
+    const { trackId } = await audioService.createTrack(arrayBuffer);
     const blobUrl = audioService.retrieveBlobUrl(trackId);
 
     expect(blobUrl).toBeDefined();
@@ -57,15 +76,55 @@ describe('createTrack', () => {
   it('stores the audio buffer for the track', async () => {
     const arrayBuffer = new ArrayBuffer(16);
 
-    const trackId = await audioService.createTrack(arrayBuffer);
+    const { trackId } = await audioService.createTrack(arrayBuffer);
     const audioBuffer = audioService.retrieveAudioBuffer(trackId);
 
     expect(audioBuffer).toBeDefined();
   });
 
+  it('stores normalization data for undo/redo retrieval', async () => {
+    const arrayBuffer = new ArrayBuffer(16);
+
+    const { trackId, initialVolume } =
+      await audioService.createTrack(arrayBuffer);
+
+    expect(audioService.retrieveInitialVolume(trackId)).toBe(initialVolume);
+    expect(typeof audioService.retrieveNormalizationGainDb(trackId)).toBe(
+      'number',
+    );
+  });
+
   it('returns undefined for unknown track IDs', () => {
     expect(audioService.retrieveBlobUrl('nonexistent')).toBeUndefined();
     expect(audioService.retrieveAudioBuffer('nonexistent')).toBeUndefined();
+    expect(audioService.retrieveInitialVolume('nonexistent')).toBeUndefined();
+  });
+
+  it('returns initial volume of 100 for a buffer at target RMS', async () => {
+    const channelData = new Float32Array(100).fill(0.2);
+    vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+      mockAudioBuffer({ getChannelData: vi.fn().mockReturnValue(channelData) }),
+    );
+
+    const { initialVolume } = await audioService.createTrack(
+      new ArrayBuffer(16),
+    );
+
+    expect(initialVolume).toBe(100);
+  });
+
+  it('returns initial volume below 100 for a quiet buffer', async () => {
+    const channelData = new Float32Array(100).fill(0.05);
+    vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+      mockAudioBuffer({ getChannelData: vi.fn().mockReturnValue(channelData) }),
+    );
+
+    const { initialVolume } = await audioService.createTrack(
+      new ArrayBuffer(16),
+    );
+
+    expect(initialVolume).toBeLessThan(100);
+    expect(initialVolume).toBeGreaterThan(0);
   });
 });
 
@@ -146,15 +205,10 @@ describe('getTotalTime', () => {
   });
 
   it('returns the duration of the longest track', async () => {
-    // decodeAudioData returns {} by default, but we need duration
-    const mockBuffer1 = { duration: 5.0 };
-    const mockBuffer2 = { duration: 10.0 };
-    const mockBuffer3 = { duration: 3.0 };
-
     vi.mocked(Tone.context.decodeAudioData)
-      .mockResolvedValueOnce(mockBuffer1 as unknown as AudioBuffer)
-      .mockResolvedValueOnce(mockBuffer2 as unknown as AudioBuffer)
-      .mockResolvedValueOnce(mockBuffer3 as unknown as AudioBuffer);
+      .mockResolvedValueOnce(mockAudioBuffer({ duration: 5.0 }))
+      .mockResolvedValueOnce(mockAudioBuffer({ duration: 10.0 }))
+      .mockResolvedValueOnce(mockAudioBuffer({ duration: 3.0 }));
 
     await audioService.createTrack(new ArrayBuffer(16));
     await audioService.createTrack(new ArrayBuffer(16));

--- a/src/services/__tests__/LoudnessNormalizer.test.ts
+++ b/src/services/__tests__/LoudnessNormalizer.test.ts
@@ -1,0 +1,129 @@
+import { LoudnessNormalizer } from '../LoudnessNormalizer';
+
+function createMockAudioBuffer(channelData: Float32Array[]): AudioBuffer {
+  const numChannels = channelData.length;
+  const length = channelData[0]?.length ?? 0;
+  return {
+    numberOfChannels: numChannels,
+    length,
+    sampleRate: 44100,
+    duration: length / 44100,
+    getChannelData: (ch: number) => channelData[ch],
+  } as unknown as AudioBuffer;
+}
+
+describe('calculateRms', () => {
+  it('returns 0 for an empty buffer', () => {
+    const buffer = createMockAudioBuffer([new Float32Array(0)]);
+
+    expect(LoudnessNormalizer.calculateRms(buffer)).toBe(0);
+  });
+
+  it('returns 0 for a silent buffer', () => {
+    const buffer = createMockAudioBuffer([new Float32Array(100)]);
+
+    expect(LoudnessNormalizer.calculateRms(buffer)).toBe(0);
+  });
+
+  it('returns correct RMS for a mono buffer', () => {
+    // All samples at 0.5: RMS = sqrt(mean(0.25)) = 0.5
+    const samples = new Float32Array(100).fill(0.5);
+    const buffer = createMockAudioBuffer([samples]);
+
+    expect(LoudnessNormalizer.calculateRms(buffer)).toBeCloseTo(0.5);
+  });
+
+  it('returns correct RMS for a full-scale sine-like signal', () => {
+    // Alternating +1 and -1: RMS = sqrt(mean(1)) = 1
+    const samples = new Float32Array(100);
+    for (let i = 0; i < 100; i++) {
+      samples[i] = i % 2 === 0 ? 1 : -1;
+    }
+    const buffer = createMockAudioBuffer([samples]);
+
+    expect(LoudnessNormalizer.calculateRms(buffer)).toBeCloseTo(1.0);
+  });
+
+  it('averages RMS across multiple channels', () => {
+    // Channel 1: all 0.4 → sum of squares = 100 * 0.16 = 16
+    // Channel 2: all 0.2 → sum of squares = 100 * 0.04 = 4
+    // Mean square = (16 + 4) / (2 * 100) = 0.1
+    // RMS = sqrt(0.1) ≈ 0.3162
+    const ch1 = new Float32Array(100).fill(0.4);
+    const ch2 = new Float32Array(100).fill(0.2);
+    const buffer = createMockAudioBuffer([ch1, ch2]);
+
+    expect(LoudnessNormalizer.calculateRms(buffer)).toBeCloseTo(Math.sqrt(0.1));
+  });
+});
+
+describe('calculateNormalizationGain', () => {
+  it('returns 0 dB for a silent buffer', () => {
+    const buffer = createMockAudioBuffer([new Float32Array(100)]);
+
+    expect(LoudnessNormalizer.calculateNormalizationGain(buffer)).toBe(0);
+  });
+
+  it('returns 0 dB for a near-silent buffer', () => {
+    const samples = new Float32Array(100).fill(0.0005);
+    const buffer = createMockAudioBuffer([samples]);
+
+    expect(LoudnessNormalizer.calculateNormalizationGain(buffer)).toBe(0);
+  });
+
+  it('returns positive gain for a quiet buffer', () => {
+    // RMS = 0.05, target = 0.2 → gain = 0.2/0.05 = 4 → 20*log10(4) ≈ 12.04 dB
+    const samples = new Float32Array(100).fill(0.05);
+    const buffer = createMockAudioBuffer([samples]);
+
+    const gain = LoudnessNormalizer.calculateNormalizationGain(buffer);
+    expect(gain).toBeCloseTo(20 * Math.log10(4));
+  });
+
+  it('returns 0 dB for a buffer already at target RMS', () => {
+    const samples = new Float32Array(100).fill(0.2);
+    const buffer = createMockAudioBuffer([samples]);
+
+    expect(LoudnessNormalizer.calculateNormalizationGain(buffer)).toBeCloseTo(
+      0,
+    );
+  });
+
+  it('returns negative gain for a loud buffer', () => {
+    // RMS = 0.8, target = 0.2 → gain = 0.2/0.8 = 0.25 → 20*log10(0.25) ≈ -12.04 dB
+    const samples = new Float32Array(100).fill(0.8);
+    const buffer = createMockAudioBuffer([samples]);
+
+    const gain = LoudnessNormalizer.calculateNormalizationGain(buffer);
+    expect(gain).toBeCloseTo(20 * Math.log10(0.25));
+  });
+});
+
+describe('gainToInitialVolume', () => {
+  it('returns 100 when normalization gain is 0 dB', () => {
+    expect(LoudnessNormalizer.gainToInitialVolume(0)).toBe(100);
+  });
+
+  it('returns a value below 100 for positive gain', () => {
+    // Positive gain means the track was amplified; original was quieter
+    const volume = LoudnessNormalizer.gainToInitialVolume(12);
+    expect(volume).toBeLessThan(100);
+    expect(volume).toBeGreaterThan(0);
+  });
+
+  it('clamps to 100 for negative gain', () => {
+    // Negative gain means the track was attenuated; original was louder
+    const volume = LoudnessNormalizer.gainToInitialVolume(-12);
+    expect(volume).toBe(100);
+  });
+
+  it('clamps to 0 for very large positive gain', () => {
+    const volume = LoudnessNormalizer.gainToInitialVolume(200);
+    expect(volume).toBe(0);
+  });
+
+  it('rounds to the nearest integer', () => {
+    const volume = LoudnessNormalizer.gainToInitialVolume(6);
+    expect(Number.isInteger(volume)).toBe(true);
+  });
+});

--- a/src/services/__tests__/Mixer.test.ts
+++ b/src/services/__tests__/Mixer.test.ts
@@ -246,6 +246,40 @@ describe('AudioChannel', () => {
     });
   });
 
+  describe('normalization gain', () => {
+    it('adds normalization gain to slider dB at full volume', () => {
+      const normGainDb = 6;
+      const normalized = new AudioChannel('ch-norm', toneChannel, normGainDb);
+
+      normalized.volume = 100;
+
+      // slider dB at 100 = 0, so total = 0 + 6 = 6
+      expect(toneChannel.volume.rampTo).toHaveBeenCalledWith(normGainDb, 0.1);
+    });
+
+    it('adds normalization gain to slider dB at mid volume', () => {
+      const normGainDb = 12;
+      const normalized = new AudioChannel('ch-norm', toneChannel, normGainDb);
+
+      normalized.volume = 50;
+
+      const sliderDb = 20 * Math.log(51 / 101);
+      expect(toneChannel.volume.rampTo).toHaveBeenCalledWith(
+        sliderDb + normGainDb,
+        0.1,
+      );
+    });
+
+    it('defaults normalization gain to 0 when not provided', () => {
+      const channel = new AudioChannel('ch-default', toneChannel);
+
+      channel.volume = 100;
+
+      // 0 dB slider + 0 dB normalization = 0 dB
+      expect(toneChannel.volume.rampTo).toHaveBeenCalledWith(0, 0.1);
+    });
+  });
+
   describe('dispose', () => {
     it('disposes the underlying Tone.Channel', () => {
       audioChannel.dispose();

--- a/src/signals/__tests__/trackSignals.test.ts
+++ b/src/signals/__tests__/trackSignals.test.ts
@@ -15,6 +15,14 @@ describe('TrackSignalStore', () => {
       expect(signals.solo.value).toBe(false);
     });
 
+    it('creates signals with a custom initial volume', () => {
+      const signals = TrackSignalStore.create('track-1', 75);
+
+      expect(signals.volume.value).toBe(75);
+      expect(signals.mute.value).toBe(false);
+      expect(signals.solo.value).toBe(false);
+    });
+
     it('stores the signals so they can be retrieved', () => {
       TrackSignalStore.create('track-1');
 

--- a/src/signals/trackSignals.ts
+++ b/src/signals/trackSignals.ts
@@ -15,9 +15,9 @@ const store = new Map<TrackId, TrackSignals>();
 // store's membership (e.g. mutedTracks) know to re-evaluate.
 const storeVersion = signal(0);
 
-function create(trackId: TrackId): TrackSignals {
+function create(trackId: TrackId, initialVolume?: number): TrackSignals {
   const signals: TrackSignals = {
-    volume: signal(DEFAULT_VOLUME),
+    volume: signal(initialVolume ?? DEFAULT_VOLUME),
     mute: signal(false),
     solo: signal(false),
   };


### PR DESCRIPTION
## Summary
This PR implements loudness normalization to automatically adjust track volumes based on their RMS (Root Mean Square) levels. When tracks are uploaded or created, the system calculates a normalization gain and derives an initial volume setting that restores the original perceived loudness when the slider is at 100%.

## Key Changes

- **New `LoudnessNormalizer` service**: Calculates RMS levels, determines normalization gain in dB, and converts gain back to initial volume slider positions
  - `calculateRms()`: Computes RMS across all channels of an audio buffer
  - `calculateNormalizationGain()`: Determines gain needed to normalize to -14 dBFS target
  - `gainToInitialVolume()`: Inverts the slider-to-dB formula to find the slider position that restores original loudness

- **Updated `AudioService.createTrack()`**: Now returns both `trackId` and `initialVolume` instead of just the ID
  - Calculates normalization gain for each uploaded track
  - Stores normalization data for undo/redo support
  - Added retrieval methods: `retrieveNormalizationGainDb()` and `retrieveInitialVolume()`

- **Enhanced `AudioChannel`**: Accepts optional normalization gain parameter
  - Adds normalization gain to slider dB when setting volume
  - Ensures normalized tracks play at original loudness when slider is at 100%

- **Updated `Mixer.createChannel()`**: Accepts normalization gain parameter and passes it to `AudioChannel`

- **Signal store integration**: `TrackSignalStore.create()` now accepts optional `initialVolume` parameter to set the initial volume signal

- **Updated all track creation callsites**: Modified file upload, microphone recording, and track restoration flows to use the new `TrackCreationResult` type and pass initial volume to signal store

## Implementation Details

- Target RMS is set to 0.2 (~-14 dBFS), a standard loudness level for audio
- Silence threshold of 0.001 prevents normalization of near-silent tracks
- The slider-to-dB formula uses natural logarithm: `20 * ln((v+1)/101)` where v is slider position [0-100]
- Normalization gain is added to the slider dB calculation, so the combined effect restores original loudness at slider position 100
- Comprehensive test coverage for all normalization calculations and integration points

https://claude.ai/code/session_01CRgH7Z4MAuQPTCwf8MMqNW