### PR TITLE
Fix audio playback silence caused by stale Tone.Transport reference

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -91,6 +91,70 @@ test.describe('Playback controls', () => {
     await expect(page.getByTitle('Play')).toBeVisible();
   });
 
+  test('synced Players produce audio when Transport starts', async ({ page }) => {
+    // Intercept AudioNode.connect to track whether the Tone.js Player
+    // actually creates an AudioBufferSourceNode during playback. If the
+    // Transport is bound to the wrong AudioContext (stale Tone.Transport
+    // reference after Tone.setContext), the synced Player never fires.
+    await page.addInitScript(() => {
+      const connections: Array<{ src: string; dst: string }> = [];
+      const origConnect = AudioNode.prototype.connect;
+      AudioNode.prototype.connect = function (
+        ...args: Parameters<typeof origConnect>
+      ) {
+        const dst = args[0];
+        connections.push({
+          src: this.constructor.name,
+          dst: dst instanceof AudioNode ? dst.constructor.name : 'AudioParam',
+        });
+        return origConnect.apply(
+          this,
+          args as unknown as Parameters<typeof origConnect>,
+        );
+      } as typeof origConnect;
+
+      (window as unknown as Record<string, unknown>).__audioConnections =
+        connections;
+    });
+
+    // Re-navigate so the init script takes effect
+    await page.goto('/project');
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__waveform')).toBeVisible();
+
+    const prePlaybackCount = await page.evaluate(() => {
+      const connections = (
+        window as unknown as Record<
+          string,
+          Array<{ src: string; dst: string }>
+        >
+      ).__audioConnections;
+      return connections.filter(
+        (c) => c.src === 'AudioBufferSourceNode' && c.dst === 'GainNode',
+      ).length;
+    });
+
+    await page.getByTitle('Play').click();
+    await expect(page.getByTitle('Pause')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    const postPlaybackCount = await page.evaluate(() => {
+      const connections = (
+        window as unknown as Record<
+          string,
+          Array<{ src: string; dst: string }>
+        >
+      ).__audioConnections;
+      return connections.filter(
+        (c) => c.src === 'AudioBufferSourceNode' && c.dst === 'GainNode',
+      ).length;
+    });
+
+    // At least one AudioBufferSourceNode → GainNode connection must appear
+    // during playback, proving the Player started producing audio.
+    expect(postPlaybackCount - prePlaybackCount).toBeGreaterThan(0);
+  });
+
   test('shows a playback cursor while playing', async ({ page }) => {
     const cursor = page.locator('.cursor');
     await expect(cursor).toBeVisible();

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -103,37 +103,37 @@ class AudioService {
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
-    Tone.Transport.start();
+    Tone.getTransport().start();
   }
 
   pausePlayback(transportTime?: number): void {
-    Tone.Transport.pause();
+    Tone.getTransport().pause();
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
   }
 
   stopPlayback(transportTime?: number): void {
-    Tone.Transport.stop();
+    Tone.getTransport().stop();
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
   }
 
   togglePlayback(): void {
-    if (Tone.Transport.state === 'started') {
-      Tone.Transport.pause();
+    if (Tone.getTransport().state === 'started') {
+      Tone.getTransport().pause();
     } else {
-      Tone.Transport.start();
+      Tone.getTransport().start();
     }
   }
 
   getTransportTime(): number {
-    return Tone.Transport.seconds;
+    return Tone.getTransport().seconds;
   }
 
   setTransportTime(transportTime: number): void {
-    Tone.Transport.seconds = transportTime;
+    Tone.getTransport().seconds = transportTime;
   }
 
   getTotalTime(): number {
@@ -152,11 +152,11 @@ class AudioService {
     this.microphone.microphone.connect(this.recorder);
 
     // Capture transport position before starting
-    this.recordingStartTime = Tone.Transport.seconds;
+    this.recordingStartTime = Tone.getTransport().seconds;
 
     // Start recorder first (has startup delay), then Transport
     await this.recorder.start();
-    Tone.Transport.start();
+    Tone.getTransport().start();
   }
 
   async stopOverdubRecording(): Promise<TrackCreationResult> {
@@ -166,7 +166,7 @@ class AudioService {
     // Transport.stop() resets the timeline so all synced players — including
     // the one about to be created for this recording — start from their
     // scheduled positions on the next Transport.start().
-    Tone.Transport.stop();
+    Tone.getTransport().stop();
     const blob = await this.recorder.stop();
     this.microphone.close();
 
@@ -175,7 +175,7 @@ class AudioService {
 
     // Position transport at the recording start so playback begins from
     // the start of the recorded content.
-    Tone.Transport.seconds = startTime;
+    Tone.getTransport().seconds = startTime;
 
     const arrayBuffer = await blob.arrayBuffer();
     const audioBuffer = await Tone.context.decodeAudioData(arrayBuffer);

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -129,73 +129,73 @@ describe('createTrack', () => {
 });
 
 describe('playback control', () => {
-  it('starts playback via Tone.Transport', () => {
+  it('starts playback via Tone.getTransport()', () => {
     audioService.startPlayback();
 
-    expect(Tone.Transport.start).toHaveBeenCalledTimes(1);
+    expect(Tone.getTransport().start).toHaveBeenCalledTimes(1);
   });
 
   it('starts playback at a given transport time', () => {
     audioService.startPlayback(5.0);
 
-    expect(Tone.Transport.seconds).toBe(5.0);
-    expect(Tone.Transport.start).toHaveBeenCalled();
+    expect(Tone.getTransport().seconds).toBe(5.0);
+    expect(Tone.getTransport().start).toHaveBeenCalled();
   });
 
-  it('pauses playback via Tone.Transport', () => {
+  it('pauses playback via Tone.getTransport()', () => {
     audioService.pausePlayback();
 
-    expect(Tone.Transport.pause).toHaveBeenCalledTimes(1);
+    expect(Tone.getTransport().pause).toHaveBeenCalledTimes(1);
   });
 
   it('pauses playback and sets transport time', () => {
     audioService.pausePlayback(3.0);
 
-    expect(Tone.Transport.pause).toHaveBeenCalled();
-    expect(Tone.Transport.seconds).toBe(3.0);
+    expect(Tone.getTransport().pause).toHaveBeenCalled();
+    expect(Tone.getTransport().seconds).toBe(3.0);
   });
 
-  it('stops playback via Tone.Transport', () => {
+  it('stops playback via Tone.getTransport()', () => {
     audioService.stopPlayback();
 
-    expect(Tone.Transport.stop).toHaveBeenCalledTimes(1);
+    expect(Tone.getTransport().stop).toHaveBeenCalledTimes(1);
   });
 
   it('stops playback and sets transport time', () => {
     audioService.stopPlayback(0);
 
-    expect(Tone.Transport.stop).toHaveBeenCalled();
-    expect(Tone.Transport.seconds).toBe(0);
+    expect(Tone.getTransport().stop).toHaveBeenCalled();
+    expect(Tone.getTransport().seconds).toBe(0);
   });
 
   it('toggles from stopped to started', () => {
-    Object.assign(Tone.Transport, { state: 'stopped' });
+    Object.assign(Tone.getTransport(), { state: 'stopped' });
 
     audioService.togglePlayback();
 
-    expect(Tone.Transport.start).toHaveBeenCalled();
+    expect(Tone.getTransport().start).toHaveBeenCalled();
   });
 
   it('toggles from started to paused', () => {
-    Object.assign(Tone.Transport, { state: 'started' });
+    Object.assign(Tone.getTransport(), { state: 'started' });
 
     audioService.togglePlayback();
 
-    expect(Tone.Transport.pause).toHaveBeenCalled();
+    expect(Tone.getTransport().pause).toHaveBeenCalled();
   });
 });
 
 describe('transport time', () => {
-  it('gets transport time from Tone.Transport', () => {
-    Tone.Transport.seconds = 42;
+  it('gets transport time from Tone.getTransport()', () => {
+    Tone.getTransport().seconds = 42;
 
     expect(audioService.getTransportTime()).toBe(42);
   });
 
-  it('sets transport time on Tone.Transport', () => {
+  it('sets transport time on Tone.getTransport()', () => {
     audioService.setTransportTime(10);
 
-    expect(Tone.Transport.seconds).toBe(10);
+    expect(Tone.getTransport().seconds).toBe(10);
   });
 });
 
@@ -239,7 +239,7 @@ describe('overdub recording', () => {
     await audioService.startOverdubRecording();
 
     expect(audioService.microphone.microphone.open).toHaveBeenCalled();
-    expect(Tone.Transport.start).toHaveBeenCalled();
+    expect(Tone.getTransport().start).toHaveBeenCalled();
   });
 
   it('connects microphone to recorder on startOverdubRecording', async () => {
@@ -249,7 +249,7 @@ describe('overdub recording', () => {
   });
 
   it('captures transport position before starting', async () => {
-    Tone.Transport.seconds = 5.0;
+    Tone.getTransport().seconds = 5.0;
 
     await audioService.startOverdubRecording();
 
@@ -285,7 +285,7 @@ describe('overdub recording', () => {
     // Transport.pause() may not trigger on resume, because they were never
     // "playing" before the pause. Transport.stop() resets the timeline so
     // all synced players start from their scheduled positions.
-    expect(Tone.Transport.stop).toHaveBeenCalled();
+    expect(Tone.getTransport().stop).toHaveBeenCalled();
     expect(recorderInstance.stop).toHaveBeenCalled();
   });
 
@@ -328,38 +328,38 @@ describe('overdub recording', () => {
 
   it('rewinds transport to recording start time after stopping', async () => {
     // Recording starts at transport position 0
-    Tone.Transport.seconds = 0;
+    Tone.getTransport().seconds = 0;
     await audioService.startOverdubRecording();
 
     const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
     Object.assign(recorderInstance, { state: 'started' });
 
     // Transport advances during recording (simulating real playback)
-    Tone.Transport.seconds = 5.0;
+    Tone.getTransport().seconds = 5.0;
 
     await audioService.stopOverdubRecording();
 
     // Transport should be rewound to the recording start time (0) so the
     // recorded track can be replayed. Without this, pressing play resumes
     // from 5.0 — past the end of the 5-second recording — producing no audio.
-    expect(Tone.Transport.seconds).toBe(0);
+    expect(Tone.getTransport().seconds).toBe(0);
   });
 
   it('rewinds transport to mid-session recording start time after stopping', async () => {
     // User played to position 3, paused, then started recording
-    Tone.Transport.seconds = 3.0;
+    Tone.getTransport().seconds = 3.0;
     await audioService.startOverdubRecording();
 
     const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
     Object.assign(recorderInstance, { state: 'started' });
 
     // Transport advances during recording
-    Tone.Transport.seconds = 8.0;
+    Tone.getTransport().seconds = 8.0;
 
     await audioService.stopOverdubRecording();
 
     // Transport should rewind to 3.0 (recording start), not stay at 8.0
-    expect(Tone.Transport.seconds).toBe(3.0);
+    expect(Tone.getTransport().seconds).toBe(3.0);
   });
 
   it('stores a retrievable blobUrl for the recorded track', async () => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -29,19 +29,21 @@ vi.mock('tone', () => {
   function makeRecorderNode() {
     return { ...makeNode(), state: 'stopped' };
   }
+  const transportMock = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    pause: vi.fn(),
+    seconds: 0,
+    state: 'stopped',
+  };
   return {
     Meter: vi.fn().mockImplementation(makeNode),
     UserMedia: vi.fn().mockImplementation(makeNode),
     Player: vi.fn().mockImplementation(makeNode),
     Channel: vi.fn().mockImplementation(makeNode),
     Recorder: vi.fn().mockImplementation(makeRecorderNode),
-    Transport: {
-      start: vi.fn(),
-      stop: vi.fn(),
-      pause: vi.fn(),
-      seconds: 0,
-      state: 'stopped',
-    },
+    Transport: transportMock,
+    getTransport: vi.fn().mockReturnValue(transportMock),
     start: vi.fn().mockResolvedValue(undefined),
     getDestination: vi.fn().mockReturnValue(makeNode()),
     context: {


### PR DESCRIPTION
Tone.js exports `Transport` as a static constant bound to the context
at import time. After `Tone.setContext()` replaces the global context,
`Tone.Transport` still refers to the old context's transport. Synced
Players are created on the new context, so starting the old transport
produces no audio while the timeline still scrolls.

Replace all `Tone.Transport` references with `Tone.getTransport()`
which dynamically resolves the current context's transport.

https://claude.ai/code/session_01Q9TDm993GsCUAPJjY2LCk7