### PR TITLE
Fix timeline scroll bugs caused by recording cursor position

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -35,6 +35,7 @@ type AudioSource = {
   blobUrl: string;
   normalizationGainDb: number;
   initialVolume: number;
+  startTime: number;
 };
 
 class AudioService {
@@ -108,6 +109,7 @@ class AudioService {
       blobUrl,
       normalizationGainDb,
       initialVolume,
+      startTime: 0,
     });
     return { trackId, initialVolume };
   }
@@ -168,7 +170,7 @@ class AudioService {
   getTotalTime(): number {
     return this.audioSourceRepository
       .getAll()
-      .map((source) => source.audioBuffer.duration)
+      .map((source) => source.startTime + source.audioBuffer.duration)
       .reduce((prev, curr) => (prev >= curr ? prev : curr), 0);
   }
 
@@ -196,15 +198,19 @@ class AudioService {
     // the one about to be created for this recording — start from their
     // scheduled positions on the next Transport.start().
     this.transport.stop();
-    const blob = await this.recorder.stop();
-    this.microphone.close();
 
     const startTime = this.recordingStartTime ?? 0;
     this.recordingStartTime = null;
 
-    // Position transport at the recording start so playback begins from
-    // the start of the recorded content.
+    // Position transport at the recording start immediately after stop,
+    // before any async operations. The Scrubber's animate loop reads
+    // transport.seconds on every frame — without this, it would briefly
+    // see seconds=0 (the post-stop default) and jump the scroll position
+    // to the beginning during the async gap.
     this.transport.seconds = startTime;
+
+    const blob = await this.recorder.stop();
+    this.microphone.close();
 
     const arrayBuffer = await blob.arrayBuffer();
     const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
@@ -285,6 +291,7 @@ class AudioService {
       blobUrl,
       normalizationGainDb,
       initialVolume,
+      startTime,
     });
     return { trackId, initialVolume };
   }

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -465,9 +465,11 @@ describe('overdub recording', () => {
     Object.assign(recorderInstance, { state: 'started' });
 
     // Simulate real transport.stop() resetting seconds to 0
-    vi.mocked(Tone.getTransport().stop).mockImplementation(() => {
-      Tone.getTransport().seconds = 0;
-    });
+    const transport = Tone.getTransport();
+    vi.mocked(transport.stop).mockImplementation((() => {
+      transport.seconds = 0;
+      return transport;
+    }) as typeof transport.stop);
 
     // Capture transport.seconds at the moment recorder.stop() is called.
     // In the Scrubber animate loop, this is the value that would be read

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -238,6 +238,31 @@ describe('getTotalTime', () => {
 
     expect(audioService.getTotalTime()).toBe(10.0);
   });
+
+  it('accounts for recording start offset in total time', async () => {
+    // Upload a 10s track starting at transport position 0
+    vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+      mockAudioBuffer({ duration: 10.0 }),
+    );
+    await audioService.createTrack(new ArrayBuffer(16));
+
+    // Start recording at transport position 8
+    Tone.getTransport().seconds = 8.0;
+    await audioService.startOverdubRecording();
+
+    const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
+    Object.assign(recorderInstance, { state: 'started' });
+
+    // Recording produces a 5s buffer (transport 8–13)
+    vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+      mockAudioBuffer({ duration: 5.0 }),
+    );
+
+    await audioService.stopOverdubRecording();
+
+    // Total time should be 13 (startTime 8 + duration 5), not 10
+    expect(audioService.getTotalTime()).toBe(13.0);
+  });
 });
 
 describe('recording', () => {
@@ -420,6 +445,7 @@ describe('overdub recording', () => {
       mockAudioBuffer({ duration: 5.0 }),
     );
 
+    Tone.getTransport().seconds = 0;
     await audioService.startOverdubRecording();
 
     const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
@@ -428,6 +454,38 @@ describe('overdub recording', () => {
     await audioService.stopOverdubRecording();
 
     expect(audioService.getTotalTime()).toBe(5.0);
+  });
+
+  it('restores transport position before async processing begins', async () => {
+    // Recording starts at transport position 5
+    Tone.getTransport().seconds = 5.0;
+    await audioService.startOverdubRecording();
+
+    const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
+    Object.assign(recorderInstance, { state: 'started' });
+
+    // Simulate real transport.stop() resetting seconds to 0
+    vi.mocked(Tone.getTransport().stop).mockImplementation(() => {
+      Tone.getTransport().seconds = 0;
+    });
+
+    // Capture transport.seconds at the moment recorder.stop() is called.
+    // In the Scrubber animate loop, this is the value that would be read
+    // between transport.stop() and the async processing completing.
+    let secondsAtRecorderStop: number | undefined;
+    recorderInstance.stop.mockImplementation(() => {
+      secondsAtRecorderStop = Tone.getTransport().seconds;
+      return Promise.resolve({
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+      });
+    });
+
+    await audioService.stopOverdubRecording();
+
+    // Transport should already be repositioned to the recording start time
+    // before the first async operation, preventing the Scrubber animate loop
+    // from briefly reading seconds=0 and jumping the scroll to the beginning.
+    expect(secondsAtRecorderStop).toBe(5.0);
   });
 });
 


### PR DESCRIPTION
Two bugs in stopOverdubRecording affected timeline scrolling after recording:

1. Transport position race: transport.stop() resets seconds to 0, but
   transport.seconds = startTime was set only after several async operations
   (recorder.stop, blob.arrayBuffer, decodeAudioData). During those async
   gaps, the Scrubber animate loop reads seconds=0 and jumps the scroll to
   the beginning, causing erratic scroll behavior.

2. getTotalTime() ignored recording start offset: it returned
   max(audioBuffer.duration) instead of max(startTime + duration). For a
   recording starting at 8s lasting 5s, it returned 5 instead of 13,
   causing the end-of-scroll detection to fire too early and the timeline
   to appear shorter than the actual audio content.

Fixes:
- Move transport.seconds = startTime immediately after transport.stop(),
  before any async operations
- Store startTime in AudioSourceRepository and account for it in
  getTotalTime()

https://claude.ai/code/session_0193yugYkiBBDBXVsizq2ixR