### PR TITLE
Fix audio recordings broken by Tone.js context mismatch

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,21 +4,8 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { BrowserSupportProvider } from './browserSupport';
 import App from './components/App';
-import * as Tone from 'tone';
 import './index.css';
 import AudioService from './services/AudioService';
-
-// Reduce scheduling lookahead from the default 0.1s to 0.05s for lower
-// recording latency while keeping enough headroom to avoid scheduling glitches
-// with many concurrent players (Tone.js issue #711).
-const RECORDING_LOOK_AHEAD = 0.05;
-
-Tone.setContext(
-  new Tone.Context({
-    latencyHint: 'interactive',
-    lookAhead: RECORDING_LOOK_AHEAD,
-  }),
-);
 
 AudioService.startAudio()
   .then(() => console.log('audio is ready'))

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -4,6 +4,11 @@ import { LoudnessNormalizer } from './LoudnessNormalizer';
 import MicrophoneUserMedia from './MicrophoneUserMedia';
 import Mixer from './Mixer';
 
+// Reduce scheduling lookahead from the default 0.1s to 0.05s for lower
+// recording latency while keeping enough headroom to avoid scheduling glitches
+// with many concurrent players (Tone.js issue #711).
+const RECORDING_LOOK_AHEAD = 0.05;
+
 type AudioContextStarter = {
   resolve: () => void;
   reject: () => void;
@@ -49,6 +54,18 @@ class AudioService {
 
   static getInstance(): AudioService {
     if (!AudioService.instance) {
+      // Configure the Tone.js context before creating any audio nodes so
+      // they share the same context as Tone.getTransport(). Without this,
+      // nodes end up on the default context while getTransport() resolves
+      // to the custom context. Transport.start() only resumes its own
+      // context, so the default context stays suspended and the Recorder's
+      // MediaStreamDestination produces no audio data.
+      Tone.setContext(
+        new Tone.Context({
+          latencyHint: 'interactive',
+          lookAhead: RECORDING_LOOK_AHEAD,
+        }),
+      );
       AudioService.instance = new AudioService();
     }
     return AudioService.instance;

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -35,6 +35,21 @@ describe('singleton', () => {
     const b = AudioService.getInstance();
     expect(a).toBe(b);
   });
+
+  it('configures Tone.js context before creating audio nodes', () => {
+    // AudioService must call Tone.setContext() before constructing Tone.js
+    // nodes (Recorder, UserMedia, Meter, etc.) so they all share the same
+    // context as Tone.getTransport(). Without this, nodes are created on
+    // the default context while getTransport() resolves to the custom
+    // context. The default context is never resumed (only the custom
+    // context is), so the Recorder's MediaStreamDestination produces no
+    // audio data and recordings silently fail.
+    const setContextOrder = vi.mocked(Tone.setContext).mock
+      .invocationCallOrder[0];
+    const recorderOrder = vi.mocked(Tone.Recorder).mock.invocationCallOrder[0];
+    expect(setContextOrder).toBeDefined();
+    expect(setContextOrder).toBeLessThan(recorderOrder);
+  });
 });
 
 describe('createTrack', () => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -57,7 +57,8 @@ vi.mock('tone', () => {
       },
     },
     setContext: vi.fn(),
-    Context: vi.fn().mockImplementation(() => ({})),
+    // Must be a regular function (not arrow) to support `new`
+    Context: vi.fn().mockImplementation(function () {}),
   };
 });
 


### PR DESCRIPTION
AudioService.getInstance() was called during module evaluation (from
useAudioService.tsx's createContext()), before Tone.setContext() in
index.tsx. This created all Tone.js nodes (Recorder, UserMedia, Meter)
on the default context, while Tone.getTransport() resolved to the
custom context. Transport.start() calls this.context.resume(), so only
the custom context was resumed — the default context stayed suspended
and the Recorder's MediaStreamDestination produced no audio data.

Move Tone.setContext() into AudioService.getInstance() so it runs
before the constructor creates any Tone.js nodes, ensuring they all
share the same context as getTransport().

https://claude.ai/code/session_01DfF6is3GBD7X16dt6ThTmc