### PR TITLE
Rewrite Spectrogram with tiled viewport rendering (unified visualization step 5)

### DIFF
--- a/src/components/workstation/Spectrogram.css
+++ b/src/components/workstation/Spectrogram.css
@@ -3,5 +3,7 @@
 }
 
 .spectrogram__canvas {
-  position: absolute;
+  position: sticky;
+  left: 0;
+  display: block;
 }

--- a/src/components/workstation/Spectrogram.tsx
+++ b/src/components/workstation/Spectrogram.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useAnimationFrame } from '../../hooks/useAnimationFrame';
 import { useAudioService } from '../../hooks/useAudioService';
 import { useTrackVolume } from '../../hooks/useTrackVolume';
-import OfflineAnalyser from '../../services/OfflineAnalyser';
-import SpectrogramCanvasRenderer from '../../services/SpectrogramCanvasRenderer';
+import { TrackSpectrogramEntry } from '../../services/SpectrogramCache';
 import { Track } from '../project/projectPageReducer';
 import './Spectrogram.css';
 
@@ -12,69 +12,118 @@ type SpectrogramProps = {
   track: Track;
 };
 
+const TILE_WIDTH = 4096;
+const SCROLL_CONTAINER_CLASS = '.scrubber__timeline';
+
 const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
-  const analyserRef = useRef<OfflineAnalyser | undefined>(undefined);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastDrawnRef = useRef({ offset: -1, pps: -1, tileCount: -1 });
 
   const { trackId, color } = track;
 
   const audioService = useAudioService();
   const audioBuffer = audioService.retrieveAudioBuffer(trackId);
 
-  if (audioBuffer && !analyserRef.current) {
-    analyserRef.current = new OfflineAnalyser(audioBuffer);
-  }
-  const duration = audioBuffer?.duration ?? 0;
-  const frequencyBinCount = analyserRef.current?.frequencyBinCount ?? 2048;
-  const timeResolution = analyserRef.current?.timeResolution ?? 0.025;
+  const [entry, setEntry] = useState<TrackSpectrogramEntry | undefined>();
 
-  const heightPixelRatio = height / frequencyBinCount;
-  const heightFactor = Math.ceil(heightPixelRatio);
-  const widthFactor = Math.ceil(pixelsPerSecond * timeResolution);
-  const canvasWidth = Math.trunc(duration / timeResolution);
-  const canvasHeight = Math.ceil(heightPixelRatio) * frequencyBinCount;
-
+  // Trigger cache analysis on mount if not already cached
   useEffect(() => {
-    if (analyserRef.current && canvasRef.current) {
-      const canvasRenderer = new SpectrogramCanvasRenderer(
-        canvasRef.current,
-        color,
-        canvasHeight,
-        heightFactor,
-      );
-      const renderCallback = (
-        frequencyData: Uint8Array,
-        currentTime: number,
-      ) => {
-        const x = Math.trunc(currentTime / timeResolution);
-        canvasRenderer.drawSpectrogramFrame(frequencyData, x);
-      };
-      analyserRef.current.getLogarithmicFrequencyData(renderCallback);
-    }
-  }, [color, canvasHeight, heightFactor, timeResolution]);
+    if (!audioBuffer) return;
 
-  const containerWidth = canvasWidth * widthFactor;
-  const containerHeight = canvasHeight * heightPixelRatio;
+    const cached = audioService.spectrogramCache.getEntry(trackId);
+    if (cached) {
+      setEntry(cached);
+      return;
+    }
+
+    let cancelled = false;
+    audioService.spectrogramCache
+      .analyse(trackId, audioBuffer, color)
+      .then(() => {
+        if (!cancelled) {
+          setEntry(audioService.spectrogramCache.getEntry(trackId));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [trackId, audioBuffer, color, audioService]);
+
+  const duration = audioBuffer?.duration ?? 0;
+  const containerWidth = duration * pixelsPerSecond;
+
+  const timeResolution = entry?.data.timeResolution ?? 0.025;
+  const frameDisplayWidth = pixelsPerSecond * timeResolution;
+  const tileDisplayWidth = TILE_WIDTH * frameDisplayWidth;
+  const totalFrames = entry?.data.frequencyFrames.length ?? 0;
+  const tiles = entry?.tiles ?? [];
+
+  // Draw visible tiles on each animation frame
+  useAnimationFrame(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container || tiles.length === 0) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const contentOffset = Math.max(0, -containerRect.left);
+
+    const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
+    const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+
+    const needsResize =
+      canvas.width !== viewportWidth || canvas.height !== height;
+
+    const last = lastDrawnRef.current;
+    if (
+      !needsResize &&
+      contentOffset === last.offset &&
+      pixelsPerSecond === last.pps &&
+      tiles.length === last.tileCount
+    ) {
+      return;
+    }
+    last.offset = contentOffset;
+    last.pps = pixelsPerSecond;
+    last.tileCount = tiles.length;
+
+    if (needsResize) {
+      canvas.width = viewportWidth;
+      canvas.height = height;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayWidth));
+    const lastTile = Math.min(
+      tiles.length - 1,
+      Math.floor((contentOffset + viewportWidth) / tileDisplayWidth),
+    );
+
+    for (let t = firstTile; t <= lastTile; t++) {
+      const tileLeftPx = t * tileDisplayWidth;
+      const drawX = tileLeftPx - contentOffset;
+      const isLastTile = t === tiles.length - 1;
+      const tileFrameCount = isLastTile
+        ? totalFrames - t * TILE_WIDTH
+        : TILE_WIDTH;
+      const drawWidth = tileFrameCount * frameDisplayWidth;
+
+      ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
+    }
+  });
 
   const { opacity } = useTrackVolume(trackId);
 
-  const containerStyles = {
-    opacity,
-    width: containerWidth,
-  };
-
   return (
-    <div className="spectrogram" style={containerStyles}>
-      <canvas
-        ref={canvasRef}
-        className="spectrogram__canvas"
-        width={canvasWidth}
-        height={canvasHeight}
-        style={{
-          width: containerWidth,
-          height: containerHeight,
-        }}
-      />
+    <div
+      ref={containerRef}
+      className="spectrogram"
+      style={{ opacity, width: containerWidth }}
+    >
+      <canvas ref={canvasRef} className="spectrogram__canvas" />
     </div>
   );
 };

--- a/src/components/workstation/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/__tests__/Spectrogram.test.tsx
@@ -1,22 +1,16 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { TrackSignalStore } from '../../../signals/trackSignals';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
 import Spectrogram from '../Spectrogram';
 
-const mockGetLogarithmicFrequencyData = vi.fn().mockResolvedValue({});
-
-vi.mock('../../../services/OfflineAnalyser', () => ({
-  // Must be a regular function (not arrow) to support `new` in Vitest v4
-  default: vi.fn().mockImplementation(function () {
-    return {
-      frequencyBinCount: 2048,
-      timeResolution: 0.025,
-      getLogarithmicFrequencyData: mockGetLogarithmicFrequencyData,
-    };
-  }),
+vi.mock('../../../hooks/useAnimationFrame', () => ({
+  useAnimationFrame: vi.fn(),
 }));
+
+const mockAnalyse = vi.fn().mockResolvedValue(undefined);
+const mockGetEntry = vi.fn().mockReturnValue(undefined);
 
 const { mockRetrieveAudioBuffer } = vi.hoisted(() => ({
   mockRetrieveAudioBuffer: vi.fn(),
@@ -25,6 +19,10 @@ const { mockRetrieveAudioBuffer } = vi.hoisted(() => ({
 vi.mock('../../../hooks/useAudioService', () => ({
   useAudioService: () => ({
     retrieveAudioBuffer: mockRetrieveAudioBuffer,
+    spectrogramCache: {
+      analyse: mockAnalyse,
+      getEntry: mockGetEntry,
+    },
   }),
 }));
 
@@ -38,6 +36,8 @@ const defaultProps = {
 
 beforeEach(() => {
   mockRetrieveAudioBuffer.mockReturnValue(undefined);
+  mockAnalyse.mockClear();
+  mockGetEntry.mockReturnValue(undefined);
   TrackSignalStore.create(TRACK_ID);
 });
 
@@ -79,34 +79,66 @@ it('renders zero opacity at volume 0', () => {
   expect(spectrogram).toHaveStyle({ opacity: '0.00' });
 });
 
-it('creates OfflineAnalyser and calls getLogarithmicFrequencyData when audio buffer exists', async () => {
+it('triggers spectrogramCache.analyse when audio buffer exists and not cached', async () => {
   const audioBuffer = { duration: 5.0 } as AudioBuffer;
   mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
 
   render(<Spectrogram {...defaultProps} />);
 
-  expect(mockGetLogarithmicFrequencyData).toHaveBeenCalledWith(
-    expect.any(Function),
-  );
+  await waitFor(() => {
+    expect(mockAnalyse).toHaveBeenCalledWith(
+      TRACK_ID,
+      audioBuffer,
+      defaultProps.track.color,
+    );
+  });
 });
 
-it('does not call getLogarithmicFrequencyData when no audio buffer', () => {
-  mockRetrieveAudioBuffer.mockReturnValue(undefined);
-  mockGetLogarithmicFrequencyData.mockClear();
+it('uses cached entry without re-analysis', () => {
+  const audioBuffer = { duration: 5.0 } as AudioBuffer;
+  mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
+  const cachedEntry = {
+    data: {
+      frequencyFrames: [],
+      timeResolution: 0.025,
+      frequencyBinCount: 2048,
+      sampleRate: 44100,
+      duration: 5.0,
+    },
+    tiles: [],
+  };
+  mockGetEntry.mockReturnValue(cachedEntry);
 
   render(<Spectrogram {...defaultProps} />);
 
-  expect(mockGetLogarithmicFrequencyData).not.toHaveBeenCalled();
+  expect(mockAnalyse).not.toHaveBeenCalled();
 });
 
-it('computes canvas dimensions from duration and time resolution', () => {
-  const duration = 2.0;
+it('does not trigger analysis without audio buffer', () => {
+  mockRetrieveAudioBuffer.mockReturnValue(undefined);
+
+  render(<Spectrogram {...defaultProps} />);
+
+  expect(mockAnalyse).not.toHaveBeenCalled();
+});
+
+it('sets container width from duration and pixelsPerSecond', () => {
+  const duration = 2.5;
   const audioBuffer = { duration } as AudioBuffer;
   mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
 
   const { container } = render(<Spectrogram {...defaultProps} />);
 
-  const canvas = container.querySelector('canvas');
-  // canvasWidth = Math.trunc(duration / timeResolution) = Math.trunc(2.0 / 0.025) = 80
-  expect(canvas?.getAttribute('width')).toBe('80');
+  const spectrogram = container.querySelector('.spectrogram');
+  // containerWidth = duration * pixelsPerSecond = 2.5 * 200 = 500
+  expect(spectrogram).toHaveStyle({ width: '500px' });
+});
+
+it('sets container width to zero when no audio buffer', () => {
+  mockRetrieveAudioBuffer.mockReturnValue(undefined);
+
+  const { container } = render(<Spectrogram {...defaultProps} />);
+
+  const spectrogram = container.querySelector('.spectrogram');
+  expect(spectrogram).toHaveStyle({ width: '0px' });
 });

--- a/src/hooks/__tests__/useAnimationFrame.test.ts
+++ b/src/hooks/__tests__/useAnimationFrame.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useAnimationFrame } from '../useAnimationFrame';
+
+it('schedules a requestAnimationFrame on mount', () => {
+  const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+  renderHook(() => useAnimationFrame(vi.fn()));
+
+  expect(rafSpy).toHaveBeenCalledTimes(1);
+  rafSpy.mockRestore();
+});
+
+it('cancels animation frame on unmount', () => {
+  const rafId = 42;
+  vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(rafId);
+  const cafSpy = vi.spyOn(window, 'cancelAnimationFrame');
+
+  const { unmount } = renderHook(() => useAnimationFrame(vi.fn()));
+  unmount();
+
+  expect(cafSpy).toHaveBeenCalledWith(rafId);
+  vi.restoreAllMocks();
+});
+
+it('calls the callback on each animation frame', () => {
+  let latestRafCallback: FrameRequestCallback | undefined;
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    latestRafCallback = cb;
+    return 1;
+  });
+  const callback = vi.fn();
+
+  renderHook(() => useAnimationFrame(callback));
+  latestRafCallback?.(0);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  vi.restoreAllMocks();
+});
+
+it('uses the latest callback after re-render', () => {
+  let latestRafCallback: FrameRequestCallback | undefined;
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    latestRafCallback = cb;
+    return 1;
+  });
+  const callback1 = vi.fn();
+  const callback2 = vi.fn();
+
+  const { rerender } = renderHook(({ cb }) => useAnimationFrame(cb), {
+    initialProps: { cb: callback1 },
+  });
+
+  // First frame calls callback1
+  latestRafCallback?.(0);
+  expect(callback1).toHaveBeenCalledTimes(1);
+
+  // Re-render with a new callback
+  rerender({ cb: callback2 });
+
+  // Next frame calls callback2
+  latestRafCallback?.(16);
+  expect(callback2).toHaveBeenCalledTimes(1);
+
+  vi.restoreAllMocks();
+});
+
+it('schedules the next frame after each callback', () => {
+  const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+
+  renderHook(() => useAnimationFrame(vi.fn()));
+  expect(rafSpy).toHaveBeenCalledTimes(1);
+
+  // Manually trigger the RAF callback to simulate a frame
+  const loopFn = rafSpy.mock.calls[0][0];
+  loopFn(0);
+
+  // After executing, it should schedule the next frame
+  expect(rafSpy).toHaveBeenCalledTimes(2);
+  vi.restoreAllMocks();
+});

--- a/src/hooks/useAnimationFrame.ts
+++ b/src/hooks/useAnimationFrame.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Runs a callback on every requestAnimationFrame tick.
+ * The ref pattern ensures the latest callback is always called
+ * without restarting the RAF loop on re-renders.
+ */
+export function useAnimationFrame(callback: () => void): void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    let rafId: number;
+    const loop = () => {
+      callbackRef.current();
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+}


### PR DESCRIPTION
Replace the monolithic full-width canvas with a viewport-sized canvas that
draws pre-computed tiles from SpectrogramCache. The canvas uses position:sticky
to stay in the viewport while a requestAnimationFrame loop determines which
tiles intersect the visible region and draws them with zoom-scaled drawImage.

- Add useAnimationFrame hook with ref-based callback pattern and auto-cleanup
- Rewrite Spectrogram.tsx to use SpectrogramCache for tile data
- Update Spectrogram.css to use sticky positioning for the canvas
- Rewrite tests for the new tile-based architecture

https://claude.ai/code/session_012JCbNwxVGrYXfE8F5iT1Gb