### PR TITLE
Add live playback overlay to spectrogram during playback

### DIFF
--- a/src/components/workstation/Spectrogram.tsx
+++ b/src/components/workstation/Spectrogram.tsx
@@ -3,7 +3,8 @@ import { useAnimationFrame } from '../../hooks/useAnimationFrame';
 import { useAudioService } from '../../hooks/useAudioService';
 import { useTrackVolume } from '../../hooks/useTrackVolume';
 import { TrackSpectrogramEntry } from '../../services/SpectrogramCache';
-import { Track } from '../project/projectPageReducer';
+import { isPlaying, transportTime } from '../../signals/transportSignals';
+import { Track, TrackColor } from '../project/projectPageReducer';
 import './Spectrogram.css';
 
 type SpectrogramProps = {
@@ -14,6 +15,12 @@ type SpectrogramProps = {
 
 const TILE_WIDTH = 4096;
 const SCROLL_CONTAINER_CLASS = '.scrubber__timeline';
+const LIVE_COLUMN_WIDTH = 2;
+
+// Match the OfflineAnalyser's AnalyserNode dB range for visual consistency
+const MIN_DB = -80;
+const MAX_DB = -30;
+const DB_RANGE = MAX_DB - MIN_DB;
 
 const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -83,12 +90,16 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
       maxContentOffset,
     );
 
+    const playing = isPlaying.value;
+
     const needsResize =
       canvas.width !== viewportWidth || canvas.height !== height;
 
     const last = lastDrawnRef.current;
+    // Always redraw during playback so the live overlay tracks the playhead
     if (
       !needsResize &&
+      !playing &&
       contentOffset === last.offset &&
       pixelsPerSecond === last.pps &&
       tiles.length === last.tileCount
@@ -125,6 +136,15 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
 
       ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
     }
+
+    // Live playback overlay: draw a bright column at the playhead
+    if (playing) {
+      const frequencyData = audioService.mixer.getFrequencyData(trackId);
+      if (frequencyData) {
+        const playheadX = transportTime.value * pixelsPerSecond - contentOffset;
+        drawLiveColumn(ctx, frequencyData, playheadX, height, color);
+      }
+    }
   });
 
   const { opacity } = useTrackVolume(trackId);
@@ -139,5 +159,56 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
     </div>
   );
 };
+
+/**
+ * Draws a single bright column on the canvas at the playhead position,
+ * reflecting live post-effects frequency content during playback.
+ *
+ * Frequency bins are grouped into pixel rows (max intensity per row)
+ * and rendered with additive compositing so the overlay appears brighter
+ * than the static spectrogram tiles underneath.
+ */
+function drawLiveColumn(
+  ctx: CanvasRenderingContext2D,
+  frequencyData: Float32Array,
+  playheadX: number,
+  height: number,
+  color: TrackColor,
+): void {
+  if (playheadX < -LIVE_COLUMN_WIDTH || playheadX > ctx.canvas.width) return;
+
+  const bins = frequencyData.length;
+  const binsPerRow = bins / height;
+  const { r, g, b } = color;
+  const x = Math.round(playheadX);
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+
+  for (let row = 0; row < height; row++) {
+    const startBin = Math.floor(row * binsPerRow);
+    const endBin = Math.floor((row + 1) * binsPerRow);
+    let maxIntensity = 0;
+    for (let bin = startBin; bin < endBin; bin++) {
+      const intensity = dbToByte(frequencyData[bin]);
+      if (intensity > maxIntensity) maxIntensity = intensity;
+    }
+    if (maxIntensity === 0) continue;
+
+    const alpha = maxIntensity / 255;
+    // bin 0 → bottom row, last bin → top row
+    const y = height - row - 1;
+    ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    ctx.fillRect(x, y, LIVE_COLUMN_WIDTH, 1);
+  }
+
+  ctx.restore();
+}
+
+function dbToByte(db: number): number {
+  if (db <= MIN_DB) return 0;
+  if (db >= MAX_DB) return 255;
+  return Math.round(((db - MIN_DB) / DB_RANGE) * 255);
+}
 
 export default Spectrogram;

--- a/src/components/workstation/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/__tests__/Spectrogram.test.tsx
@@ -1,5 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame';
+import { isPlaying, transportTime } from '../../../signals/transportSignals';
 import { TrackSignalStore } from '../../../signals/trackSignals';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
@@ -11,6 +13,7 @@ vi.mock('../../../hooks/useAnimationFrame', () => ({
 
 const mockAnalyse = vi.fn().mockResolvedValue(undefined);
 const mockGetEntry = vi.fn().mockReturnValue(undefined);
+const mockGetFrequencyData = vi.fn();
 
 const { mockRetrieveAudioBuffer } = vi.hoisted(() => ({
   mockRetrieveAudioBuffer: vi.fn(),
@@ -22,6 +25,9 @@ vi.mock('../../../hooks/useAudioService', () => ({
     spectrogramCache: {
       analyse: mockAnalyse,
       getEntry: mockGetEntry,
+    },
+    mixer: {
+      getFrequencyData: mockGetFrequencyData,
     },
   }),
 }));
@@ -38,6 +44,7 @@ beforeEach(() => {
   mockRetrieveAudioBuffer.mockReturnValue(undefined);
   mockAnalyse.mockClear();
   mockGetEntry.mockReturnValue(undefined);
+  mockGetFrequencyData.mockReset();
   TrackSignalStore.create(TRACK_ID);
 });
 
@@ -147,3 +154,116 @@ it('sets container width to zero when no audio buffer', () => {
 // redraw on scroll change) are covered by the e2e suite in
 // e2e/spectrogram-timeline.spec.ts which verifies actual rendered pixels
 // across the full scroll range, including past the sticky boundary.
+
+describe('live playback overlay', () => {
+  const mockCtx = {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    getImageData: vi.fn(),
+    putImageData: vi.fn(),
+    globalCompositeOperation: 'source-over' as string,
+    fillStyle: '' as string,
+    canvas: { width: 800, height: 128 },
+  };
+
+  const cachedEntry = {
+    data: {
+      frequencyFrames: [new Uint8Array(1024)],
+      timeResolution: 0.025,
+      frequencyBinCount: 1024,
+      sampleRate: 44100,
+      duration: 5.0,
+    },
+    tiles: [{ close: vi.fn() }],
+  };
+
+  beforeEach(() => {
+    const audioBuffer = { duration: 5.0 } as AudioBuffer;
+    mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
+    mockGetEntry.mockReturnValue(cachedEntry);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function invokeAnimationCallback() {
+    // The component renders twice: initial (tiles empty) + re-render
+    // after useEffect sets the cached entry. Get the latest callback
+    // which closes over the populated tiles array.
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+  }
+
+  it('reads live frequency data from mixer during playback', () => {
+    isPlaying.value = true;
+    transportTime.value = 1.0;
+    const fftData = new Float32Array(1024).fill(-50);
+    mockGetFrequencyData.mockReturnValue(fftData);
+
+    render(<Spectrogram {...defaultProps} />);
+    invokeAnimationCallback();
+
+    expect(mockGetFrequencyData).toHaveBeenCalledWith(TRACK_ID);
+  });
+
+  it('does not read frequency data when not playing', () => {
+    isPlaying.value = false;
+
+    render(<Spectrogram {...defaultProps} />);
+    invokeAnimationCallback();
+
+    expect(mockGetFrequencyData).not.toHaveBeenCalled();
+  });
+
+  it('draws overlay column with additive compositing during playback', () => {
+    isPlaying.value = true;
+    transportTime.value = 1.0;
+    const fftData = new Float32Array(1024).fill(-50);
+    mockGetFrequencyData.mockReturnValue(fftData);
+
+    render(<Spectrogram {...defaultProps} />);
+    invokeAnimationCallback();
+
+    expect(mockCtx.save).toHaveBeenCalled();
+    expect(mockCtx.globalCompositeOperation).toBe('lighter');
+    expect(mockCtx.fillRect).toHaveBeenCalled();
+    expect(mockCtx.restore).toHaveBeenCalled();
+  });
+
+  it('skips overlay when mixer returns no frequency data', () => {
+    isPlaying.value = true;
+    transportTime.value = 1.0;
+    mockGetFrequencyData.mockReturnValue(undefined);
+
+    render(<Spectrogram {...defaultProps} />);
+    invokeAnimationCallback();
+
+    expect(mockGetFrequencyData).toHaveBeenCalledWith(TRACK_ID);
+    // save/restore are not called when there is no frequency data
+    expect(mockCtx.save).not.toHaveBeenCalled();
+  });
+
+  it('does not draw overlay column for silent frequency data', () => {
+    isPlaying.value = true;
+    transportTime.value = 1.0;
+    // All bins at or below -80 dB map to intensity 0
+    const silentData = new Float32Array(1024).fill(-100);
+    mockGetFrequencyData.mockReturnValue(silentData);
+
+    render(<Spectrogram {...defaultProps} />);
+    invokeAnimationCallback();
+
+    expect(mockCtx.save).toHaveBeenCalled();
+    // No fillRect calls because all intensities are 0
+    expect(mockCtx.fillRect).not.toHaveBeenCalled();
+    expect(mockCtx.restore).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a real-time visual overlay to the spectrogram that displays live frequency data from the audio mixer during playback. A bright column is drawn at the playhead position, showing the current post-effects frequency content with additive compositing for visual prominence.

## Key Changes
- **Live frequency data integration**: The Spectrogram component now reads live frequency data from the mixer's `getFrequencyData()` method during playback
- **Playhead overlay rendering**: Added `drawLiveColumn()` function that renders a single-pixel-wide column at the playhead position, with frequency bins grouped into pixel rows
- **Additive compositing**: Uses `globalCompositeOperation: 'lighter'` to blend the overlay brightly over the static spectrogram tiles
- **Continuous redraw during playback**: Modified the animation frame logic to always redraw when playing, ensuring the overlay tracks the playhead smoothly
- **dB to intensity conversion**: Implemented `dbToByte()` function to convert frequency data from dB scale (-80 to -30 dB) to visual intensity (0-255), matching the OfflineAnalyser's range for consistency
- **Comprehensive test coverage**: Added 5 new test cases covering playback state detection, frequency data reading, overlay rendering with additive compositing, missing data handling, and silent frequency data scenarios

## Implementation Details
- The live column is only drawn when `isPlaying.value` is true and the mixer returns valid frequency data
- Frequency bins are dynamically grouped based on canvas height to ensure proper vertical resolution
- The overlay respects track color settings for visual consistency
- Silent frequency data (all bins ≤ -80 dB) results in no visible pixels, preventing visual noise
- Playhead position is calculated from `transportTime.value` and adjusted for the current scroll offset

https://claude.ai/code/session_019keQWoRDQySFBdVysv95wf