### PR TITLE
Add SpectrogramCache service for caching spectrogram analysis (rebase of #129)

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LoudnessNormalizer } from './LoudnessNormalizer';
 import MicrophoneUserMedia from './MicrophoneUserMedia';
 import Mixer from './Mixer';
+import SpectrogramCache from './SpectrogramCache';
 
 // Reduce scheduling lookahead from the default 0.1s to 0.05s for lower
 // recording latency while keeping enough headroom to avoid scheduling glitches
@@ -39,6 +40,7 @@ type AudioSource = {
 class AudioService {
   microphone: MicrophoneUserMedia;
   mixer: Mixer;
+  spectrogramCache: SpectrogramCache;
 
   private static instance: AudioService;
   private audioSourceRepository: AudioSourceRepository;
@@ -59,6 +61,7 @@ class AudioService {
     this.microphone = new MicrophoneUserMedia();
     this.mixer = new Mixer();
     this.recorder = new Tone.Recorder();
+    this.spectrogramCache = new SpectrogramCache();
   }
 
   static getInstance(): AudioService {

--- a/src/services/SpectrogramCache.ts
+++ b/src/services/SpectrogramCache.ts
@@ -1,0 +1,44 @@
+import { TrackColor } from '../components/project/projectPageReducer';
+import OfflineAnalyser, { SpectrogramData } from './OfflineAnalyser';
+import { renderTiles } from './SpectrogramTileRenderer';
+
+export type TrackSpectrogramEntry = {
+  data: SpectrogramData;
+  tiles: ImageBitmap[];
+};
+
+class SpectrogramCache {
+  private entries = new Map<string, TrackSpectrogramEntry>();
+
+  async analyse(
+    trackId: string,
+    audioBuffer: AudioBuffer,
+    color: TrackColor,
+  ): Promise<void> {
+    const analyser = new OfflineAnalyser(audioBuffer);
+    const data = await analyser.analyseToFrames();
+    const tiles = renderTiles(data, color);
+    this.entries.set(trackId, { data, tiles });
+  }
+
+  getEntry(trackId: string): TrackSpectrogramEntry | undefined {
+    return this.entries.get(trackId);
+  }
+
+  invalidate(trackId: string): void {
+    const entry = this.entries.get(trackId);
+    if (entry) {
+      entry.tiles.forEach((tile) => tile.close());
+      this.entries.delete(trackId);
+    }
+  }
+
+  invalidateAll(): void {
+    this.entries.forEach((entry) => {
+      entry.tiles.forEach((tile) => tile.close());
+    });
+    this.entries.clear();
+  }
+}
+
+export default SpectrogramCache;

--- a/src/services/__tests__/SpectrogramCache.test.ts
+++ b/src/services/__tests__/SpectrogramCache.test.ts
@@ -1,0 +1,195 @@
+import { vi } from 'vitest';
+import { TrackColor } from '../../components/project/projectPageReducer';
+import type { SpectrogramData } from '../OfflineAnalyser';
+import SpectrogramCache from '../SpectrogramCache';
+
+const COLOR: TrackColor = { r: 77, g: 238, b: 234 };
+
+const MOCK_SPECTROGRAM_DATA: SpectrogramData = {
+  frequencyFrames: [new Uint8Array([10, 20]), new Uint8Array([30, 40])],
+  timeResolution: 0.025,
+  frequencyBinCount: 2,
+  sampleRate: 44100,
+  duration: 0.05,
+};
+
+const mockAnalyseToFrames = vi.fn().mockResolvedValue(MOCK_SPECTROGRAM_DATA);
+
+const mockOfflineAnalyserConstructor = vi.fn();
+
+vi.mock('../OfflineAnalyser', () => {
+  // Must be a regular function (not arrow) to support `new` in Vitest v4
+  function MockOfflineAnalyser(...args: unknown[]) {
+    mockOfflineAnalyserConstructor(...args);
+    return { analyseToFrames: mockAnalyseToFrames };
+  }
+  return { default: MockOfflineAnalyser };
+});
+
+const mockTileBitmap = {
+  close: vi.fn(),
+  width: 2,
+  height: 2,
+} as unknown as ImageBitmap;
+const mockRenderTiles = vi.fn().mockReturnValue([mockTileBitmap]);
+
+vi.mock('../SpectrogramTileRenderer', () => ({
+  renderTiles: (...args: unknown[]) => mockRenderTiles(...args),
+}));
+
+function mockAudioBuffer(): AudioBuffer {
+  return {
+    numberOfChannels: 1,
+    length: 100,
+    sampleRate: 44100,
+    duration: 0.05,
+    getChannelData: vi.fn(),
+  } as unknown as AudioBuffer;
+}
+
+let cache: SpectrogramCache;
+
+beforeEach(() => {
+  cache = new SpectrogramCache();
+  mockOfflineAnalyserConstructor.mockClear();
+  mockAnalyseToFrames.mockClear();
+  mockRenderTiles.mockClear();
+  mockTileBitmap.close = vi.fn();
+});
+
+describe('analyse', () => {
+  it('creates an OfflineAnalyser and calls analyseToFrames', async () => {
+    const audioBuffer = mockAudioBuffer();
+
+    await cache.analyse('track-1', audioBuffer, COLOR);
+
+    expect(mockOfflineAnalyserConstructor).toHaveBeenCalledWith(audioBuffer);
+    expect(mockAnalyseToFrames).toHaveBeenCalledOnce();
+  });
+
+  it('passes spectrogram data and color to renderTiles', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    expect(mockRenderTiles).toHaveBeenCalledWith(MOCK_SPECTROGRAM_DATA, COLOR);
+  });
+
+  it('stores the entry for later retrieval', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    const entry = cache.getEntry('track-1');
+    expect(entry).toBeDefined();
+    expect(entry!.data).toBe(MOCK_SPECTROGRAM_DATA);
+    expect(entry!.tiles).toEqual([mockTileBitmap]);
+  });
+
+  it('overwrites an existing entry for the same track', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    const secondData: SpectrogramData = {
+      ...MOCK_SPECTROGRAM_DATA,
+      duration: 1.0,
+    };
+    mockAnalyseToFrames.mockResolvedValueOnce(secondData);
+    const secondTile = { close: vi.fn() } as unknown as ImageBitmap;
+    mockRenderTiles.mockReturnValueOnce([secondTile]);
+
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    const entry = cache.getEntry('track-1');
+    expect(entry!.data).toBe(secondData);
+    expect(entry!.tiles).toEqual([secondTile]);
+  });
+});
+
+describe('getEntry', () => {
+  it('returns undefined for an unknown track', () => {
+    expect(cache.getEntry('nonexistent')).toBeUndefined();
+  });
+
+  it('returns the correct entry when multiple tracks are cached', async () => {
+    const secondData: SpectrogramData = {
+      ...MOCK_SPECTROGRAM_DATA,
+      duration: 2.0,
+    };
+    const secondTile = { close: vi.fn() } as unknown as ImageBitmap;
+
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    mockAnalyseToFrames.mockResolvedValueOnce(secondData);
+    mockRenderTiles.mockReturnValueOnce([secondTile]);
+
+    await cache.analyse('track-2', mockAudioBuffer(), COLOR);
+
+    expect(cache.getEntry('track-1')!.data).toBe(MOCK_SPECTROGRAM_DATA);
+    expect(cache.getEntry('track-2')!.data).toBe(secondData);
+  });
+});
+
+describe('invalidate', () => {
+  it('removes the entry for the given track', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    cache.invalidate('track-1');
+
+    expect(cache.getEntry('track-1')).toBeUndefined();
+  });
+
+  it('closes ImageBitmap tiles on invalidation', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    cache.invalidate('track-1');
+
+    expect(mockTileBitmap.close).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when invalidating an unknown track', () => {
+    expect(() => cache.invalidate('nonexistent')).not.toThrow();
+  });
+
+  it('does not affect other cached tracks', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    const secondTile = { close: vi.fn() } as unknown as ImageBitmap;
+    mockRenderTiles.mockReturnValueOnce([secondTile]);
+    await cache.analyse('track-2', mockAudioBuffer(), COLOR);
+
+    cache.invalidate('track-1');
+
+    expect(cache.getEntry('track-1')).toBeUndefined();
+    expect(cache.getEntry('track-2')).toBeDefined();
+  });
+});
+
+describe('invalidateAll', () => {
+  it('removes all cached entries', async () => {
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    const secondTile = { close: vi.fn() } as unknown as ImageBitmap;
+    mockRenderTiles.mockReturnValueOnce([secondTile]);
+    await cache.analyse('track-2', mockAudioBuffer(), COLOR);
+
+    cache.invalidateAll();
+
+    expect(cache.getEntry('track-1')).toBeUndefined();
+    expect(cache.getEntry('track-2')).toBeUndefined();
+  });
+
+  it('closes all ImageBitmap tiles', async () => {
+    const tile1 = { close: vi.fn() } as unknown as ImageBitmap;
+    const tile2 = { close: vi.fn() } as unknown as ImageBitmap;
+    mockRenderTiles.mockReturnValueOnce([tile1]);
+    await cache.analyse('track-1', mockAudioBuffer(), COLOR);
+
+    mockRenderTiles.mockReturnValueOnce([tile2]);
+    await cache.analyse('track-2', mockAudioBuffer(), COLOR);
+
+    cache.invalidateAll();
+
+    expect(tile1.close).toHaveBeenCalledOnce();
+    expect(tile2.close).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when cache is empty', () => {
+    expect(() => cache.invalidateAll()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Rebase of #129 onto current `master` to resolve conflicts with commits #130–#135.

- **New `SpectrogramCache` class** (`src/services/SpectrogramCache.ts`): Caches spectrogram analysis data and rendered ImageBitmap tiles per track ID, with proper resource cleanup on invalidation
- **Comprehensive test suite** (`src/services/__tests__/SpectrogramCache.test.ts`): Tests for analysis, retrieval, resource cleanup, and edge cases
- **Integration with `AudioService`**: Added `spectrogramCache` instance property

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 331 tests pass (`npm test -- --run`)
- [x] Rebased cleanly on latest master (25738c7)

Supersedes #129

https://claude.ai/code/session_01LyAUpoophyvkpgsMgW6vMQ