### PR TITLE
Isolate Tone.js dependencies within the service layer

### DIFF
--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -25,17 +25,61 @@ test.use({
 });
 
 /**
+ * Intercepts AudioContext construction so ensureAudioContextRunning() can
+ * verify the context state after Tone.start(). Must be called before
+ * page.goto() so the init script runs before the application creates its
+ * AudioContext.
+ */
+async function installAudioContextSpy(
+  page: import('@playwright/test').Page,
+) {
+  await page.addInitScript(() => {
+    const captured: AudioContext[] = [];
+    Object.defineProperty(window, '__audioContexts', { value: captured });
+    const NativeAudioContext = window.AudioContext;
+    window.AudioContext = class extends NativeAudioContext {
+      constructor(options?: AudioContextOptions) {
+        super(options);
+        captured.push(this);
+      }
+    } as typeof AudioContext;
+  });
+}
+
+/**
  * Ensures the Tone.js AudioContext is running before performing audio operations.
  *
  * AudioService.startAudio() installs a click handler on window that calls
  * Tone.start(). Clicking the toolbar area triggers this handler without
  * interfering with the dropzone file dialog on the editor area.
+ *
+ * After clicking, we poll the captured AudioContext state to confirm it
+ * reached 'running'. This replaces a blind waitForTimeout(500) that could
+ * mask a regression where the context stays 'suspended' (e.g. Tone.start()
+ * removed, or the click listener never fires).
+ *
+ * Note: --autoplay-policy=no-user-gesture-required means Chrome may start
+ * contexts in 'running' state automatically. The check still guards against
+ * context creation failures or unexpected 'closed' / 'suspended' states.
  */
 async function ensureAudioContextRunning(
   page: import('@playwright/test').Page,
 ) {
   await page.locator('.workstation__toolbar').click();
-  await page.waitForTimeout(500);
+
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const ctxs = (
+            window as unknown as { __audioContexts: AudioContext[] }
+          ).__audioContexts;
+          if (!ctxs || ctxs.length === 0) return null;
+          return ctxs[ctxs.length - 1].state;
+        }),
+      { message: 'AudioContext did not reach running state', timeout: 3000 },
+    )
+    .toBe('running');
 }
 
 /**
@@ -58,6 +102,7 @@ async function recordAudio(
 
 test.describe('Recording', () => {
   test.beforeEach(async ({ page }) => {
+    await installAudioContextSpy(page);
     await page.goto('/project');
     await ensureAudioContextRunning(page);
   });
@@ -135,6 +180,7 @@ test.describe('Recording', () => {
 
 test.describe('Recording with existing tracks', () => {
   test.beforeEach(async ({ page }) => {
+    await installAudioContextSpy(page);
     await page.goto('/project');
     await ensureAudioContextRunning(page);
 

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -45,6 +45,15 @@ class AudioService {
   private recorder: Tone.Recorder;
   private recordingStartTime: number | null = null;
 
+  // Cache Tone.js singletons at construction time so every method uses the
+  // same transport/context that was configured in getInstance(). Repeated
+  // Tone.getTransport() / Tone.context lookups are fragile because Tone.js
+  // resolves them from mutable global state — if the context is swapped or
+  // re-created the cached references stay consistent while fresh lookups
+  // could silently resolve to a different object.
+  private readonly transport = Tone.getTransport();
+  private readonly context = Tone.context;
+
   private constructor() {
     this.audioSourceRepository = new AudioSourceRepository();
     this.microphone = new MicrophoneUserMedia();
@@ -81,7 +90,7 @@ class AudioService {
   }
 
   async createTrack(arrayBuffer: ArrayBuffer): Promise<TrackCreationResult> {
-    const audioBuffer = await Tone.context.decodeAudioData(arrayBuffer);
+    const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
     const trackId = uuidv4();
     const blob = new Blob([arrayBuffer], { type: 'audio/*' });
     const blobUrl = URL.createObjectURL(blob);
@@ -120,37 +129,37 @@ class AudioService {
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
-    Tone.getTransport().start();
+    this.transport.start();
   }
 
   pausePlayback(transportTime?: number): void {
-    Tone.getTransport().pause();
+    this.transport.pause();
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
   }
 
   stopPlayback(transportTime?: number): void {
-    Tone.getTransport().stop();
+    this.transport.stop();
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);
     }
   }
 
   togglePlayback(): void {
-    if (Tone.getTransport().state === 'started') {
-      Tone.getTransport().pause();
+    if (this.transport.state === 'started') {
+      this.transport.pause();
     } else {
-      Tone.getTransport().start();
+      this.transport.start();
     }
   }
 
   getTransportTime(): number {
-    return Tone.getTransport().seconds;
+    return this.transport.seconds;
   }
 
   setTransportTime(transportTime: number): void {
-    Tone.getTransport().seconds = transportTime;
+    this.transport.seconds = transportTime;
   }
 
   getTotalTime(): number {
@@ -163,17 +172,17 @@ class AudioService {
   // --- Overdub recording (Phase 1: MediaRecorder + timestamp bookkeeping) ---
 
   async startOverdubRecording(): Promise<void> {
-    if (this.microphone.microphone.state !== 'started') {
+    if (!this.microphone.isOpen) {
       await this.microphone.open();
     }
-    this.microphone.microphone.connect(this.recorder);
+    this.microphone.connect(this.recorder);
 
     // Capture transport position before starting
-    this.recordingStartTime = Tone.getTransport().seconds;
+    this.recordingStartTime = this.transport.seconds;
 
     // Start recorder first (has startup delay), then Transport
     await this.recorder.start();
-    Tone.getTransport().start();
+    this.transport.start();
   }
 
   async stopOverdubRecording(): Promise<TrackCreationResult> {
@@ -183,7 +192,7 @@ class AudioService {
     // Transport.stop() resets the timeline so all synced players — including
     // the one about to be created for this recording — start from their
     // scheduled positions on the next Transport.start().
-    Tone.getTransport().stop();
+    this.transport.stop();
     const blob = await this.recorder.stop();
     this.microphone.close();
 
@@ -192,10 +201,10 @@ class AudioService {
 
     // Position transport at the recording start so playback begins from
     // the start of the recorded content.
-    Tone.getTransport().seconds = startTime;
+    this.transport.seconds = startTime;
 
     const arrayBuffer = await blob.arrayBuffer();
-    const audioBuffer = await Tone.context.decodeAudioData(arrayBuffer);
+    const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
 
     const latencyCompensation = this.estimateRoundTripLatency();
 
@@ -212,10 +221,10 @@ class AudioService {
   }
 
   estimateRoundTripLatency(): number {
-    const ctx = Tone.context.rawContext as AudioContext;
+    const ctx = this.context.rawContext as AudioContext;
     const outputLatency = ctx.outputLatency ?? 0;
     const baseLatency = ctx.baseLatency ?? 0;
-    const lookAhead = Tone.context.lookAhead;
+    const lookAhead = this.context.lookAhead;
     // One render quantum (~2.9ms at 44.1kHz) as a conservative input latency
     // estimate, per research on Web Audio API latency characteristics
     const estimatedInputLatency = 128 / ctx.sampleRate;
@@ -225,10 +234,10 @@ class AudioService {
   // --- Legacy recording methods (independent of transport) ---
 
   async startRecording(): Promise<unknown> {
-    if (this.microphone.microphone.state !== 'started') {
+    if (!this.microphone.isOpen) {
       return Promise.reject();
     }
-    this.microphone.microphone.connect(this.recorder);
+    this.microphone.connect(this.recorder);
     return await this.recorder.start();
   }
 

--- a/src/services/MicrophoneUserMedia.ts
+++ b/src/services/MicrophoneUserMedia.ts
@@ -1,14 +1,16 @@
 import * as Tone from 'tone';
 
 class MicrophoneUserMedia {
-  // TODO: make private again
-  microphone: Tone.UserMedia;
-
+  private microphone: Tone.UserMedia;
   private meter: Tone.Meter;
 
   constructor() {
     this.meter = new Tone.Meter();
     this.microphone = new Tone.UserMedia().connect(this.meter);
+  }
+
+  get isOpen(): boolean {
+    return this.microphone.state === 'started';
   }
 
   async open(): Promise<void> {
@@ -17,6 +19,10 @@ class MicrophoneUserMedia {
 
   close(): void {
     this.microphone.close();
+  }
+
+  connect(destination: Tone.ToneAudioNode): void {
+    this.microphone.connect(destination);
   }
 
   getLoudness(): number {

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -251,16 +251,20 @@ describe('recording', () => {
 
 describe('overdub recording', () => {
   it('opens microphone and starts transport on startOverdubRecording', async () => {
+    const openSpy = vi.spyOn(audioService.microphone, 'open');
+
     await audioService.startOverdubRecording();
 
-    expect(audioService.microphone.microphone.open).toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalled();
     expect(Tone.getTransport().start).toHaveBeenCalled();
   });
 
   it('connects microphone to recorder on startOverdubRecording', async () => {
+    const connectSpy = vi.spyOn(audioService.microphone, 'connect');
+
     await audioService.startOverdubRecording();
 
-    expect(audioService.microphone.microphone.connect).toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalled();
   });
 
   it('captures transport position before starting', async () => {
@@ -327,6 +331,8 @@ describe('overdub recording', () => {
   });
 
   it('closes microphone on stopOverdubRecording', async () => {
+    const closeSpy = vi.spyOn(audioService.microphone, 'close');
+
     await audioService.startOverdubRecording();
 
     const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
@@ -334,7 +340,7 @@ describe('overdub recording', () => {
 
     await audioService.stopOverdubRecording();
 
-    expect(audioService.microphone.microphone.close).toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
   });
 
   it('reports overdub recording state', () => {

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -36,6 +36,13 @@ describe('singleton', () => {
     expect(a).toBe(b);
   });
 
+  it('configures Tone.Context with interactive latency and reduced lookAhead', () => {
+    expect(Tone.Context).toHaveBeenCalledWith({
+      latencyHint: 'interactive',
+      lookAhead: 0.05,
+    });
+  });
+
   it('configures Tone.js context before creating audio nodes', () => {
     // AudioService must call Tone.setContext() before constructing Tone.js
     // nodes (Recorder, UserMedia, Meter, etc.) so they all share the same
@@ -436,11 +443,42 @@ describe('estimateRoundTripLatency', () => {
 });
 
 describe('startAudio', () => {
+  beforeEach(() => {
+    // Reset context state to 'suspended' before each startAudio test,
+    // mirroring a freshly created AudioContext that hasn't been resumed yet.
+    Object.assign(Tone.context, { state: 'suspended' });
+  });
+
   it('resolves when a click event fires on the element', async () => {
     const promise = AudioService.startAudio(window);
     window.dispatchEvent(new Event('click'));
 
     await expect(promise).resolves.toBeUndefined();
     expect(Tone.start).toHaveBeenCalled();
+  });
+
+  it('transitions context from suspended to running', async () => {
+    expect(Tone.context.state).toBe('suspended');
+
+    const promise = AudioService.startAudio(window);
+    window.dispatchEvent(new Event('click'));
+    await promise;
+
+    expect(Tone.context.state).toBe('running');
+  });
+
+  it('rejects when Tone.start() fails', async () => {
+    vi.mocked(Tone.start).mockImplementationOnce(() =>
+      Promise.reject(new Error('not allowed')),
+    );
+
+    // Use a fresh element to avoid stale listeners from earlier tests
+    // (startAudioContext.bind() creates a new reference, so
+    // removeEventListener with the original reference is a no-op).
+    const el = document.createElement('div');
+    const promise = AudioService.startAudio(el as unknown as Window);
+    el.dispatchEvent(new Event('click'));
+
+    await expect(promise).rejects.toBeUndefined();
   });
 });

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -476,7 +476,9 @@ describe('startAudio', () => {
     // (startAudioContext.bind() creates a new reference, so
     // removeEventListener with the original reference is a no-op).
     const el = document.createElement('div');
-    const promise = AudioService.startAudio(el as unknown as Window);
+    const promise = AudioService.startAudio(
+      el as unknown as Window & typeof globalThis,
+    );
     el.dispatchEvent(new Event('click'));
 
     await expect(promise).rejects.toBeUndefined();

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -36,6 +36,17 @@ vi.mock('tone', () => {
     seconds: 0,
     state: 'stopped',
   };
+  const contextMock = {
+    state: 'suspended',
+    decodeAudioData: vi.fn().mockResolvedValue({}),
+    lookAhead: 0.05,
+    sampleRate: 44100,
+    rawContext: {
+      outputLatency: 0.01,
+      baseLatency: 0.005,
+      sampleRate: 44100,
+    },
+  };
   return {
     Meter: vi.fn().mockImplementation(makeNode),
     UserMedia: vi.fn().mockImplementation(makeNode),
@@ -44,18 +55,14 @@ vi.mock('tone', () => {
     Recorder: vi.fn().mockImplementation(makeRecorderNode),
     Transport: transportMock,
     getTransport: vi.fn().mockReturnValue(transportMock),
-    start: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn().mockImplementation(() => {
+      // Simulate the real Tone.start() behaviour: the AudioContext transitions
+      // from 'suspended' to 'running' when the promise resolves.
+      contextMock.state = 'running';
+      return Promise.resolve();
+    }),
     getDestination: vi.fn().mockReturnValue(makeNode()),
-    context: {
-      decodeAudioData: vi.fn().mockResolvedValue({}),
-      lookAhead: 0.05,
-      sampleRate: 44100,
-      rawContext: {
-        outputLatency: 0.01,
-        baseLatency: 0.005,
-        sampleRate: 44100,
-      },
-    },
+    context: contextMock,
     setContext: vi.fn(),
     // Must be a regular function (not arrow) to support `new`
     Context: vi.fn().mockImplementation(function () {}),


### PR DESCRIPTION
Cache Tone.js transport and context singletons as readonly instance
fields in AudioService, resolved once at construction time. This
eliminates repeated Tone.getTransport() / Tone.context global lookups
that are fragile because Tone.js resolves them from mutable global
state — the same class of bug that caused the context mismatch in #134.

Close the MicrophoneUserMedia abstraction gap: make the internal
Tone.UserMedia field private (resolving the existing TODO), and expose
isOpen and connect() so AudioService no longer reaches through to the
Tone.js object directly.

https://claude.ai/code/session_01HKScSX4DsJ6CCkhj3bbebd