### PR TITLE
Fix mobile canvas positioning: move padding from scroll container to timeline

### DIFF
--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -141,16 +141,17 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
   test('canvas sticks at the viewport edge, not the content edge', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__timeline');
+    const scrollContainer = page.locator('.scrubber__timeline');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
-    const paddingLeft = await timeline.evaluate((el) =>
-      parseFloat(getComputedStyle(el).paddingLeft),
-    );
+    const paddingLeft = await scrollContainer.evaluate((el) => {
+      const tl = el.querySelector('.timeline') as HTMLElement;
+      return parseFloat(getComputedStyle(tl).paddingLeft);
+    });
 
     // Scroll well past the padding so sticky positioning is active
     const scrollPos = Math.floor(paddingLeft + 300);
-    await timeline.evaluate((el, pos) => {
+    await scrollContainer.evaluate((el, pos) => {
       el.scrollLeft = pos;
     }, scrollPos);
     await page.waitForTimeout(200);
@@ -191,15 +192,16 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram content updates when scrolling into content range', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__timeline');
+    const scrollContainer = page.locator('.scrubber__timeline');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
     // Compute the scroll position where the spectrogram container's left
     // edge aligns with the scroll parent's left edge. Beyond this point,
     // contentOffset increases and the canvas draws different audio content.
-    const paddingLeft = await timeline.evaluate((el) =>
-      parseFloat(getComputedStyle(el).paddingLeft),
-    );
+    const paddingLeft = await scrollContainer.evaluate((el) => {
+      const tl = el.querySelector('.timeline') as HTMLElement;
+      return parseFloat(getComputedStyle(tl).paddingLeft);
+    });
 
     // Hash the full canvas pixel buffer (not just the visible strip),
     // since the canvas is sticky and may be partially off-screen before
@@ -221,7 +223,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
     // Scroll just past the padding so the spectrogram enters the content
     // range where contentOffset starts increasing.
     const scrollA = Math.floor(paddingLeft + 100);
-    await timeline.evaluate((el, pos) => {
+    await scrollContainer.evaluate((el, pos) => {
       el.scrollLeft = pos;
     }, scrollA);
     await page.waitForTimeout(200);
@@ -230,7 +232,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
 
     // Scroll further into the content range
     const scrollB = scrollA + 400;
-    await timeline.evaluate((el, pos) => {
+    await scrollContainer.evaluate((el, pos) => {
       el.scrollLeft = pos;
     }, scrollB);
     await page.waitForTimeout(200);
@@ -250,12 +252,13 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram fills the visible canvas when scrolled into content', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__timeline');
+    const scrollContainer = page.locator('.scrubber__timeline');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
     // Scroll to mid-content where the sticky canvas should be fully visible
-    const contentInfo = await timeline.evaluate((el) => {
-      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+    const contentInfo = await scrollContainer.evaluate((el) => {
+      const tl = el.querySelector('.timeline') as HTMLElement;
+      const paddingLeft = parseFloat(getComputedStyle(tl).paddingLeft);
       const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
       const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
       return { paddingLeft, spectrogramWidth, clientWidth: el.clientWidth };
@@ -266,7 +269,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
         (contentInfo.spectrogramWidth - contentInfo.clientWidth) / 2,
     );
 
-    await timeline.evaluate((el, pos) => {
+    await scrollContainer.evaluate((el, pos) => {
       el.scrollLeft = pos;
     }, midScroll);
     await page.waitForTimeout(200);
@@ -278,11 +281,12 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram visible canvas stays filled past the sticky boundary', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__timeline');
+    const scrollContainer = page.locator('.scrubber__timeline');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
-    const contentInfo = await timeline.evaluate((el) => {
-      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+    const contentInfo = await scrollContainer.evaluate((el) => {
+      const tl = el.querySelector('.timeline') as HTMLElement;
+      const paddingLeft = parseFloat(getComputedStyle(tl).paddingLeft);
       const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
       const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
       return {
@@ -314,7 +318,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
     const results: Array<{ scrollPos: number; ratio: number }> = [];
 
     for (const scrollPos of testPositions) {
-      await timeline.evaluate((el, pos) => {
+      await scrollContainer.evaluate((el, pos) => {
         el.scrollLeft = pos;
       }, scrollPos);
       await page.waitForTimeout(150);
@@ -338,11 +342,12 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram coverage is consistent across the full scroll range', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__timeline');
+    const scrollContainer = page.locator('.scrubber__timeline');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
-    const contentInfo = await timeline.evaluate((el) => {
-      const paddingLeft = parseFloat(getComputedStyle(el).paddingLeft);
+    const contentInfo = await scrollContainer.evaluate((el) => {
+      const tl = el.querySelector('.timeline') as HTMLElement;
+      const paddingLeft = parseFloat(getComputedStyle(tl).paddingLeft);
       const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
       const spectrogramWidth = spectrogram?.offsetWidth ?? 0;
       return {
@@ -371,7 +376,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
       );
       if (scrollPos < 0 || scrollPos > maxScroll) continue;
 
-      await timeline.evaluate((el, pos) => {
+      await scrollContainer.evaluate((el, pos) => {
         el.scrollLeft = pos;
       }, scrollPos);
       await page.waitForTimeout(100);

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -121,6 +121,57 @@ function forceSpectrogramRendering(page: import('@playwright/test').Page) {
   });
 }
 
+test.describe('Spectrogram canvas sticky positioning on mobile', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async ({ page }) => {
+    await forceSpectrogramRendering(page);
+    await page.goto('/project');
+    await uploadAudioFile(page, LONG_AUDIO);
+
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+    await expect(spectrogramCanvas).toBeVisible({ timeout: 15000 });
+
+    await expect(async () => {
+      const hasContent = await canvasHasContent(spectrogramCanvas);
+      expect(hasContent).toBe(true);
+    }).toPass({ timeout: 15000 });
+  });
+
+  test('canvas sticks at the viewport edge, not the content edge', async ({
+    page,
+  }) => {
+    const timeline = page.locator('.scrubber__timeline');
+    const spectrogramCanvas = page.locator('.spectrogram__canvas');
+
+    const paddingLeft = await timeline.evaluate((el) =>
+      parseFloat(getComputedStyle(el).paddingLeft),
+    );
+
+    // Scroll well past the padding so sticky positioning is active
+    const scrollPos = Math.floor(paddingLeft + 300);
+    await timeline.evaluate((el, pos) => {
+      el.scrollLeft = pos;
+    }, scrollPos);
+    await page.waitForTimeout(200);
+
+    const canvasLeft = await spectrogramCanvas.evaluate(
+      (canvas: HTMLCanvasElement) => canvas.getBoundingClientRect().left,
+    );
+
+    // The canvas should be at the viewport edge (left: 0), not offset
+    // by the scroll container's padding-left. On a 390px mobile viewport
+    // with 75% cursor position, the padding is ~292px — if the canvas is
+    // at the padding edge, only ~25% of the viewport shows spectrogram.
+    expect(
+      canvasLeft,
+      `Canvas left edge is at ${canvasLeft}px instead of 0px — ` +
+        `it is stuck at the scroll container content edge (paddingLeft=${paddingLeft}) ` +
+        'instead of the viewport edge',
+    ).toBeCloseTo(0, 0);
+  });
+});
+
 test.describe('Spectrogram timeline visualization during scroll', () => {
   test.beforeEach(async ({ page }) => {
     await forceSpectrogramRendering(page);

--- a/src/components/workstation/Scrubber.css
+++ b/src/components/workstation/Scrubber.css
@@ -13,8 +13,7 @@
 .scrubber__timeline {
   display: flex;
   min-width: 100vw;
-  padding: var(--timeline-margin) 0 var(--timeline-margin)
-    calc(var(--cursor-position) * 100vw);
+  padding: var(--timeline-margin) 0;
   overflow-x: scroll;
 }
 

--- a/src/components/workstation/Spectrogram.css
+++ b/src/components/workstation/Spectrogram.css
@@ -4,6 +4,9 @@
 
 .spectrogram__canvas {
   position: sticky;
-  left: 0;
+  /* Sticky left is relative to the scroll container's content edge (after
+     padding), not the scrollport edge.  Offset by the negative of the scroll
+     container's padding-left so the canvas sticks at the viewport edge. */
+  left: calc(var(--cursor-position) * -100vw);
   display: block;
 }

--- a/src/components/workstation/Spectrogram.css
+++ b/src/components/workstation/Spectrogram.css
@@ -4,9 +4,6 @@
 
 .spectrogram__canvas {
   position: sticky;
-  /* Sticky left is relative to the scroll container's content edge (after
-     padding), not the scrollport edge.  Offset by the negative of the scroll
-     container's padding-left so the canvas sticks at the viewport edge. */
-  left: calc(var(--cursor-position) * -100vw);
+  left: 0;
   display: block;
 }

--- a/src/components/workstation/Spectrogram.tsx
+++ b/src/components/workstation/Spectrogram.tsx
@@ -73,8 +73,9 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
     // in how position:sticky elements report their rect (desktop vs. mobile
     // compositors) and is cheaper than triggering layout queries each frame.
     const scrollLeft = scrollParent?.scrollLeft ?? 0;
-    const paddingLeft = scrollParent
-      ? parseFloat(getComputedStyle(scrollParent).paddingLeft) || 0
+    const timeline = container.closest('.timeline');
+    const paddingLeft = timeline
+      ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
       : 0;
     const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
     const contentOffset = Math.min(

--- a/src/components/workstation/Timeline.css
+++ b/src/components/workstation/Timeline.css
@@ -4,6 +4,7 @@
   grid-template-rows: 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
+  padding-left: calc(var(--cursor-position) * 100vw);
   padding-right: calc((1 - var(--cursor-position)) * 100vw);
 }
 


### PR DESCRIPTION
## Summary

- The spectrogram canvas uses `position: sticky; left: 0` to pin itself at the viewport edge while scrolling. However, `left: 0` for sticky positioning is computed relative to the scroll container's **content edge** (after padding), not the scrollport edge. Since the scroll container (`.scrubber__timeline`) had `padding-left: 75vw` for cursor alignment, the canvas stuck 75% across the screen — showing only ~25% of the viewport on mobile.
- Fix: move `padding-left` from the scroll container to `.timeline` (the content element inside). This makes the scroll container's content edge coincide with its scrollport edge, so `left: 0` correctly pins the canvas at the viewport edge. The `paddingLeft` read in Spectrogram.tsx is updated to query `.timeline` accordingly.
- This also fixes the fragile coupling introduced in #141, where the `scrollLeft - paddingLeft` offset calculation assumed padding lived on the scroll container.

## Test plan

- [x] New e2e test: `canvas sticks at the viewport edge, not the content edge` (390×844 mobile viewport)
- [x] All 4 existing desktop spectrogram e2e tests pass
- [x] All unit tests pass
- [x] ESLint clean

https://claude.ai/code/session_01KRKvizwWaX2vwLR887motw