### PR TITLE
Remove deploy job and restrict e2e tests to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
@@ -60,7 +61,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [ci, e2e]
+    needs: [ci]
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,3 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [ci]
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Deploy to Netlify
-        run: npx netlify-cli deploy --dir=dist --prod
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
## Summary
This PR removes the automated Netlify deployment workflow and adds a condition to run end-to-end tests only on pull requests.

## Key Changes
- **Removed deploy job**: Deleted the entire `deploy` job that was responsible for building and deploying to Netlify on the master branch. This job is no longer needed in the CI/CD pipeline.
- **Restricted e2e tests**: Added `if: github.event_name == 'pull_request'` condition to the `e2e` job to ensure end-to-end tests only run when code is being reviewed in a pull request, reducing unnecessary test runs on other events.

## Implementation Details
The e2e job will now skip execution for events other than pull requests (such as direct pushes to master or scheduled runs), optimizing CI/CD resource usage while maintaining test coverage for code review workflows.

https://claude.ai/code/session_01VLebRfNV7xrzeNWJPxe3vL