### PR TITLE
Add frequency analysis capability to audio channels

### DIFF
--- a/src/services/Mixer.ts
+++ b/src/services/Mixer.ts
@@ -2,6 +2,7 @@ import * as Tone from 'tone';
 
 const SMOOTHING = 0.8;
 const POWER_CURVE_EXPONENT = 0.6;
+const FFT_SIZE = 2048;
 
 class Mixer {
   private audioChannelRepository: AudioChannelRepository;
@@ -29,11 +30,20 @@ class Mixer {
     const player = new Tone.Player(audioBuffer)
       .sync()
       .start(startTime, audioOffset);
-    const channel = new Tone.Channel().toDestination();
-    player.chain(channel);
+    const channel = new Tone.Channel();
+    const analyser = new Tone.Analyser({
+      type: 'fft',
+      size: FFT_SIZE,
+      smoothing: 0,
+    });
+    player.chain(channel, analyser, Tone.getDestination());
     this.audioChannelRepository.add(
-      new AudioChannel(trackId, channel, normalizationGainDb),
+      new AudioChannel(trackId, channel, analyser, normalizationGainDb),
     );
+  }
+
+  getFrequencyData(trackId: string): Float32Array | undefined {
+    return this.audioChannelRepository.get(trackId)?.getFrequencyData();
   }
 
   retrieveChannel(trackId: string): AudioChannel | undefined {
@@ -72,16 +82,28 @@ class Mixer {
 export class AudioChannel {
   id: string;
   private channel: Tone.Channel;
+  private analyser: Tone.Analyser;
   private normalizationGainDb: number;
 
-  constructor(id: string, channel: Tone.Channel, normalizationGainDb = 0) {
+  constructor(
+    id: string,
+    channel: Tone.Channel,
+    analyser: Tone.Analyser,
+    normalizationGainDb = 0,
+  ) {
     this.id = id;
     this.channel = channel;
+    this.analyser = analyser;
     this.normalizationGainDb = normalizationGainDb;
+  }
+
+  getFrequencyData(): Float32Array {
+    return this.analyser.getValue() as Float32Array;
   }
 
   dispose(): void {
     this.channel.dispose();
+    this.analyser.dispose();
   }
 
   get mute(): boolean {

--- a/src/services/__tests__/Mixer.test.ts
+++ b/src/services/__tests__/Mixer.test.ts
@@ -73,20 +73,36 @@ describe('createChannel', () => {
     expect(playerInstance.start).toHaveBeenCalledWith(0, 0);
   });
 
-  it('creates a Tone.Channel routed to destination', () => {
+  it('creates a Tone.Channel', () => {
     mixer.createChannel('track-1', {} as AudioBuffer);
 
     expect(Tone.Channel).toHaveBeenCalled();
-    const channelInstance = vi.mocked(Tone.Channel).mock.results[0].value;
-    expect(channelInstance.toDestination).toHaveBeenCalled();
   });
 
-  it('chains the player to the channel', () => {
+  it('creates a Tone.Analyser with FFT type and no smoothing', () => {
+    mixer.createChannel('track-1', {} as AudioBuffer);
+
+    expect(Tone.Analyser).toHaveBeenCalledWith({
+      type: 'fft',
+      size: 2048,
+      smoothing: 0,
+    });
+  });
+
+  it('chains player through channel and analyser to destination', () => {
     mixer.createChannel('track-1', {} as AudioBuffer);
 
     const playerInstance = vi.mocked(Tone.Player).mock.results[0].value;
     const channelInstance = vi.mocked(Tone.Channel).mock.results[0].value;
-    expect(playerInstance.chain).toHaveBeenCalledWith(channelInstance);
+    const analyserInstance = vi.mocked(Tone.Analyser).mock.results[0].value;
+    const destination = vi
+      .mocked(Tone.getDestination)
+      .mock.results.at(-1)!.value;
+    expect(playerInstance.chain).toHaveBeenCalledWith(
+      channelInstance,
+      analyserInstance,
+      destination,
+    );
   });
 
   it('starts player at given transport time and audio offset', () => {
@@ -134,6 +150,21 @@ describe('deleteChannel', () => {
   it('does nothing when deleting unknown track ID', () => {
     // Should not throw
     mixer.deleteChannel('nonexistent');
+  });
+});
+
+describe('getFrequencyData', () => {
+  it('returns frequency data for existing track', () => {
+    mixer.createChannel('track-1', {} as AudioBuffer);
+
+    const data = mixer.getFrequencyData('track-1');
+
+    expect(data).toBeInstanceOf(Float32Array);
+    expect(data!.length).toBe(2048);
+  });
+
+  it('returns undefined for unknown track ID', () => {
+    expect(mixer.getFrequencyData('nonexistent')).toBeUndefined();
   });
 });
 
@@ -191,6 +222,7 @@ describe('getMutedChannels', () => {
 
 describe('AudioChannel', () => {
   let toneChannel: Tone.Channel;
+  let toneAnalyser: Tone.Analyser;
   let audioChannel: AudioChannel;
 
   beforeEach(() => {
@@ -200,7 +232,11 @@ describe('AudioChannel', () => {
       volume: { rampTo: vi.fn() },
       dispose: vi.fn(),
     } as unknown as Tone.Channel;
-    audioChannel = new AudioChannel('ch-1', toneChannel);
+    toneAnalyser = {
+      getValue: vi.fn().mockReturnValue(new Float32Array(2048)),
+      dispose: vi.fn(),
+    } as unknown as Tone.Analyser;
+    audioChannel = new AudioChannel('ch-1', toneChannel, toneAnalyser);
   });
 
   it('exposes the channel id', () => {
@@ -263,7 +299,12 @@ describe('AudioChannel', () => {
   describe('normalization gain', () => {
     it('adds normalization gain to slider dB at full volume', () => {
       const normGainDb = 6;
-      const normalized = new AudioChannel('ch-norm', toneChannel, normGainDb);
+      const normalized = new AudioChannel(
+        'ch-norm',
+        toneChannel,
+        toneAnalyser,
+        normGainDb,
+      );
 
       normalized.volume = 100;
 
@@ -273,7 +314,12 @@ describe('AudioChannel', () => {
 
     it('adds normalization gain to slider dB at mid volume', () => {
       const normGainDb = 12;
-      const normalized = new AudioChannel('ch-norm', toneChannel, normGainDb);
+      const normalized = new AudioChannel(
+        'ch-norm',
+        toneChannel,
+        toneAnalyser,
+        normGainDb,
+      );
 
       normalized.volume = 50;
 
@@ -285,7 +331,7 @@ describe('AudioChannel', () => {
     });
 
     it('defaults normalization gain to 0 when not provided', () => {
-      const channel = new AudioChannel('ch-default', toneChannel);
+      const channel = new AudioChannel('ch-default', toneChannel, toneAnalyser);
 
       channel.volume = 100;
 
@@ -294,10 +340,24 @@ describe('AudioChannel', () => {
     });
   });
 
+  describe('getFrequencyData', () => {
+    it('returns Float32Array from the analyser', () => {
+      const data = audioChannel.getFrequencyData();
+
+      expect(toneAnalyser.getValue).toHaveBeenCalled();
+      expect(data).toBeInstanceOf(Float32Array);
+    });
+  });
+
   describe('dispose', () => {
     it('disposes the underlying Tone.Channel', () => {
       audioChannel.dispose();
       expect(toneChannel.dispose).toHaveBeenCalled();
+    });
+
+    it('disposes the underlying Tone.Analyser', () => {
+      audioChannel.dispose();
+      expect(toneAnalyser.dispose).toHaveBeenCalled();
     });
   });
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -47,7 +47,14 @@ vi.mock('tone', () => {
       sampleRate: 44100,
     },
   };
+  function makeAnalyserNode() {
+    return {
+      ...makeNode(),
+      getValue: vi.fn().mockReturnValue(new Float32Array(2048)),
+    };
+  }
   return {
+    Analyser: vi.fn().mockImplementation(makeAnalyserNode),
     Meter: vi.fn().mockImplementation(makeNode),
     UserMedia: vi.fn().mockImplementation(makeNode),
     Player: vi.fn().mockImplementation(makeNode),


### PR DESCRIPTION
## Summary
This PR adds frequency data analysis to the audio mixer by integrating Tone.js Analyser nodes into the audio signal chain. Each audio channel now captures FFT frequency data that can be retrieved for visualization or analysis purposes.

## Key Changes
- **Analyser Integration**: Added `Tone.Analyser` to each audio channel's signal chain with FFT configuration (2048 size, no smoothing)
- **Signal Chain Update**: Modified player routing from `player → channel → destination` to `player → channel → analyser → destination`
- **Frequency Data API**: 
  - Added `getFrequencyData(trackId)` method to `Mixer` class to retrieve frequency data for a specific track
  - Added `getFrequencyData()` method to `AudioChannel` class to access analyser data
- **AudioChannel Constructor**: Updated to accept `Tone.Analyser` as a required parameter
- **Resource Management**: Added proper disposal of analyser nodes when channels are cleaned up
- **Test Coverage**: Added comprehensive tests for frequency data retrieval and analyser lifecycle management

## Implementation Details
- FFT size is set to 2048 samples for frequency analysis
- Smoothing is disabled (set to 0) to get raw frequency data without averaging
- The analyser is positioned after the channel in the signal chain to capture the final mixed audio
- Frequency data is returned as `Float32Array` matching Tone.js Analyser API

https://claude.ai/code/session_01SxpPYWdEYPT3Tpg3R2Rvjo