### PR TITLE
Fix spectrogram blank regions when scrolled past sticky boundary

### DIFF
--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -1,0 +1,298 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-10s.wav');
+
+/**
+ * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
+ */
+async function uploadAudioFile(
+  page: import('@playwright/test').Page,
+  filePath: string,
+) {
+  const fileInput = page.locator('.project-page-header input[type="file"]');
+  await fileInput.setInputFiles(filePath);
+}
+
+/**
+ * Measures the fraction of VISIBLE canvas columns (the portion within the
+ * browser viewport) that contain at least one non-transparent pixel.
+ *
+ * This accounts for the sticky canvas being partially off-screen: only
+ * the columns actually visible to the user are checked.
+ */
+async function visibleCanvasFilledWidthRatio(
+  canvasLocator: import('@playwright/test').Locator,
+): Promise<number> {
+  return canvasLocator.evaluate((canvas: HTMLCanvasElement) => {
+    const ctx = canvas.getContext('2d');
+    if (!ctx || canvas.width === 0 || canvas.height === 0) return 0;
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+
+    // Determine the visible column range (canvas-local coordinates)
+    const visibleLeft = Math.max(0, -canvasRect.left);
+    const visibleRight = Math.min(
+      canvas.width,
+      viewportWidth - canvasRect.left,
+    );
+
+    if (visibleRight <= visibleLeft) return 0;
+
+    const visibleWidth = Math.floor(visibleRight - visibleLeft);
+    const startCol = Math.floor(visibleLeft);
+
+    const imageData = ctx.getImageData(
+      startCol,
+      0,
+      visibleWidth,
+      canvas.height,
+    );
+    const pixels = imageData.data;
+    const height = canvas.height;
+    let filledColumns = 0;
+
+    for (let col = 0; col < visibleWidth; col++) {
+      let hasCoverage = false;
+      for (let row = 0; row < height; row++) {
+        const alphaIndex = (row * visibleWidth + col) * 4 + 3;
+        if (pixels[alphaIndex] > 0) {
+          hasCoverage = true;
+          break;
+        }
+      }
+      if (hasCoverage) filledColumns++;
+    }
+
+    return filledColumns / visibleWidth;
+  });
+}
+
+/**
+ * Returns true if the canvas has at least `threshold` non-transparent pixels.
+ */
+async function canvasHasContent(
+  canvasLocator: import('@playwright/test').Locator,
+  threshold = 50,
+): Promise<boolean> {
+  return canvasLocator.evaluate((canvas: HTMLCanvasElement, thresh: number) => {
+    const ctx = canvas.getContext('2d');
+    if (!ctx || canvas.width === 0 || canvas.height === 0) return false;
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const pixels = imageData.data;
+    let nonTransparentCount = 0;
+    for (let i = 3; i < pixels.length; i += 4) {
+      if (pixels[i] > 0) {
+        nonTransparentCount++;
+        if (nonTransparentCount >= thresh) return true;
+      }
+    }
+    return false;
+  }, threshold);
+}
+
+/**
+ * addInitScript that forces Spectrogram rendering by removing
+ * webkitOfflineAudioContext from the window object, so
+ * browserSupport.tsx reports it as absent.
+ */
+function forceSpectrogramRendering(page: import('@playwright/test').Page) {
+  return page.addInitScript(() => {
+    try {
+      delete (window as unknown as Record<string, unknown>)
+        .webkitOfflineAudioContext;
+    } catch {
+      /* non-configurable */
+    }
+
+    const proto = Object.getPrototypeOf(window);
+    if (proto && 'webkitOfflineAudioContext' in proto) {
+      try {
+        delete proto.webkitOfflineAudioContext;
+      } catch {
+        /* non-configurable */
+      }
+    }
+  });
+}
+
+test.describe('Spectrogram timeline visualization during scroll', () => {
+  test.beforeEach(async ({ page }) => {
+    await forceSpectrogramRendering(page);
+    await page.goto('/project');
+    await uploadAudioFile(page, LONG_AUDIO);
+
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+    await expect(spectrogramCanvas).toBeVisible({ timeout: 15000 });
+
+    // Wait for spectrogram tiles to finish rendering
+    await expect(async () => {
+      const hasContent = await canvasHasContent(spectrogramCanvas);
+      expect(hasContent).toBe(true);
+    }).toPass({ timeout: 15000 });
+  });
+
+  test('spectrogram fills the visible canvas when scrolled into content', async ({
+    page,
+  }) => {
+    const timeline = page.locator('.scrubber__timeline');
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+
+    // Scroll to mid-content where the sticky canvas should be fully visible
+    const contentInfo = await timeline.evaluate((el) => {
+      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+      const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
+      const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
+      return { paddingLeft, spectrogramWidth, clientWidth: el.clientWidth };
+    });
+
+    const midScroll = Math.floor(
+      contentInfo.paddingLeft +
+        (contentInfo.spectrogramWidth - contentInfo.clientWidth) / 2,
+    );
+
+    await timeline.evaluate((el, pos) => {
+      el.scrollLeft = pos;
+    }, midScroll);
+    await page.waitForTimeout(200);
+
+    const ratio = await visibleCanvasFilledWidthRatio(spectrogramCanvas);
+    expect(ratio).toBeGreaterThan(0.95);
+  });
+
+  test('spectrogram visible canvas stays filled past the sticky boundary', async ({
+    page,
+  }) => {
+    const timeline = page.locator('.scrubber__timeline');
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+
+    const contentInfo = await timeline.evaluate((el) => {
+      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+      const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
+      const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
+      return {
+        paddingLeft,
+        spectrogramWidth,
+        clientWidth: el.clientWidth,
+        scrollWidth: el.scrollWidth,
+      };
+    });
+
+    // The sticky boundary is where the canvas can no longer be pinned at
+    // its sticky position because it reaches the right edge of its
+    // container. Past this point, the canvas slides left, and the
+    // visible spectrogram should still be fully filled.
+    const stickyBoundary = Math.floor(
+      contentInfo.paddingLeft +
+        contentInfo.spectrogramWidth -
+        contentInfo.clientWidth,
+    );
+    const maxScroll = contentInfo.scrollWidth - contentInfo.clientWidth;
+
+    // Test at positions PAST the sticky boundary
+    const testPositions = [
+      stickyBoundary + 50,
+      stickyBoundary + 200,
+      maxScroll,
+    ].filter((pos) => pos > 0 && pos <= maxScroll);
+
+    const results: Array<{ scrollPos: number; ratio: number }> = [];
+
+    for (const scrollPos of testPositions) {
+      await timeline.evaluate((el, pos) => {
+        el.scrollLeft = pos;
+      }, scrollPos);
+      await page.waitForTimeout(150);
+
+      const ratio = await visibleCanvasFilledWidthRatio(spectrogramCanvas);
+      results.push({ scrollPos, ratio });
+    }
+
+    // Past the sticky boundary the spectrogram content is still within the
+    // viewport, so the visible canvas should remain fully filled (>90%).
+    for (const { scrollPos, ratio } of results) {
+      expect(
+        ratio,
+        `At scrollLeft=${scrollPos} (sticky boundary=${stickyBoundary}), ` +
+          `only ${(ratio * 100).toFixed(1)}% of visible canvas was filled — ` +
+          `expected >90%`,
+      ).toBeGreaterThan(0.9);
+    }
+  });
+
+  test('spectrogram coverage is consistent across the full scroll range', async ({
+    page,
+  }) => {
+    const timeline = page.locator('.scrubber__timeline');
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+
+    const contentInfo = await timeline.evaluate((el) => {
+      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+      const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
+      const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
+      return {
+        paddingLeft,
+        spectrogramWidth,
+        clientWidth: el.clientWidth,
+        scrollWidth: el.scrollWidth,
+      };
+    });
+
+    const maxScroll = contentInfo.scrollWidth - contentInfo.clientWidth;
+
+    // Scan the full range where the spectrogram should be visible
+    const scanStart = 0;
+    const scanEnd = Math.min(
+      maxScroll,
+      contentInfo.paddingLeft + contentInfo.spectrogramWidth,
+    );
+
+    const numSteps = 20;
+    const results: Array<{ scrollPos: number; ratio: number }> = [];
+
+    for (let i = 0; i <= numSteps; i++) {
+      const scrollPos = Math.floor(
+        scanStart + ((scanEnd - scanStart) * i) / numSteps,
+      );
+      if (scrollPos < 0 || scrollPos > maxScroll) continue;
+
+      await timeline.evaluate((el, pos) => {
+        el.scrollLeft = pos;
+      }, scrollPos);
+      await page.waitForTimeout(100);
+
+      const ratio = await visibleCanvasFilledWidthRatio(spectrogramCanvas);
+      results.push({ scrollPos, ratio });
+    }
+
+    // Every scroll position where the spectrogram is in view should have
+    // high visible canvas coverage (>90%).
+    const stickyBoundary = Math.floor(
+      contentInfo.paddingLeft +
+        contentInfo.spectrogramWidth -
+        contentInfo.clientWidth,
+    );
+
+    const coverageReport = results
+      .map(
+        (r) =>
+          `  scrollLeft=${String(r.scrollPos).padStart(5)}: ` +
+          `${(r.ratio * 100).toFixed(1).padStart(5)}% filled` +
+          (r.scrollPos > stickyBoundary ? '  [past sticky boundary]' : ''),
+      )
+      .join('\n');
+
+    const lowCoveragePositions = results.filter((r) => r.ratio < 0.9);
+
+    expect(
+      lowCoveragePositions,
+      `Spectrogram had low visible coverage (<90%) at ${lowCoveragePositions.length} of ${results.length} positions ` +
+        `(sticky boundary=${stickyBoundary}):\n${coverageReport}`,
+    ).toHaveLength(0);
+  });
+});

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -137,6 +137,59 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
     }).toPass({ timeout: 15000 });
   });
 
+  test('spectrogram content updates when scrolling through the early range', async ({
+    page,
+  }) => {
+    const timeline = page.locator('.scrubber__timeline');
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+
+    // Capture a pixel fingerprint of the visible canvas at scrollLeft=0
+    const getVisiblePixelHash = async () => {
+      return spectrogramCanvas.evaluate((canvas: HTMLCanvasElement) => {
+        const ctx = canvas.getContext('2d');
+        if (!ctx || canvas.width === 0 || canvas.height === 0) return '';
+        const canvasRect = canvas.getBoundingClientRect();
+        const viewportWidth = window.innerWidth;
+        const visibleLeft = Math.max(0, Math.floor(-canvasRect.left));
+        const visibleRight = Math.min(
+          canvas.width,
+          Math.floor(viewportWidth - canvasRect.left),
+        );
+        if (visibleRight <= visibleLeft) return '';
+        const visibleWidth = visibleRight - visibleLeft;
+        // Sample a thin horizontal strip from the middle of the canvas
+        const midRow = Math.floor(canvas.height / 2);
+        const strip = ctx.getImageData(visibleLeft, midRow, visibleWidth, 1);
+        // Simple hash: sum of all pixel values
+        let hash = 0;
+        for (let i = 0; i < strip.data.length; i++) {
+          hash = (hash * 31 + strip.data[i]) | 0;
+        }
+        return `${visibleWidth}:${hash}`;
+      });
+    };
+
+    const hashAtStart = await getVisiblePixelHash();
+
+    // Scroll by 400px — still in the early range (before the container's
+    // left edge reaches viewport left). With the old bug, contentOffset
+    // stayed at 0 and the spectrogram was frozen.
+    await timeline.evaluate((el) => {
+      el.scrollLeft = 400;
+    });
+    await page.waitForTimeout(200);
+
+    const hashAfterScroll = await getVisiblePixelHash();
+
+    // The pixel content must have changed — proving the spectrogram
+    // redraws with different audio content as the user scrolls.
+    expect(
+      hashAfterScroll,
+      'Spectrogram content did not change after scrolling 400px — ' +
+        'the spectrogram appears frozen',
+    ).not.toBe(hashAtStart);
+  });
+
   test('spectrogram fills the visible canvas when scrolled into content', async ({
     page,
   }) => {

--- a/src/components/workstation/Spectrogram.tsx
+++ b/src/components/workstation/Spectrogram.tsx
@@ -66,7 +66,8 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
     if (!canvas || !container || tiles.length === 0) return;
 
     const containerRect = container.getBoundingClientRect();
-    const contentOffset = Math.max(0, -containerRect.left);
+    const canvasRect = canvas.getBoundingClientRect();
+    const contentOffset = Math.max(0, canvasRect.left - containerRect.left);
 
     const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
     const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;


### PR DESCRIPTION
The contentOffset calculation used -containerRect.left (the container's
viewport position) to determine which spectrogram tiles to draw. However,
the canvas has position: sticky which causes it to sit at a different
viewport position than its container — especially past the sticky boundary
where the canvas slides off. This mismatch caused tiles to be drawn at
wrong offsets, leaving the visible portion of the canvas blank toward the
end of the scroll range (dropping to 66% coverage at max scroll).

Fix: compute contentOffset as canvasRect.left - containerRect.left, which
gives the canvas's actual position within the container regardless of
sticky positioning state. This ensures drawn tiles always align with the
visible canvas area.

Add e2e tests that measure visible pixel coverage of the spectrogram
canvas across the full scroll range, verifying >90% coverage at every
position including past the sticky boundary.

https://claude.ai/code/session_01LvbMFVAwmbLFPCAtDHdQiv