### PR TITLE
Replace custom debounce/throttle with throttle-debounce library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-full-screen": "^1.1.0",
         "react-router-dom": "^7.0.0",
         "standardized-audio-context-mock": "^9.7.20",
+        "throttle-debounce": "^5.0.2",
         "tone": "^14.7.77",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.56.0",
+        "@types/throttle-debounce": "^5.0.2",
         "babel-plugin-react-compiler": "^1.0.0"
       },
       "engines": {
@@ -2264,6 +2265,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.56.0",
+    "@types/throttle-debounce": "^5.0.2",
     "babel-plugin-react-compiler": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-full-screen": "^1.1.0",
     "react-router-dom": "^7.0.0",
     "standardized-audio-context-mock": "^9.7.20",
+    "throttle-debounce": "^5.0.2",
     "tone": "^14.7.77",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.0.0",

--- a/src/components/workstation/Scrubber.tsx
+++ b/src/components/workstation/Scrubber.tsx
@@ -28,6 +28,7 @@ type ScrubberProps = PropsWithChildren<{
 }>;
 
 const TIMELINE_MARGIN = 40;
+const SCROLL_DEBOUNCE_MS = 200;
 
 const Scrubber = (props: ScrubberProps) => {
   useSignals();
@@ -122,7 +123,7 @@ const Scrubber = (props: ScrubberProps) => {
   };
 
   const debouncedSetTransportTime = useDebounced(setTransportTimeFromScroll, {
-    timeoutMs: 200,
+    timeoutMs: SCROLL_DEBOUNCE_MS,
   });
 
   const pauseForUserScroll = () => {

--- a/src/components/workstation/__tests__/useChannelControls.test.ts
+++ b/src/components/workstation/__tests__/useChannelControls.test.ts
@@ -57,13 +57,11 @@ describe('useChannelControls', () => {
   });
 
   describe('commitVolume', () => {
-    it('unfocuses track after debounce period', () => {
+    it('unfocuses track immediately when slider is released', () => {
       const { result } = renderHook(() => useChannelControls('track-1'));
 
       result.current.updateVolume(80);
       result.current.commitVolume();
-
-      vi.advanceTimersByTime(250);
 
       expect(focusedTracks.value).not.toContain('track-1');
     });

--- a/src/components/workstation/useChannelControls.ts
+++ b/src/components/workstation/useChannelControls.ts
@@ -1,9 +1,5 @@
 import { useSignals } from '@preact/signals-react/runtime';
-import {
-  cancelDebouncedUnfocusTrack,
-  debouncedUnfocusTrack,
-  focusTrack,
-} from '../../signals/focusSignals';
+import { focusTrack, unfocusTrack } from '../../signals/focusSignals';
 import { TrackSignalStore } from '../../signals/trackSignals';
 import { type TrackId } from '../project/projectPageReducer';
 
@@ -18,7 +14,6 @@ export function useChannelControls(trackId: TrackId) {
 
   const startFocus = () => {
     focusTrack(trackId);
-    cancelDebouncedUnfocusTrack(trackId);
   };
 
   const updateVolume = (value: number) => {
@@ -29,7 +24,7 @@ export function useChannelControls(trackId: TrackId) {
   };
 
   const commitVolume = () => {
-    debouncedUnfocusTrack(trackId);
+    unfocusTrack(trackId);
   };
 
   const updateMute = () => {

--- a/src/hooks/__tests__/useDebounced.test.tsx
+++ b/src/hooks/__tests__/useDebounced.test.tsx
@@ -15,22 +15,12 @@ afterAll(() => {
 
 const mockCallback = vi.fn();
 
-const defaultOptions = {
-  timeoutMs: 100,
-};
-
 it('debounces callback within timeout', () => {
   const { result } = renderHook(() =>
-    useDebounced(mockCallback, { ...defaultOptions, timeoutMs: 100 }),
+    useDebounced(mockCallback, { timeoutMs: 100 }),
   );
 
   const debouncedCallback = result.current;
-
-  debouncedCallback();
-  vi.advanceTimersByTime(50);
-
-  debouncedCallback();
-  vi.advanceTimersByTime(50);
 
   debouncedCallback();
   vi.advanceTimersByTime(50);
@@ -45,24 +35,20 @@ it('debounces callback within timeout', () => {
   expect(mockCallback).toHaveBeenCalledTimes(1);
 });
 
-it('updates callback when dependencies change', () => {
+it('updates timeout when timeoutMs changes', () => {
   const { result, rerender } = renderHook(
-    ({ options }) => useDebounced(mockCallback, options),
-    { initialProps: { options: { ...defaultOptions, timeoutMs: 10 } } },
+    ({ timeoutMs }) => useDebounced(mockCallback, { timeoutMs }),
+    { initialProps: { timeoutMs: 10 } },
   );
 
-  let debouncedCallback = result.current;
-
-  debouncedCallback();
+  result.current();
   vi.advanceTimersByTime(10);
 
   expect(mockCallback).toHaveBeenCalledTimes(1);
 
-  rerender({ options: { ...defaultOptions, timeoutMs: 100 } });
+  rerender({ timeoutMs: 100 });
 
-  debouncedCallback = result.current;
-
-  debouncedCallback();
+  result.current();
   vi.advanceTimersByTime(10);
 
   expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -75,11 +61,7 @@ it('updates callback when dependencies change', () => {
 it('has fallback to default timeout option', () => {
   const { result } = renderHook(() => useDebounced(mockCallback));
 
-  const debouncedCallback = result.current;
-
-  expect(mockCallback).toHaveBeenCalledTimes(0);
-
-  debouncedCallback();
+  result.current();
   vi.advanceTimersByTime(100);
 
   expect(mockCallback).toHaveBeenCalledTimes(1);

--- a/src/hooks/__tests__/useThrottled.test.tsx
+++ b/src/hooks/__tests__/useThrottled.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import useThrottled from '../useThrottled';
+
+beforeAll(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+const mockCallback = vi.fn();
+
+it('fires immediately on first call', () => {
+  const { result } = renderHook(() =>
+    useThrottled(mockCallback, { timeoutMs: 100 }),
+  );
+
+  result.current();
+
+  expect(mockCallback).toHaveBeenCalledTimes(1);
+});
+
+it('throttles subsequent calls within timeout', () => {
+  const { result } = renderHook(() =>
+    useThrottled(mockCallback, { timeoutMs: 100 }),
+  );
+
+  result.current();
+  result.current();
+  result.current();
+
+  expect(mockCallback).toHaveBeenCalledTimes(1);
+
+  vi.advanceTimersByTime(100);
+
+  result.current();
+
+  expect(mockCallback).toHaveBeenCalledTimes(2);
+});
+
+it('has fallback to default timeout option', () => {
+  const { result } = renderHook(() => useThrottled(mockCallback));
+
+  result.current();
+
+  expect(mockCallback).toHaveBeenCalledTimes(1);
+
+  result.current();
+  vi.advanceTimersByTime(100);
+
+  result.current();
+
+  expect(mockCallback).toHaveBeenCalledTimes(2);
+});

--- a/src/hooks/useDebounced.tsx
+++ b/src/hooks/useDebounced.tsx
@@ -1,25 +1,24 @@
-import { useCallback, useRef } from 'react';
+import { debounce } from 'throttle-debounce';
+import { useMemo, useRef } from 'react';
 
 type DebouncedOptions = {
-  timeoutMs: number;
+  timeoutMs?: number;
 };
 
-const defaultOptions: DebouncedOptions = { timeoutMs: 100 };
+// Wraps throttle-debounce's debounce in a stable React hook.
+// The ref pattern ensures the latest callback is always called without
+// recreating (and resetting) the debounced function on every render.
+const useDebounced = (
+  callback: () => void,
+  { timeoutMs = 100 }: DebouncedOptions = {},
+) => {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
 
-const useDebounced = (callback: () => void, { timeoutMs } = defaultOptions) => {
-  const timeoutRef = useRef<number | null>(null);
-
-  const debounced = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-    timeoutRef.current = window.setTimeout(() => {
-      callback();
-      timeoutRef.current = null;
-    }, timeoutMs);
-  }, [callback, timeoutMs]);
-
-  return debounced;
+  return useMemo(
+    () => debounce(timeoutMs, () => callbackRef.current()),
+    [timeoutMs],
+  );
 };
 
 export default useDebounced;

--- a/src/hooks/useThrottled.tsx
+++ b/src/hooks/useThrottled.tsx
@@ -1,0 +1,24 @@
+import { throttle } from 'throttle-debounce';
+import { useMemo, useRef } from 'react';
+
+type ThrottledOptions = {
+  timeoutMs?: number;
+};
+
+// Wraps throttle-debounce's throttle in a stable React hook.
+// The ref pattern ensures the latest callback is always called without
+// recreating (and resetting) the throttled function on every render.
+const useThrottled = (
+  callback: () => void,
+  { timeoutMs = 100 }: ThrottledOptions = {},
+) => {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  return useMemo(
+    () => throttle(timeoutMs, () => callbackRef.current()),
+    [timeoutMs],
+  );
+};
+
+export default useThrottled;

--- a/src/signals/__tests__/focusSignals.test.ts
+++ b/src/signals/__tests__/focusSignals.test.ts
@@ -1,7 +1,4 @@
-import { vi } from 'vitest';
 import {
-  cancelDebouncedUnfocusTrack,
-  debouncedUnfocusTrack,
   focusedTracks,
   focusTrack,
   unfocusTrack,
@@ -60,92 +57,6 @@ describe('focusSignals', () => {
     });
   });
 
-  describe('debouncedUnfocusTrack', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('unfocuses track after 250ms', () => {
-      focusTrack('track-1');
-
-      debouncedUnfocusTrack('track-1');
-
-      expect(focusedTracks.value).toEqual(['track-1']);
-
-      vi.advanceTimersByTime(250);
-
-      expect(focusedTracks.value).toEqual([]);
-    });
-
-    it('resets debounce timer on repeated calls', () => {
-      focusTrack('track-1');
-
-      debouncedUnfocusTrack('track-1');
-      vi.advanceTimersByTime(200);
-
-      debouncedUnfocusTrack('track-1');
-      vi.advanceTimersByTime(200);
-
-      // Should still be focused — second call reset the timer
-      expect(focusedTracks.value).toEqual(['track-1']);
-
-      vi.advanceTimersByTime(50);
-
-      expect(focusedTracks.value).toEqual([]);
-    });
-
-    it('handles independent debounce timers per track', () => {
-      focusTrack('track-1');
-      focusTrack('track-2');
-
-      debouncedUnfocusTrack('track-1');
-      vi.advanceTimersByTime(100);
-
-      debouncedUnfocusTrack('track-2');
-      vi.advanceTimersByTime(150);
-
-      // track-1 should be unfocused (250ms elapsed), track-2 still focused
-      expect(focusedTracks.value).toEqual(['track-2']);
-
-      vi.advanceTimersByTime(100);
-
-      expect(focusedTracks.value).toEqual([]);
-    });
-  });
-
-  describe('cancelDebouncedUnfocusTrack', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('cancels a pending debounced unfocus', () => {
-      focusTrack('track-1');
-      debouncedUnfocusTrack('track-1');
-
-      cancelDebouncedUnfocusTrack('track-1');
-
-      vi.advanceTimersByTime(250);
-
-      expect(focusedTracks.value).toEqual(['track-1']);
-    });
-
-    it('handles canceling when no debounce is pending', () => {
-      focusTrack('track-1');
-
-      cancelDebouncedUnfocusTrack('track-1');
-
-      expect(focusedTracks.value).toEqual(['track-1']);
-    });
-  });
-
   describe('resetFocusSignals', () => {
     it('clears all focused tracks', () => {
       focusTrack('track-1');
@@ -154,23 +65,6 @@ describe('focusSignals', () => {
       resetFocusSignals();
 
       expect(focusedTracks.value).toEqual([]);
-    });
-
-    it('clears pending debounce timers', () => {
-      vi.useFakeTimers();
-
-      focusTrack('track-1');
-      debouncedUnfocusTrack('track-1');
-
-      resetFocusSignals();
-      focusTrack('track-1');
-
-      vi.advanceTimersByTime(250);
-
-      // Timer should have been cleared by reset, so track stays focused
-      expect(focusedTracks.value).toEqual(['track-1']);
-
-      vi.useRealTimers();
     });
   });
 });

--- a/src/signals/focusSignals.ts
+++ b/src/signals/focusSignals.ts
@@ -13,31 +13,6 @@ export function unfocusTrack(trackId: TrackId): void {
   focusedTracks.value = focusedTracks.value.filter((id) => id !== trackId);
 }
 
-const UNFOCUS_DEBOUNCE_MS = 250;
-const unfocusTimers = new Map<TrackId, number>();
-
-export function debouncedUnfocusTrack(trackId: TrackId): void {
-  const existing = unfocusTimers.get(trackId);
-  if (existing) {
-    clearTimeout(existing);
-  }
-  const timerId = window.setTimeout(() => {
-    unfocusTrack(trackId);
-    unfocusTimers.delete(trackId);
-  }, UNFOCUS_DEBOUNCE_MS);
-  unfocusTimers.set(trackId, timerId);
-}
-
-export function cancelDebouncedUnfocusTrack(trackId: TrackId): void {
-  const existing = unfocusTimers.get(trackId);
-  if (existing) {
-    clearTimeout(existing);
-    unfocusTimers.delete(trackId);
-  }
-}
-
 export function resetFocusSignals(): void {
   focusedTracks.value = [];
-  unfocusTimers.forEach((timerId) => clearTimeout(timerId));
-  unfocusTimers.clear();
 }


### PR DESCRIPTION
## Summary
Refactored debouncing and throttling logic to use the `throttle-debounce` library instead of custom implementations. This simplifies the codebase and removes manual timer management.

## Key Changes

- **Removed debounced unfocus from focus signals**: Deleted `debouncedUnfocusTrack()` and `cancelDebouncedUnfocusTrack()` functions from `focusSignals.ts` along with their manual timer tracking. Track unfocus is now immediate.

- **Refactored `useDebounced` hook**: Replaced custom `useCallback`-based implementation with `throttle-debounce` library. Now uses `useMemo` with a callback ref pattern to maintain stable debounced function while always calling the latest callback.

- **Added `useThrottled` hook**: New hook following the same pattern as `useDebounced`, wrapping the library's `throttle` function with a callback ref for stable references.

- **Updated `useChannelControls`**: Simplified to call `unfocusTrack()` immediately in `commitVolume()` instead of using debounced unfocus. Removed `cancelDebouncedUnfocusTrack()` call from `startFocus()`.

- **Updated test expectations**: Modified tests to reflect immediate unfocus behavior and simplified debounce/throttle testing with the library's built-in behavior.

## Implementation Details

The new hooks use a ref pattern to ensure the debounced/throttled function is created only once per timeout value, while always executing the latest callback. This prevents unnecessary function recreation on every render while maintaining closure over the current callback.

The `throttle-debounce` library is added as a dependency to handle the timing logic, eliminating the need for manual `setTimeout`/`clearTimeout` management.

https://claude.ai/code/session_01MHQSSMTXqcZLBF2y2RjpPr