### PR TITLE
Fix recording playback silence and first recording not showing

### DIFF
--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -24,7 +24,7 @@ const Timeline = ({ pixelsPerSecond, tracks }: TimelineProps) => {
 
   return (
     <div ref={containerRef} className="timeline">
-      {containerRef.current &&
+      {height > 0 &&
         tracks.map((track) => {
           const timelineWaveformClass = getTimelineWaveformClass(
             track,

--- a/src/hooks/__tests__/useContainerHeight.test.ts
+++ b/src/hooks/__tests__/useContainerHeight.test.ts
@@ -1,0 +1,154 @@
+import { render, act } from '@testing-library/react';
+import { createElement, useEffect } from 'react';
+import { vi } from 'vitest';
+import { useContainerHeight } from '../useContainerHeight';
+
+// --- ResizeObserver mock ---
+
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+const resizeCallbacks = new Map<Element, ResizeCallback>();
+
+class MockResizeObserver {
+  private callback: ResizeCallback;
+
+  constructor(callback: ResizeCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    resizeCallbacks.set(target, this.callback);
+  }
+
+  unobserve(target: Element) {
+    resizeCallbacks.delete(target);
+  }
+
+  disconnect() {
+    resizeCallbacks.clear();
+  }
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+});
+
+function triggerResizeObserver(
+  target: Element,
+  contentRect: Partial<DOMRectReadOnly>,
+) {
+  const callback = resizeCallbacks.get(target);
+  if (callback) {
+    callback([
+      {
+        target,
+        contentRect: {
+          x: 0,
+          y: 0,
+          width: 800,
+          height: 0,
+          top: 0,
+          right: 800,
+          bottom: 0,
+          left: 0,
+          ...contentRect,
+        } as DOMRectReadOnly,
+        borderBoxSize: [],
+        contentBoxSize: [],
+        devicePixelContentBoxSize: [],
+      },
+    ]);
+  }
+}
+
+// --- getBoundingClientRect mock ---
+
+let mockHeight = 0;
+
+beforeEach(() => {
+  mockHeight = 0;
+  resizeCallbacks.clear();
+  vi.spyOn(
+    HTMLDivElement.prototype,
+    'getBoundingClientRect',
+  ).mockImplementation(
+    () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 800,
+        height: mockHeight,
+        top: 0,
+        right: 800,
+        bottom: mockHeight,
+        left: 0,
+        toJSON: vi.fn(),
+      }) as DOMRect,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- Test helper component ---
+
+// Renders a div with the useContainerHeight hook and exposes the height
+// via a data attribute so tests can assert against the real DOM.
+function HeightReporter({ onHeight }: { onHeight: (h: number) => void }) {
+  const { containerRef, height } = useContainerHeight();
+
+  useEffect(() => {
+    onHeight(height);
+  }, [height, onHeight]);
+
+  return createElement('div', {
+    ref: containerRef,
+    'data-testid': 'container',
+    'data-height': height,
+  });
+}
+
+it('measures container height on mount', () => {
+  mockHeight = 600;
+  let reportedHeight = -1;
+
+  render(
+    createElement(HeightReporter, {
+      onHeight: (h: number) => {
+        reportedHeight = h;
+      },
+    }),
+  );
+
+  expect(reportedHeight).toBe(600);
+});
+
+it('updates height when the container resizes', async () => {
+  // Start with height 0 — simulates Timeline mounting before the browser
+  // has resolved the flex layout, which can happen on first mount when
+  // the container switches from EmptyTimeline to Scrubber > Timeline.
+  mockHeight = 0;
+  let reportedHeight = -1;
+
+  const { getByTestId } = render(
+    createElement(HeightReporter, {
+      onHeight: (h: number) => {
+        reportedHeight = h;
+      },
+    }),
+  );
+
+  expect(reportedHeight).toBe(0);
+
+  // Simulate the container gaining height after layout resolves
+  const container = getByTestId('container');
+  await act(async () => {
+    triggerResizeObserver(container, { height: 500 });
+  });
+
+  // The hook must re-measure and update. Without a ResizeObserver, the
+  // hook stays at 0 because it only measures once on mount, preventing
+  // Timeline from ever rendering tracks for the first recording.
+  expect(reportedHeight).toBe(500);
+});

--- a/src/hooks/useContainerHeight.ts
+++ b/src/hooks/useContainerHeight.ts
@@ -5,11 +5,25 @@ export function useContainerHeight() {
   const [height, setHeight] = useState(0);
 
   useLayoutEffect(() => {
-    if (containerRef.current) {
-      const { height } = containerRef.current.getBoundingClientRect();
-      setHeight(height);
-    }
-  }, []); // measure once on mount
+    const el = containerRef.current;
+    if (!el) return;
+
+    // Synchronous initial measurement (prevents flash of empty content)
+    const rect = el.getBoundingClientRect();
+    setHeight(rect.height);
+
+    // Re-measure when the container resizes. This handles the case where
+    // the initial measurement returns 0 (e.g. Timeline mounting before
+    // flex layout resolves) and the container gains height later.
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setHeight(entry.contentRect.height);
+      }
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
 
   return { containerRef, height };
 }

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -160,17 +160,21 @@ class AudioService {
   }
 
   async stopOverdubRecording(): Promise<TrackCreationResult> {
-    Tone.Transport.pause();
+    // Transport.stop() (not pause) ensures the next Transport.start() is a
+    // fresh start. Synced players created after Transport.pause() don't
+    // trigger on resume because they were never "playing" before the pause.
+    // Transport.stop() resets the timeline so all synced players — including
+    // the one about to be created for this recording — start from their
+    // scheduled positions on the next Transport.start().
+    Tone.Transport.stop();
     const blob = await this.recorder.stop();
     this.microphone.close();
 
     const startTime = this.recordingStartTime ?? 0;
     this.recordingStartTime = null;
 
-    // Rewind transport to the recording start position so the recorded
-    // track can be replayed immediately. Without this, Transport stays
-    // at the position where recording ended — pressing play resumes from
-    // there, which is past the recorded content, producing no audio.
+    // Position transport at the recording start so playback begins from
+    // the start of the recorded content.
     Tone.Transport.seconds = startTime;
 
     const arrayBuffer = await blob.arrayBuffer();

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -272,7 +272,7 @@ describe('overdub recording', () => {
     );
   });
 
-  it('pauses transport and stops recorder on stopOverdubRecording', async () => {
+  it('stops transport and stops recorder on stopOverdubRecording', async () => {
     await audioService.startOverdubRecording();
 
     const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
@@ -280,7 +280,12 @@ describe('overdub recording', () => {
 
     await audioService.stopOverdubRecording();
 
-    expect(Tone.Transport.pause).toHaveBeenCalled();
+    // Transport.stop() (not pause) ensures the next Transport.start() is a
+    // fresh start rather than a resume. Synced players created after
+    // Transport.pause() may not trigger on resume, because they were never
+    // "playing" before the pause. Transport.stop() resets the timeline so
+    // all synced players start from their scheduled positions.
+    expect(Tone.Transport.stop).toHaveBeenCalled();
     expect(recorderInstance.stop).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- **No audio on playback after recording**: `stopOverdubRecording()` used `Transport.pause()`, but synced Tone.js players created while Transport is paused don't trigger on resume — they were never "playing" before the pause. Changed to `Transport.stop()` so the next `Transport.start()` is a fresh start that properly triggers all synced players from their scheduled positions.
- **First recording not showing in timeline**: `useContainerHeight` measured the container only once on mount. If the initial measurement returned 0, `setHeight(0)` didn't trigger a re-render (initial state was already 0), leaving `containerRef.current` set but never re-checked. Added `ResizeObserver` to re-measure on resize, and changed Timeline's render guard from `containerRef.current` (a ref) to `height > 0` (a state variable that triggers re-renders).

## Test plan
- [x] Failing unit test written before fix: `AudioService.test.ts` — expects `Transport.stop()` (not `pause()`) in `stopOverdubRecording`
- [x] Failing unit test written before fix: `useContainerHeight.test.ts` — verifies height updates when container resizes from 0 to non-zero
- [x] All 314 unit tests pass
- [x] Build succeeds with no type errors
- [x] ESLint passes
- [ ] Manual test: record first track → verify spectrogram/waveform appears in timeline
- [ ] Manual test: record first track → press play → verify audio is audible
- [ ] Manual test: record second track (overdub) → press play → verify both tracks play

https://claude.ai/code/session_018vpcNhCp3KEZvCimELC1jk