### PR TITLE
Add Tone.Analyser to MicrophoneUserMedia (visualization step 9)

### DIFF
--- a/src/services/MicrophoneUserMedia.ts
+++ b/src/services/MicrophoneUserMedia.ts
@@ -3,10 +3,14 @@ import * as Tone from 'tone';
 class MicrophoneUserMedia {
   private microphone: Tone.UserMedia;
   private meter: Tone.Meter;
+  private analyser: Tone.Analyser;
 
   constructor() {
     this.meter = new Tone.Meter();
-    this.microphone = new Tone.UserMedia().connect(this.meter);
+    this.analyser = new Tone.Analyser({ type: 'fft', size: 2048 });
+    this.microphone = new Tone.UserMedia()
+      .connect(this.meter)
+      .connect(this.analyser);
   }
 
   get isOpen(): boolean {
@@ -28,6 +32,10 @@ class MicrophoneUserMedia {
   getLoudness(): number {
     const value = this.meter.getValue();
     return typeof value === 'number' ? Math.max(0, value) : 0;
+  }
+
+  getFrequencyData(): Float32Array {
+    return this.analyser.getValue() as Float32Array;
   }
 
   mute(): void {

--- a/src/services/__tests__/MicrophoneUserMedia.test.ts
+++ b/src/services/__tests__/MicrophoneUserMedia.test.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest';
+import * as Tone from 'tone';
+import MicrophoneUserMedia from '../MicrophoneUserMedia';
+
+let mic: MicrophoneUserMedia;
+
+beforeEach(() => {
+  mic = new MicrophoneUserMedia();
+});
+
+describe('constructor', () => {
+  it('creates a Tone.Meter', () => {
+    expect(Tone.Meter).toHaveBeenCalled();
+  });
+
+  it('creates a Tone.Analyser with FFT type and size 2048', () => {
+    expect(Tone.Analyser).toHaveBeenCalledWith({
+      type: 'fft',
+      size: 2048,
+    });
+  });
+
+  it('creates a Tone.UserMedia connected to both meter and analyser', () => {
+    expect(Tone.UserMedia).toHaveBeenCalled();
+
+    const userMediaInstance = vi.mocked(Tone.UserMedia).mock.results[0].value;
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+    const analyserInstance = vi.mocked(Tone.Analyser).mock.results[0].value;
+
+    expect(userMediaInstance.connect).toHaveBeenCalledWith(meterInstance);
+    expect(userMediaInstance.connect).toHaveBeenCalledWith(analyserInstance);
+  });
+});
+
+describe('getFrequencyData', () => {
+  it('returns a Float32Array from the analyser', () => {
+    const data = mic.getFrequencyData();
+
+    expect(data).toBeInstanceOf(Float32Array);
+  });
+
+  it('delegates to analyser.getValue()', () => {
+    const analyserInstance = vi.mocked(Tone.Analyser).mock.results[0].value;
+    const expectedData = new Float32Array([1, 2, 3]);
+    analyserInstance.getValue.mockReturnValue(expectedData);
+
+    const data = mic.getFrequencyData();
+
+    expect(data).toBe(expectedData);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `Tone.Analyser` (FFT, size 2048) to the microphone signal path in `MicrophoneUserMedia`, fan-out connected alongside the existing `Tone.Meter`
- Expose `getFrequencyData()` method returning real-time `Float32Array` frequency data from the analyser
- Add unit tests for the new analyser construction and `getFrequencyData()` method

This is preparatory infrastructure for step 10 (recording spectrogram), which will read live frequency data from the microphone input to paint a growing spectrogram during recording.

## Test plan
- [x] New `MicrophoneUserMedia.test.ts` tests pass (5 tests)
- [x] Full test suite passes (347 tests across 34 files)
- [x] App visually unchanged — analyser exists but nothing reads from it yet

https://claude.ai/code/session_01HLbY6MBqdUJ17oC2oqGJLZ