### PR TITLE
Add live recording spectrogram visualization

### DIFF
--- a/src/components/project/ProjectPage.tsx
+++ b/src/components/project/ProjectPage.tsx
@@ -7,6 +7,7 @@ import {
   useTrackSideEffects,
   useUploadFile,
 } from './projectPageEffects';
+import { COLOR_PALETTE } from './projectPageReducer';
 import ProjectPageHeader from './ProjectPageHeader';
 import { ProjectDispatch } from './useProjectDispatch';
 import useProjectReducer from './useProjectReducer';
@@ -17,6 +18,8 @@ const ProjectPage = () => {
   const uploadFile = useUploadFile(dispatch);
   const [fullScreenHandle, toggleFullscreen] = useFullscreen();
   useTrackSideEffects(state.tracks);
+
+  const recordingColor = COLOR_PALETTE[state.nextColorId];
 
   return (
     <ProjectDispatch.Provider value={dispatch}>
@@ -35,7 +38,11 @@ const ProjectPage = () => {
             />
           </PageHeader>
           <PageContent>
-            <Workstation tracks={state.tracks} uploadFile={uploadFile} />
+            <Workstation
+              recordingColor={recordingColor}
+              tracks={state.tracks}
+              uploadFile={uploadFile}
+            />
           </PageContent>
         </PageLayout>
       </Fullscreen>

--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -2,42 +2,71 @@ import { useSignals } from '@preact/signals-react/runtime';
 import classNames from 'classnames';
 import { useContainerHeight } from '../../hooks/useContainerHeight';
 import { focusedTracks as focusedTracksSignal } from '../../signals/focusSignals';
+import { isRecording as isRecordingSignal } from '../../signals/transportSignals';
 import { mutedTracks as mutedTracksSignal } from '../../signals/trackSignals';
-import { type Track, type TrackId } from '../../types/track';
+import { type Track, type TrackColor, type TrackId } from '../../types/track';
 import Spectrogram from './spectrogram/Spectrogram';
 import './Timeline.css';
 
+const RECORDING_TRACK_ID = '__recording__';
+
 type TimelineProps = {
   pixelsPerSecond: number;
+  recordingColor: TrackColor;
   tracks: Track[];
 };
 
-const Timeline = ({ pixelsPerSecond, tracks }: TimelineProps) => {
+const Timeline = ({
+  pixelsPerSecond,
+  recordingColor,
+  tracks,
+}: TimelineProps) => {
   useSignals();
   const { containerRef, height } = useContainerHeight();
 
   const focusedTracks = focusedTracksSignal.value;
   const mutedTracks = mutedTracksSignal.value;
+  const isRecording = isRecordingSignal.value;
+
+  const recordingTrack: Track = {
+    trackId: RECORDING_TRACK_ID,
+    color: recordingColor,
+    fileName: 'Recording',
+    index: tracks.length,
+  };
 
   return (
     <div ref={containerRef} className="timeline">
-      {height > 0 &&
-        tracks.map((track) => {
-          const timelineTrackClass = getTimelineTrackClass(
-            track,
-            mutedTracks,
-            focusedTracks,
-          );
-          return (
-            <div key={track.trackId} className={timelineTrackClass}>
+      {height > 0 && (
+        <>
+          {tracks.map((track) => {
+            const timelineTrackClass = getTimelineTrackClass(
+              track,
+              mutedTracks,
+              focusedTracks,
+            );
+            return (
+              <div key={track.trackId} className={timelineTrackClass}>
+                <Spectrogram
+                  height={height}
+                  pixelsPerSecond={pixelsPerSecond}
+                  track={track}
+                />
+              </div>
+            );
+          })}
+          {isRecording && (
+            <div className="timeline__track">
               <Spectrogram
                 height={height}
                 pixelsPerSecond={pixelsPerSecond}
-                track={track}
+                track={recordingTrack}
+                isRecordingTrack
               />
             </div>
-          );
-        })}
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -3,10 +3,11 @@ import classNames from 'classnames';
 import { useState } from 'react';
 import { useAudioBridge } from '../../hooks/useAudioBridge';
 import { useTransportBridge } from '../../hooks/useTransportBridge';
+import { isRecording as isRecordingSignal } from '../../signals/transportSignals';
 import { pixelsPerSecond as pixelsPerSecondSignal } from '../../signals/workstationSignals';
+import { type Track, type TrackColor } from '../../types/track';
 import Dropzone from '../dropzone/Dropzone';
 import { useFileDropzone } from '../dropzone/useFileDropzone';
-import { type Track } from '../../types/track';
 import EmptyTimeline from './EmptyTimeline';
 import Mixer from './Mixer';
 import Scrubber from './scrubber/Scrubber';
@@ -21,6 +22,7 @@ import {
 } from './workstationEffects';
 
 type WorkstationProps = {
+  recordingColor: TrackColor;
   tracks: Track[];
   uploadFile: (file: File) => void;
 };
@@ -30,7 +32,7 @@ const Workstation = (props: WorkstationProps) => {
   const [isMixerOpen, setIsMixerOpen] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
 
-  const { tracks, uploadFile } = props;
+  const { recordingColor, tracks, uploadFile } = props;
   const hasTracks = tracks.length > 0;
 
   const pixelsPerSecond = pixelsPerSecondSignal.value;
@@ -49,6 +51,11 @@ const Workstation = (props: WorkstationProps) => {
   const toggleMixer = () => setIsMixerOpen((prev) => !prev);
   const toggleRecording = () => setIsRecording((prev) => !prev);
 
+  // Show the timeline when tracks exist or when recording is active.
+  // Use the signal (not local state) so the timeline stays visible during
+  // the async stop-recording transition until the new track is added.
+  const showTimeline = hasTracks || isRecording || isRecordingSignal.value;
+
   const editorMixerClass = classNames('editor__mixer', {
     'editor__mixer--closed': !isMixerOpen,
   });
@@ -61,13 +68,17 @@ const Workstation = (props: WorkstationProps) => {
     <div className="workstation">
       <div className="editor" {...rootProps}>
         <div className="editor__timeline">
-          {hasTracks ? (
+          {showTimeline ? (
             <Scrubber
               drawerHeight={mixerHeight}
               isMixerOpen={isMixerOpen}
               pixelsPerSecond={pixelsPerSecond}
             >
-              <Timeline pixelsPerSecond={pixelsPerSecond} tracks={tracks} />
+              <Timeline
+                pixelsPerSecond={pixelsPerSecond}
+                recordingColor={recordingColor}
+                tracks={tracks}
+              />
             </Scrubber>
           ) : (
             <EmptyTimeline isDragActive={isDragActive} />

--- a/src/components/workstation/__tests__/Workstation.test.tsx
+++ b/src/components/workstation/__tests__/Workstation.test.tsx
@@ -46,6 +46,7 @@ vi.mock('../../dropzone/useFileDropzone', () => ({
 }));
 
 const defaultProps = {
+  recordingColor: { r: 77, g: 238, b: 234 },
   tracks: [],
   uploadFile: vi.fn(),
 };

--- a/src/components/workstation/spectrogram/RecordingBuffer.ts
+++ b/src/components/workstation/spectrogram/RecordingBuffer.ts
@@ -1,0 +1,95 @@
+import { createColorMap } from '../../../services/SpectrogramTileRenderer';
+import { type TrackColor } from '../../../types/track';
+import { dbToByte } from './spectrogramRenderer';
+
+const INITIAL_WIDTH = 8192;
+const BYTES_PER_PIXEL = 4;
+
+/**
+ * Accumulates live microphone frequency data during recording into an
+ * OffscreenCanvas buffer. Each call to addFrame() appends a single-pixel
+ * column. The buffer grows automatically when full.
+ *
+ * Frequency bins are drawn bottom-to-top (bin 0 at bottom) to match
+ * the offline tile rendering convention.
+ */
+class RecordingBuffer {
+  frameCount = 0;
+
+  private canvas: OffscreenCanvas;
+  private ctx: OffscreenCanvasRenderingContext2D;
+  private colorMap: Uint8Array;
+  private height: number;
+
+  constructor(color: TrackColor, frequencyBinCount: number) {
+    this.height = frequencyBinCount;
+    this.canvas = new OffscreenCanvas(INITIAL_WIDTH, frequencyBinCount);
+    this.ctx = this.canvas.getContext('2d')!;
+    this.colorMap = createColorMap(color);
+  }
+
+  addFrame(frequencyData: Float32Array): void {
+    if (this.frameCount >= this.canvas.width) {
+      this.grow();
+    }
+
+    const col = this.frameCount;
+    const bins = Math.min(frequencyData.length, this.height);
+    const imageData = this.ctx.createImageData(1, this.height);
+    const pixels = imageData.data;
+
+    for (let bin = 0; bin < bins; bin++) {
+      const byte = dbToByte(frequencyData[bin]);
+      // bin 0 → bottom row, last bin → top row
+      const row = this.height - 1 - bin;
+      const pixelOffset = row * BYTES_PER_PIXEL;
+      const colorOffset = byte * BYTES_PER_PIXEL;
+
+      pixels[pixelOffset] = this.colorMap[colorOffset];
+      pixels[pixelOffset + 1] = this.colorMap[colorOffset + 1];
+      pixels[pixelOffset + 2] = this.colorMap[colorOffset + 2];
+      pixels[pixelOffset + 3] = this.colorMap[colorOffset + 3];
+    }
+
+    this.ctx.putImageData(imageData, col, 0);
+    this.frameCount++;
+  }
+
+  /**
+   * Draws a region of the recording buffer to a destination canvas,
+   * scaling from the buffer's native frequency bin height to the
+   * display height.
+   */
+  drawTo(
+    ctx: CanvasRenderingContext2D,
+    srcX: number,
+    srcWidth: number,
+    destX: number,
+    destWidth: number,
+    destHeight: number,
+  ): void {
+    if (this.frameCount === 0 || srcWidth <= 0) return;
+    ctx.drawImage(
+      this.canvas,
+      srcX,
+      0,
+      srcWidth,
+      this.height,
+      destX,
+      0,
+      destWidth,
+      destHeight,
+    );
+  }
+
+  private grow(): void {
+    const newWidth = this.canvas.width * 2;
+    const newCanvas = new OffscreenCanvas(newWidth, this.height);
+    const newCtx = newCanvas.getContext('2d')!;
+    newCtx.drawImage(this.canvas, 0, 0);
+    this.canvas = newCanvas;
+    this.ctx = newCtx;
+  }
+}
+
+export default RecordingBuffer;

--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -1,9 +1,14 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAnimationFrame } from '../../../hooks/useAnimationFrame';
 import { useAudioService } from '../../../hooks/useAudioService';
 import { useTrackVolume } from '../../../hooks/useTrackVolume';
-import { isPlaying, transportTime } from '../../../signals/transportSignals';
+import {
+  isPlaying,
+  isRecording as isRecordingSignal,
+  transportTime,
+} from '../../../signals/transportSignals';
 import { type Track } from '../../../types/track';
+import RecordingBuffer from './RecordingBuffer';
 import './Spectrogram.css';
 import { drawLiveColumn } from './spectrogramRenderer';
 import { useSpectrogramCache } from './useSpectrogramCache';
@@ -12,25 +17,36 @@ type SpectrogramProps = {
   height: number;
   pixelsPerSecond: number;
   track: Track;
+  isRecordingTrack?: boolean;
 };
 
 const TILE_WIDTH = 4096;
 const SCROLL_CONTAINER_CLASS = '.scrubber__timeline';
 
-const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
+// Frequency bin count from the Tone.Analyser (size: 2048 → 1024 bins)
+const MIC_FREQUENCY_BINS = 1024;
+
+const Spectrogram = ({
+  height,
+  pixelsPerSecond,
+  track,
+  isRecordingTrack = false,
+}: SpectrogramProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const lastDrawnRef = useRef({ offset: -1, pps: -1, tileCount: -1 });
+  const recordingBufferRef = useRef<RecordingBuffer | null>(null);
 
   const { trackId, color } = track;
 
   const audioService = useAudioService();
-  const audioBuffer = audioService.retrieveAudioBuffer(trackId);
+  const audioBuffer = isRecordingTrack
+    ? undefined
+    : audioService.retrieveAudioBuffer(trackId);
 
   const entry = useSpectrogramCache(trackId, audioBuffer, color);
 
   const duration = audioBuffer?.duration ?? 0;
-  const containerWidth = duration * pixelsPerSecond;
 
   const timeResolution = entry?.data.timeResolution ?? 0.025;
   const frameDisplayWidth = pixelsPerSecond * timeResolution;
@@ -38,88 +54,63 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
   const totalFrames = entry?.data.frequencyFrames.length ?? 0;
   const tiles = entry?.tiles ?? [];
 
+  // Create/dispose recording buffer when entering/leaving recording mode
+  useEffect(() => {
+    if (isRecordingTrack) {
+      recordingBufferRef.current = new RecordingBuffer(
+        color,
+        MIC_FREQUENCY_BINS,
+      );
+    }
+    return () => {
+      recordingBufferRef.current = null;
+    };
+  }, [isRecordingTrack, color]);
+
   // Draw visible tiles on each animation frame
   useAnimationFrame(() => {
     const canvas = canvasRef.current;
     const container = containerRef.current;
-    if (!canvas || !container || tiles.length === 0) return;
+    if (!canvas || !container) return;
 
-    const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
-    const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
-
-    // Derive content offset from the scroll parent's scrollLeft property
-    // rather than getBoundingClientRect(). This avoids browser differences
-    // in how position:sticky elements report their rect (desktop vs. mobile
-    // compositors) and is cheaper than triggering layout queries each frame.
-    const scrollLeft = scrollParent?.scrollLeft ?? 0;
-    const timeline = container.closest('.timeline');
-    const paddingLeft = timeline
-      ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
-      : 0;
-    const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
-    const contentOffset = Math.min(
-      Math.max(0, scrollLeft - paddingLeft),
-      maxContentOffset,
-    );
-
-    const playing = isPlaying.value;
-
-    const needsResize =
-      canvas.width !== viewportWidth || canvas.height !== height;
-
-    const last = lastDrawnRef.current;
-    // Always redraw during playback so the live overlay tracks the playhead
-    if (
-      !needsResize &&
-      !playing &&
-      contentOffset === last.offset &&
-      pixelsPerSecond === last.pps &&
-      tiles.length === last.tileCount
-    ) {
+    if (isRecordingTrack) {
+      drawRecordingFrame(
+        canvas,
+        container,
+        recordingBufferRef.current,
+        audioService,
+        pixelsPerSecond,
+        height,
+        color,
+      );
       return;
     }
-    last.offset = contentOffset;
-    last.pps = pixelsPerSecond;
-    last.tileCount = tiles.length;
 
-    if (needsResize) {
-      canvas.width = viewportWidth;
-      canvas.height = height;
-    }
+    if (tiles.length === 0) return;
 
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayWidth));
-    const lastTile = Math.min(
-      tiles.length - 1,
-      Math.floor((contentOffset + viewportWidth) / tileDisplayWidth),
+    drawTilesFrame(
+      canvas,
+      container,
+      audioService,
+      trackId,
+      color,
+      pixelsPerSecond,
+      height,
+      tiles,
+      totalFrames,
+      frameDisplayWidth,
+      tileDisplayWidth,
+      duration,
+      lastDrawnRef,
     );
-
-    for (let t = firstTile; t <= lastTile; t++) {
-      const tileLeftPx = t * tileDisplayWidth;
-      const drawX = tileLeftPx - contentOffset;
-      const isLastTile = t === tiles.length - 1;
-      const tileFrameCount = isLastTile
-        ? totalFrames - t * TILE_WIDTH
-        : TILE_WIDTH;
-      const drawWidth = tileFrameCount * frameDisplayWidth;
-
-      ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
-    }
-
-    // Live playback overlay: draw a bright column at the playhead
-    if (playing) {
-      const frequencyData = audioService.mixer.getFrequencyData(trackId);
-      if (frequencyData) {
-        const playheadX = transportTime.value * pixelsPerSecond - contentOffset;
-        drawLiveColumn(ctx, frequencyData, playheadX, height, color);
-      }
-    }
   });
 
   const { opacity } = useTrackVolume(trackId);
+
+  // For non-recording tracks, width is set from audio buffer duration.
+  // For recording tracks, width is updated in the rAF loop directly on the
+  // DOM node to avoid React re-renders at 60fps.
+  const containerWidth = isRecordingTrack ? 0 : duration * pixelsPerSecond;
 
   return (
     <div
@@ -131,5 +122,168 @@ const Spectrogram = ({ height, pixelsPerSecond, track }: SpectrogramProps) => {
     </div>
   );
 };
+
+function drawRecordingFrame(
+  canvas: HTMLCanvasElement,
+  container: HTMLDivElement,
+  buffer: RecordingBuffer | null,
+  audioService: ReturnType<typeof useAudioService>,
+  pixelsPerSecond: number,
+  height: number,
+  color: { r: number; g: number; b: number },
+): void {
+  if (!buffer) return;
+
+  const recording = isRecordingSignal.value;
+  const recordingStartTime = audioService.getRecordingStartTime();
+  const elapsed = Math.max(0, transportTime.value - recordingStartTime);
+  const contentWidth = elapsed * pixelsPerSecond;
+
+  // Update container width directly to avoid React re-renders
+  container.style.width = `${contentWidth}px`;
+
+  // Accumulate a new frame while recording is active
+  if (recording) {
+    const frequencyData = audioService.microphone.getFrequencyData();
+    buffer.addFrame(frequencyData);
+  }
+
+  if (buffer.frameCount === 0) return;
+
+  const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
+  const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+
+  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const timeline = container.closest('.timeline');
+  const paddingLeft = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+    : 0;
+  const maxContentOffset = Math.max(0, contentWidth - viewportWidth);
+  const contentOffset = Math.min(
+    Math.max(0, scrollLeft - paddingLeft),
+    maxContentOffset,
+  );
+
+  const needsResize =
+    canvas.width !== viewportWidth || canvas.height !== height;
+  if (needsResize) {
+    canvas.width = viewportWidth;
+    canvas.height = height;
+  }
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  // Map buffer frames (1 frame = 1 pixel in the buffer) to display pixels.
+  // bufferFrames maps to contentWidth display pixels.
+  const framesPerPixel = buffer.frameCount / contentWidth;
+  const srcX = Math.floor(contentOffset * framesPerPixel);
+  const srcWidth = Math.min(
+    Math.ceil(viewportWidth * framesPerPixel),
+    buffer.frameCount - srcX,
+  );
+
+  buffer.drawTo(ctx, srcX, srcWidth, 0, viewportWidth, height);
+
+  // Draw live column at the recording head during active recording
+  if (recording) {
+    const frequencyData = audioService.microphone.getFrequencyData();
+    const playheadX = contentWidth - contentOffset;
+    drawLiveColumn(ctx, frequencyData, playheadX, height, color);
+  }
+}
+
+function drawTilesFrame(
+  canvas: HTMLCanvasElement,
+  container: HTMLDivElement,
+  audioService: ReturnType<typeof useAudioService>,
+  trackId: string,
+  color: { r: number; g: number; b: number },
+  pixelsPerSecond: number,
+  height: number,
+  tiles: ImageBitmap[],
+  totalFrames: number,
+  frameDisplayWidth: number,
+  tileDisplayWidth: number,
+  duration: number,
+  lastDrawnRef: React.MutableRefObject<{
+    offset: number;
+    pps: number;
+    tileCount: number;
+  }>,
+): void {
+  const containerWidth = duration * pixelsPerSecond;
+
+  const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
+  const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+
+  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const timeline = container.closest('.timeline');
+  const paddingLeft = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+    : 0;
+  const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
+  const contentOffset = Math.min(
+    Math.max(0, scrollLeft - paddingLeft),
+    maxContentOffset,
+  );
+
+  const playing = isPlaying.value;
+
+  const needsResize =
+    canvas.width !== viewportWidth || canvas.height !== height;
+
+  const last = lastDrawnRef.current;
+  // Always redraw during playback so the live overlay tracks the playhead
+  if (
+    !needsResize &&
+    !playing &&
+    contentOffset === last.offset &&
+    pixelsPerSecond === last.pps &&
+    tiles.length === last.tileCount
+  ) {
+    return;
+  }
+  last.offset = contentOffset;
+  last.pps = pixelsPerSecond;
+  last.tileCount = tiles.length;
+
+  if (needsResize) {
+    canvas.width = viewportWidth;
+    canvas.height = height;
+  }
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayWidth));
+  const lastTile = Math.min(
+    tiles.length - 1,
+    Math.floor((contentOffset + viewportWidth) / tileDisplayWidth),
+  );
+
+  for (let t = firstTile; t <= lastTile; t++) {
+    const tileLeftPx = t * tileDisplayWidth;
+    const drawX = tileLeftPx - contentOffset;
+    const isLastTile = t === tiles.length - 1;
+    const tileFrameCount = isLastTile
+      ? totalFrames - t * TILE_WIDTH
+      : TILE_WIDTH;
+    const drawWidth = tileFrameCount * frameDisplayWidth;
+
+    ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
+  }
+
+  // Live playback overlay: draw a bright column at the playhead
+  if (playing) {
+    const frequencyData = audioService.mixer.getFrequencyData(trackId);
+    if (frequencyData) {
+      const playheadX = transportTime.value * pixelsPerSecond - contentOffset;
+      drawLiveColumn(ctx, frequencyData, playheadX, height, color);
+    }
+  }
+}
 
 export default Spectrogram;

--- a/src/components/workstation/spectrogram/__tests__/RecordingBuffer.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/RecordingBuffer.test.ts
@@ -1,0 +1,181 @@
+import { vi } from 'vitest';
+import RecordingBuffer from '../RecordingBuffer';
+
+// OffscreenCanvas is not available in jsdom. Provide a minimal mock that
+// tracks putImageData calls and supports the drawTo() path.
+const mockPutImageData = vi.fn();
+const mockDrawImage = vi.fn();
+const mockClearRect = vi.fn();
+
+const mockCtx = {
+  putImageData: mockPutImageData,
+  drawImage: mockDrawImage,
+  clearRect: mockClearRect,
+  createImageData: (w: number, h: number) => ({
+    width: w,
+    height: h,
+    data: new Uint8ClampedArray(w * h * 4),
+  }),
+};
+
+vi.stubGlobal(
+  'OffscreenCanvas',
+  class {
+    width: number;
+    height: number;
+    constructor(w: number, h: number) {
+      this.width = w;
+      this.height = h;
+    }
+    getContext() {
+      return mockCtx;
+    }
+  },
+);
+
+const WHITE = { r: 255, g: 255, b: 255 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it('starts with zero frames', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  expect(buffer.frameCount).toBe(0);
+});
+
+it('increments frameCount on each addFrame call', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  const data = new Float32Array(8).fill(-50);
+
+  buffer.addFrame(data);
+  expect(buffer.frameCount).toBe(1);
+
+  buffer.addFrame(data);
+  expect(buffer.frameCount).toBe(2);
+});
+
+it('calls putImageData for each frame', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  const data = new Float32Array(8).fill(-50);
+
+  buffer.addFrame(data);
+  buffer.addFrame(data);
+
+  // putImageData called once per frame, at column 0 and 1
+  expect(mockPutImageData).toHaveBeenCalledTimes(2);
+  expect(mockPutImageData.mock.calls[0][1]).toBe(0);
+  expect(mockPutImageData.mock.calls[1][1]).toBe(1);
+});
+
+it('does not draw to destination when frameCount is 0', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  const destCtx = { drawImage: vi.fn() } as unknown as CanvasRenderingContext2D;
+
+  buffer.drawTo(destCtx, 0, 10, 0, 100, 128);
+
+  expect(destCtx.drawImage).not.toHaveBeenCalled();
+});
+
+it('does not draw to destination when srcWidth is 0', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  const data = new Float32Array(8).fill(-50);
+  buffer.addFrame(data);
+
+  const destCtx = { drawImage: vi.fn() } as unknown as CanvasRenderingContext2D;
+
+  buffer.drawTo(destCtx, 0, 0, 0, 100, 128);
+
+  expect(destCtx.drawImage).not.toHaveBeenCalled();
+});
+
+it('draws to destination canvas with correct parameters', () => {
+  const buffer = new RecordingBuffer(WHITE, 8);
+  const data = new Float32Array(8).fill(-50);
+  buffer.addFrame(data);
+  buffer.addFrame(data);
+
+  const destDrawImage = vi.fn();
+  const destCtx = {
+    drawImage: destDrawImage,
+  } as unknown as CanvasRenderingContext2D;
+
+  buffer.drawTo(destCtx, 0, 2, 10, 200, 128);
+
+  expect(destDrawImage).toHaveBeenCalledTimes(1);
+  // drawImage(source, srcX, srcY, srcW, srcH, destX, destY, destW, destH)
+  const args = destDrawImage.mock.calls[0];
+  expect(args[1]).toBe(0); // srcX
+  expect(args[2]).toBe(0); // srcY
+  expect(args[3]).toBe(2); // srcWidth
+  expect(args[4]).toBe(8); // srcHeight (frequency bin count)
+  expect(args[5]).toBe(10); // destX
+  expect(args[6]).toBe(0); // destY
+  expect(args[7]).toBe(200); // destWidth
+  expect(args[8]).toBe(128); // destHeight
+});
+
+it('creates ImageData with correct dimensions for each frame', () => {
+  const bins = 16;
+  const buffer = new RecordingBuffer(WHITE, bins);
+  const data = new Float32Array(bins).fill(-60);
+
+  buffer.addFrame(data);
+
+  // createImageData is called with width=1, height=bins
+  const imageData = mockPutImageData.mock.calls[0][0];
+  expect(imageData.width).toBe(1);
+  expect(imageData.height).toBe(bins);
+});
+
+it('maps silent data to transparent pixels', () => {
+  const bins = 4;
+  const buffer = new RecordingBuffer(WHITE, bins);
+  // -100 dB is below MIN_DB (-80), so dbToByte returns 0 → fully transparent
+  const silentData = new Float32Array(bins).fill(-100);
+
+  buffer.addFrame(silentData);
+
+  const imageData = mockPutImageData.mock.calls[0][0];
+  // All alpha values should be 0 (transparent)
+  for (let i = 0; i < bins; i++) {
+    const row = bins - 1 - i;
+    const alpha = imageData.data[row * 4 + 3];
+    expect(alpha).toBe(0);
+  }
+});
+
+it('maps loud data to opaque pixels', () => {
+  const bins = 4;
+  const buffer = new RecordingBuffer(WHITE, bins);
+  // -30 dB is at MAX_DB, so dbToByte returns 255 → near-full opacity
+  const loudData = new Float32Array(bins).fill(-30);
+
+  buffer.addFrame(loudData);
+
+  const imageData = mockPutImageData.mock.calls[0][0];
+  // All alpha values should be near max (255 maps to alpha ~254)
+  for (let i = 0; i < bins; i++) {
+    const row = bins - 1 - i;
+    const alpha = imageData.data[row * 4 + 3];
+    expect(alpha).toBeGreaterThan(200);
+  }
+});
+
+it('draws frequency bins bottom-to-top', () => {
+  const bins = 4;
+  const buffer = new RecordingBuffer(WHITE, bins);
+  // Only the first bin has signal, rest are silent
+  const data = new Float32Array(bins).fill(-100);
+  data[0] = -30; // bin 0 = loud
+
+  buffer.addFrame(data);
+
+  const imageData = mockPutImageData.mock.calls[0][0];
+  // bin 0 should be at the bottom row (row = bins - 1 - 0 = 3)
+  const bottomAlpha = imageData.data[3 * 4 + 3]; // row 3
+  const topAlpha = imageData.data[0 * 4 + 3]; // row 0
+
+  expect(bottomAlpha).toBeGreaterThan(200);
+  expect(topAlpha).toBe(0);
+});

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -1,7 +1,11 @@
 import { render, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { useAnimationFrame } from '../../../../hooks/useAnimationFrame';
-import { isPlaying, transportTime } from '../../../../signals/transportSignals';
+import {
+  isPlaying,
+  isRecording,
+  transportTime,
+} from '../../../../signals/transportSignals';
 import { TrackSignalStore } from '../../../../signals/trackSignals';
 import { resetAllSignals } from '../../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../../testUtils';
@@ -11,9 +15,36 @@ vi.mock('../../../../hooks/useAnimationFrame', () => ({
   useAnimationFrame: vi.fn(),
 }));
 
+// OffscreenCanvas mock for RecordingBuffer
+vi.stubGlobal(
+  'OffscreenCanvas',
+  class {
+    width: number;
+    height: number;
+    constructor(w: number, h: number) {
+      this.width = w;
+      this.height = h;
+    }
+    getContext() {
+      return {
+        putImageData: vi.fn(),
+        drawImage: vi.fn(),
+        clearRect: vi.fn(),
+        createImageData: (w: number, h: number) => ({
+          width: w,
+          height: h,
+          data: new Uint8ClampedArray(w * h * 4),
+        }),
+      };
+    }
+  },
+);
+
 const mockAnalyse = vi.fn().mockResolvedValue(undefined);
 const mockGetEntry = vi.fn().mockReturnValue(undefined);
 const mockGetFrequencyData = vi.fn();
+const mockMicGetFrequencyData = vi.fn();
+const mockGetRecordingStartTime = vi.fn().mockReturnValue(0);
 
 const { mockRetrieveAudioBuffer } = vi.hoisted(() => ({
   mockRetrieveAudioBuffer: vi.fn(),
@@ -29,6 +60,10 @@ vi.mock('../../../../hooks/useAudioService', () => ({
     mixer: {
       getFrequencyData: mockGetFrequencyData,
     },
+    microphone: {
+      getFrequencyData: mockMicGetFrequencyData,
+    },
+    getRecordingStartTime: mockGetRecordingStartTime,
   }),
 }));
 
@@ -45,6 +80,8 @@ beforeEach(() => {
   mockAnalyse.mockClear();
   mockGetEntry.mockReturnValue(undefined);
   mockGetFrequencyData.mockReset();
+  mockMicGetFrequencyData.mockReset();
+  mockGetRecordingStartTime.mockReturnValue(0);
   TrackSignalStore.create(TRACK_ID);
 });
 
@@ -265,5 +302,143 @@ describe('live playback overlay', () => {
     // No fillRect calls because all intensities are 0
     expect(mockCtx.fillRect).not.toHaveBeenCalled();
     expect(mockCtx.restore).toHaveBeenCalled();
+  });
+});
+
+describe('recording mode', () => {
+  const RECORDING_TRACK_ID = '__recording__';
+  const recordingTrack = mockTrack({
+    trackId: RECORDING_TRACK_ID,
+    color: { r: 77, g: 238, b: 234 },
+  });
+
+  const recordingProps = {
+    height: 128,
+    pixelsPerSecond: 200,
+    track: recordingTrack,
+    isRecordingTrack: true,
+  };
+
+  beforeEach(() => {
+    TrackSignalStore.create(RECORDING_TRACK_ID);
+  });
+
+  it('renders without crashing in recording mode', () => {
+    render(<Spectrogram {...recordingProps} />);
+  });
+
+  it('does not retrieve audio buffer in recording mode', () => {
+    render(<Spectrogram {...recordingProps} />);
+
+    expect(mockRetrieveAudioBuffer).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger cache analysis in recording mode', () => {
+    render(<Spectrogram {...recordingProps} />);
+
+    expect(mockAnalyse).not.toHaveBeenCalled();
+  });
+
+  it('sets initial container width to zero in recording mode', () => {
+    const { container } = render(<Spectrogram {...recordingProps} />);
+
+    const spectrogram = container.querySelector('.spectrogram');
+    expect(spectrogram).toHaveStyle({ width: '0px' });
+  });
+
+  it('reads microphone frequency data during recording', () => {
+    isRecording.value = true;
+    transportTime.value = 1.5;
+    mockGetRecordingStartTime.mockReturnValue(0);
+    const micData = new Float32Array(1024).fill(-50);
+    mockMicGetFrequencyData.mockReturnValue(micData);
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: 800, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
+    render(<Spectrogram {...recordingProps} />);
+
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    expect(mockMicGetFrequencyData).toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('does not read mixer frequency data in recording mode', () => {
+    isRecording.value = true;
+    transportTime.value = 1.5;
+    mockGetRecordingStartTime.mockReturnValue(0);
+    mockMicGetFrequencyData.mockReturnValue(new Float32Array(1024).fill(-50));
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: 800, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
+    render(<Spectrogram {...recordingProps} />);
+
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    expect(mockGetFrequencyData).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('updates container width based on elapsed recording time', () => {
+    isRecording.value = true;
+    transportTime.value = 2.0;
+    mockGetRecordingStartTime.mockReturnValue(0);
+    mockMicGetFrequencyData.mockReturnValue(new Float32Array(1024).fill(-50));
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: 800, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
+    const { container } = render(<Spectrogram {...recordingProps} />);
+
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    const spectrogram = container.querySelector('.spectrogram');
+    // elapsed = 2.0 - 0 = 2.0, width = 2.0 * 200 = 400
+    expect(spectrogram).toHaveStyle({ width: '400px' });
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -229,6 +229,10 @@ class AudioService {
     return this.recorder.state === 'started';
   }
 
+  getRecordingStartTime(): number {
+    return this.recordingStartTime ?? 0;
+  }
+
   estimateRoundTripLatency(): number {
     const ctx = this.context.rawContext as AudioContext;
     const outputLatency = ctx.outputLatency ?? 0;

--- a/src/services/SpectrogramTileRenderer.ts
+++ b/src/services/SpectrogramTileRenderer.ts
@@ -10,7 +10,7 @@ const BYTES_PER_PIXEL = 4;
  * Index 0 = fully transparent (silence), index 255 = near-full opacity (loudest).
  * Each entry is [r, g, b, a] where a is 0–255.
  */
-function createColorMap(color: TrackColor): Uint8Array {
+export function createColorMap(color: TrackColor): Uint8Array {
   const { r, g, b } = color;
   const map = new Uint8Array(COLOR_MAP_SIZE * BYTES_PER_PIXEL);
   for (let i = 0; i < COLOR_MAP_SIZE; i++) {


### PR DESCRIPTION
## Summary
This PR adds support for visualizing live microphone input as a spectrogram during audio recording. A new `RecordingBuffer` class accumulates frequency data in real-time, and the `Spectrogram` component now supports a recording mode that displays the live input alongside playback spectrograms.

## Key Changes

- **New `RecordingBuffer` class** (`RecordingBuffer.ts`): Manages an `OffscreenCanvas` that accumulates frequency frames during recording. Each frame is a single-pixel column that grows the buffer automatically. Includes comprehensive unit tests covering frame accumulation, pixel mapping, and canvas drawing.

- **Recording mode in `Spectrogram` component**: 
  - Added `isRecordingTrack` prop to enable recording visualization mode
  - Refactored drawing logic into two separate functions: `drawRecordingFrame()` for live input and `drawTilesFrame()` for pre-rendered tiles
  - Recording mode reads from `audioService.microphone.getFrequencyData()` instead of the mixer
  - Container width is updated directly on the DOM to avoid React re-renders at 60fps

- **Timeline integration**: 
  - Added `recordingColor` prop to `Timeline` and `Workstation` components
  - Conditionally renders a recording track spectrogram when `isRecording` signal is active
  - Recording track uses a dedicated track ID (`__recording__`)

- **Signal and service updates**:
  - Imported `isRecording` signal in relevant components
  - Added `getRecordingStartTime()` method to `AudioService` to calculate elapsed recording time
  - Exported `createColorMap()` from `SpectrogramTileRenderer` for reuse in `RecordingBuffer`

- **Test coverage**: Added comprehensive tests for `RecordingBuffer` behavior and recording mode in `Spectrogram` tests, including frequency data mapping, canvas updates, and microphone data integration.

## Implementation Details

- Frequency bins are rendered bottom-to-top (bin 0 at bottom) to match the offline tile rendering convention
- The recording buffer uses dB-to-byte conversion (`dbToByte`) to map frequency magnitudes to pixel opacity
- Live column overlay is drawn at the recording head position during active recording
- Container width is calculated from elapsed time: `(transportTime - recordingStartTime) * pixelsPerSecond`

https://claude.ai/code/session_01QvAM5wY7bZJre2w3cLkLMa