### PR TITLE
Extract logarithmic frequency mapping to shared service

### DIFF
--- a/src/components/workstation/spectrogram/RecordingBuffer.ts
+++ b/src/components/workstation/spectrogram/RecordingBuffer.ts
@@ -1,3 +1,7 @@
+import {
+  applyLogFrequencyMapping,
+  createLogFrequencyMapping,
+} from '../../../services/logFrequencyMapping';
 import { createColorMap } from '../../../services/SpectrogramTileRenderer';
 import { type TrackColor } from '../../../types/track';
 import { dbToByte } from './spectrogramRenderer';
@@ -10,8 +14,9 @@ const BYTES_PER_PIXEL = 4;
  * OffscreenCanvas buffer. Each call to addFrame() appends a single-pixel
  * column. The buffer grows automatically when full.
  *
- * Frequency bins are drawn bottom-to-top (bin 0 at bottom) to match
- * the offline tile rendering convention.
+ * Frequency data is remapped to a logarithmic scale before rendering,
+ * matching the offline spectrogram tile convention. Bins are drawn
+ * bottom-to-top (bin 0 at bottom).
  */
 class RecordingBuffer {
   frameCount = 0;
@@ -20,12 +25,16 @@ class RecordingBuffer {
   private ctx: OffscreenCanvasRenderingContext2D;
   private colorMap: Uint8Array;
   private height: number;
+  private logMapping: number[][];
+  private logBuffer: Float32Array;
 
   constructor(color: TrackColor, frequencyBinCount: number) {
     this.height = frequencyBinCount;
     this.canvas = new OffscreenCanvas(INITIAL_WIDTH, frequencyBinCount);
     this.ctx = this.canvas.getContext('2d')!;
     this.colorMap = createColorMap(color);
+    this.logMapping = createLogFrequencyMapping(frequencyBinCount);
+    this.logBuffer = new Float32Array(frequencyBinCount);
   }
 
   addFrame(frequencyData: Float32Array): void {
@@ -33,13 +42,15 @@ class RecordingBuffer {
       this.grow();
     }
 
+    applyLogFrequencyMapping(frequencyData, this.logMapping, this.logBuffer);
+
     const col = this.frameCount;
-    const bins = Math.min(frequencyData.length, this.height);
+    const bins = Math.min(this.logBuffer.length, this.height);
     const imageData = this.ctx.createImageData(1, this.height);
     const pixels = imageData.data;
 
     for (let bin = 0; bin < bins; bin++) {
-      const byte = dbToByte(frequencyData[bin]);
+      const byte = dbToByte(this.logBuffer[bin]);
       // bin 0 → bottom row, last bin → top row
       const row = this.height - 1 - bin;
       const pixelOffset = row * BYTES_PER_PIXEL;

--- a/src/components/workstation/spectrogram/__tests__/RecordingBuffer.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/RecordingBuffer.test.ts
@@ -179,3 +179,27 @@ it('draws frequency bins bottom-to-top', () => {
   expect(bottomAlpha).toBeGreaterThan(200);
   expect(topAlpha).toBe(0);
 });
+
+it('applies logarithmic frequency mapping so low frequencies span more rows', () => {
+  const bins = 4;
+  const buffer = new RecordingBuffer(WHITE, bins);
+  // Only the lowest frequency bin is loud
+  const data = new Float32Array(bins).fill(-100);
+  data[0] = -30;
+
+  buffer.addFrame(data);
+
+  const imageData = mockPutImageData.mock.calls[0][0];
+  // With log mapping for 4 bins, output bins 0 and 1 both map to
+  // input bin 0. So the bottom two rows (rows 3 and 2) should be bright,
+  // not just the bottom one.
+  const row3Alpha = imageData.data[3 * 4 + 3]; // bottom
+  const row2Alpha = imageData.data[2 * 4 + 3]; // second from bottom
+  const row1Alpha = imageData.data[1 * 4 + 3]; // third from bottom
+  const row0Alpha = imageData.data[0 * 4 + 3]; // top
+
+  expect(row3Alpha).toBeGreaterThan(200);
+  expect(row2Alpha).toBeGreaterThan(200);
+  expect(row1Alpha).toBe(0);
+  expect(row0Alpha).toBe(0);
+});

--- a/src/components/workstation/spectrogram/__tests__/spectrogramRenderer.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/spectrogramRenderer.test.ts
@@ -1,0 +1,74 @@
+import { vi } from 'vitest';
+import { drawLiveColumn, dbToByte } from '../spectrogramRenderer';
+
+describe('dbToByte', () => {
+  it('returns 0 for values at or below MIN_DB', () => {
+    expect(dbToByte(-80)).toBe(0);
+    expect(dbToByte(-100)).toBe(0);
+  });
+
+  it('returns 255 for values at or above MAX_DB', () => {
+    expect(dbToByte(-30)).toBe(255);
+    expect(dbToByte(0)).toBe(255);
+  });
+
+  it('returns proportional value for mid-range dB', () => {
+    // -55 dB is halfway between -80 and -30 → ~128
+    expect(dbToByte(-55)).toBe(128);
+  });
+});
+
+describe('drawLiveColumn', () => {
+  function createMockCtx(canvasWidth = 100) {
+    const fillRectCalls: { x: number; y: number; w: number; h: number }[] = [];
+    const ctx = {
+      canvas: { width: canvasWidth },
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: '',
+      fillStyle: '',
+      fillRect(x: number, y: number, w: number, h: number) {
+        fillRectCalls.push({ x, y, w, h });
+      },
+    };
+    return { ctx: ctx as unknown as CanvasRenderingContext2D, fillRectCalls };
+  }
+
+  const WHITE = { r: 255, g: 255, b: 255 };
+
+  it('applies logarithmic frequency mapping so low frequencies occupy more rows', () => {
+    // 8 bins, canvas height 8. Only the lowest frequency bin (0) is loud.
+    //
+    // With logarithmic mapping for 8 bins, output bins 0, 1, and 2 all
+    // map to input bin 0 — so three rows should be drawn, not one.
+    const data = new Float32Array(8).fill(-100);
+    data[0] = -30; // loud at lowest frequency
+
+    const { ctx, fillRectCalls } = createMockCtx();
+
+    drawLiveColumn(ctx, data, 50, 8, WHITE);
+
+    // Logarithmic: output bins 0, 1, 2 all read from input bin 0
+    // → 3 bright rows at the bottom of the canvas (y = 5, 6, 7)
+    expect(fillRectCalls.length).toBe(3);
+    const drawnYs = fillRectCalls.map((c) => c.y).sort((a, b) => a - b);
+    expect(drawnYs).toEqual([5, 6, 7]);
+  });
+
+  it('compresses high-frequency bins into fewer rows', () => {
+    // With logarithmic mapping for 8 bins, output bin 5 pools input
+    // bins 2, 3, and 4. So if only input bin 3 has signal, output bin 5
+    // (and only bin 5) should light up.
+    const data = new Float32Array(8).fill(-100);
+    data[3] = -30; // loud at input bin 3
+
+    const { ctx, fillRectCalls } = createMockCtx();
+
+    drawLiveColumn(ctx, data, 50, 8, WHITE);
+
+    // Output bin 5 maps to input bins [2, 3, 4] → picks up the signal.
+    // Row 5 → y = height - 5 - 1 = 2
+    expect(fillRectCalls.length).toBe(1);
+    expect(fillRectCalls[0].y).toBe(2);
+  });
+});

--- a/src/components/workstation/spectrogram/spectrogramRenderer.ts
+++ b/src/components/workstation/spectrogram/spectrogramRenderer.ts
@@ -1,3 +1,7 @@
+import {
+  applyLogFrequencyMapping,
+  createLogFrequencyMapping,
+} from '../../../services/logFrequencyMapping';
 import { type TrackColor } from '../../../types/track';
 
 const LIVE_COLUMN_WIDTH = 2;
@@ -7,13 +11,31 @@ const MIN_DB = -80;
 const MAX_DB = -30;
 const DB_RANGE = MAX_DB - MIN_DB;
 
+// Lazily initialised log-frequency mapping cache, keyed by bin count.
+let cachedBinCount = 0;
+let cachedMapping: number[][] = [];
+let cachedBuffer: Float32Array = new Float32Array(0);
+
+function getLogMapping(binCount: number): {
+  mapping: number[][];
+  buffer: Float32Array;
+} {
+  if (cachedBinCount !== binCount) {
+    cachedMapping = createLogFrequencyMapping(binCount);
+    cachedBuffer = new Float32Array(binCount);
+    cachedBinCount = binCount;
+  }
+  return { mapping: cachedMapping, buffer: cachedBuffer };
+}
+
 /**
  * Draws a single bright column on the canvas at the playhead position,
  * reflecting live post-effects frequency content during playback.
  *
- * Frequency bins are grouped into pixel rows (max intensity per row)
- * and rendered with additive compositing so the overlay appears brighter
- * than the static spectrogram tiles underneath.
+ * Frequency data is first remapped to a logarithmic scale (matching the
+ * static spectrogram tiles), then grouped into pixel rows (max intensity
+ * per row) and rendered with additive compositing so the overlay appears
+ * brighter than the tiles underneath.
  */
 export function drawLiveColumn(
   ctx: CanvasRenderingContext2D,
@@ -25,6 +47,9 @@ export function drawLiveColumn(
   if (playheadX < -LIVE_COLUMN_WIDTH || playheadX > ctx.canvas.width) return;
 
   const bins = frequencyData.length;
+  const { mapping, buffer: logData } = getLogMapping(bins);
+  applyLogFrequencyMapping(frequencyData, mapping, logData);
+
   const binsPerRow = bins / height;
   const { r, g, b } = color;
   const x = Math.round(playheadX);
@@ -37,7 +62,7 @@ export function drawLiveColumn(
     const endBin = Math.floor((row + 1) * binsPerRow);
     let maxIntensity = 0;
     for (let bin = startBin; bin < endBin; bin++) {
-      const intensity = dbToByte(frequencyData[bin]);
+      const intensity = dbToByte(logData[bin]);
       if (intensity > maxIntensity) maxIntensity = intensity;
     }
     if (maxIntensity === 0) continue;

--- a/src/services/OfflineAnalyser.ts
+++ b/src/services/OfflineAnalyser.ts
@@ -1,3 +1,5 @@
+import { createLogFrequencyMapping } from './logFrequencyMapping';
+
 export type SpectrogramData = {
   frequencyFrames: Uint8Array[];
   timeResolution: number;
@@ -41,7 +43,9 @@ class OfflineAnalyser {
     this.timeResolution = isContextSuspendSupported
       ? this.offlineContextSuspendTime
       : this.scriptProcessorBufferLength / sampleRate;
-    this.logFrequencyMapping = this.createLogFrequencyMapping();
+    this.logFrequencyMapping = createLogFrequencyMapping(
+      analyser.frequencyBinCount,
+    );
     this.frequencyDataCopy = new Uint8Array(this.frequencyBinCount);
   }
 
@@ -228,32 +232,6 @@ class OfflineAnalyser {
     bufferSource.start(0);
 
     return this.offlineContext.startRendering();
-  }
-
-  private createLogFrequencyMapping() {
-    const logFrequencyMapping: number[][] = new Array(this.frequencyBinCount);
-    const lower = 1;
-    const upper = this.frequencyBinCount + 1;
-    const b = Math.log(lower / upper) / (lower - upper);
-    const a = 1; // lower / Math.exp(b * lower);
-    for (let i = 0, binCount = this.frequencyBinCount; i < binCount; i++) {
-      const logIdx = Math.trunc(a * Math.exp(b * i)) - 1;
-      logFrequencyMapping[i] = [logIdx];
-    }
-    for (
-      let i = 0, binCountDec = this.frequencyBinCount - 1;
-      i < binCountDec;
-      i++
-    ) {
-      const df = logFrequencyMapping[i + 1][0] - logFrequencyMapping[i][0];
-      if (df === 1) {
-        continue;
-      }
-      for (let j = 1; j <= df; j++) {
-        logFrequencyMapping[i].push(logFrequencyMapping[i][0] + j);
-      }
-    }
-    return logFrequencyMapping;
   }
 
   private transformFrequencies(

--- a/src/services/__tests__/spectrogram.worker.test.ts
+++ b/src/services/__tests__/spectrogram.worker.test.ts
@@ -1,8 +1,6 @@
 import { vi } from 'vitest';
-import {
-  analyseToFrames,
-  createLogFrequencyMapping,
-} from '../spectrogram.worker';
+import { createLogFrequencyMapping } from '../logFrequencyMapping';
+import { analyseToFrames } from '../spectrogram.worker';
 
 // OfflineAudioContext is not available in jsdom — mock it identically to OfflineAnalyser tests
 const mockGetByteFrequencyData = vi.fn();

--- a/src/services/logFrequencyMapping.ts
+++ b/src/services/logFrequencyMapping.ts
@@ -1,0 +1,59 @@
+/**
+ * Logarithmic frequency mapping for FFT visualisation.
+ *
+ * Linear FFT bins are remapped to perceptually-spaced (log) bins so that
+ * equal visual distances correspond to equal musical intervals — matching
+ * human pitch perception.
+ */
+
+/**
+ * Creates a mapping from output (log-spaced) bins to input (linear) bins.
+ *
+ * Each entry `mapping[i]` is an array of linear bin indices that feed into
+ * output bin `i`. Low-frequency output bins map to a single input bin
+ * (expanding the low range); high-frequency output bins pool multiple
+ * input bins (compressing the high range).
+ */
+export function createLogFrequencyMapping(
+  frequencyBinCount: number,
+): number[][] {
+  const mapping: number[][] = new Array(frequencyBinCount);
+  const lower = 1;
+  const upper = frequencyBinCount + 1;
+  const b = Math.log(lower / upper) / (lower - upper);
+  for (let i = 0; i < frequencyBinCount; i++) {
+    const logIdx = Math.trunc(Math.exp(b * i)) - 1;
+    mapping[i] = [logIdx];
+  }
+  for (let i = 0; i < frequencyBinCount - 1; i++) {
+    const df = mapping[i + 1][0] - mapping[i][0];
+    if (df === 1) {
+      continue;
+    }
+    for (let j = 1; j <= df; j++) {
+      mapping[i].push(mapping[i][0] + j);
+    }
+  }
+  return mapping;
+}
+
+/**
+ * Applies a logarithmic frequency mapping to Float32Array dB data.
+ *
+ * When multiple input bins map to one output bin the **maximum** value
+ * is kept, preserving the strongest frequency component in each band.
+ */
+export function applyLogFrequencyMapping(
+  input: Float32Array,
+  mapping: number[][],
+  output: Float32Array,
+): void {
+  for (let i = 0; i < mapping.length; i++) {
+    const pool = mapping[i];
+    let max = input[pool[0]];
+    for (let j = 1; j < pool.length; j++) {
+      if (input[pool[j]] > max) max = input[pool[j]];
+    }
+    output[i] = max;
+  }
+}

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -1,4 +1,5 @@
 import { type TrackColor } from '../types/track';
+import { createLogFrequencyMapping } from './logFrequencyMapping';
 import { type SpectrogramData } from './OfflineAnalyser';
 import { renderTiles } from './SpectrogramTileRenderer';
 
@@ -19,36 +20,6 @@ export type AnalyseRequest = {
 export type AnalyseResponse =
   | { id: number; type: 'result'; data: SpectrogramData; tiles: ImageBitmap[] }
   | { id: number; type: 'error'; message: string };
-
-/**
- * Logarithmic frequency mapping — identical to OfflineAnalyser.createLogFrequencyMapping.
- *
- * Maps linear FFT bins to perceptual (log-spaced) bins. Lower bins pool
- * multiple linear bins together, compressing the high-frequency region
- * and expanding the low-frequency region for musical relevance.
- */
-export function createLogFrequencyMapping(
-  frequencyBinCount: number,
-): number[][] {
-  const mapping: number[][] = new Array(frequencyBinCount);
-  const lower = 1;
-  const upper = frequencyBinCount + 1;
-  const b = Math.log(lower / upper) / (lower - upper);
-  for (let i = 0; i < frequencyBinCount; i++) {
-    const logIdx = Math.trunc(Math.exp(b * i)) - 1;
-    mapping[i] = [logIdx];
-  }
-  for (let i = 0; i < frequencyBinCount - 1; i++) {
-    const df = mapping[i + 1][0] - mapping[i][0];
-    if (df === 1) {
-      continue;
-    }
-    for (let j = 1; j <= df; j++) {
-      mapping[i].push(mapping[i][0] + j);
-    }
-  }
-  return mapping;
-}
 
 /**
  * FFT analysis producing log-frequency spectrogram frames —


### PR DESCRIPTION
## Summary
Refactors the logarithmic frequency mapping logic into a reusable service module, eliminating code duplication across the codebase. The mapping is now consistently applied to both live playhead visualization and recording buffer rendering.

## Key Changes
- **New service module** (`src/services/logFrequencyMapping.ts`):
  - Extracted `createLogFrequencyMapping()` function (previously duplicated in `OfflineAnalyser` and `spectrogram.worker`)
  - Added `applyLogFrequencyMapping()` function to apply log-frequency remapping to Float32Array dB data
  
- **Live column rendering** (`spectrogramRenderer.ts`):
  - Now applies logarithmic frequency mapping before rendering the playhead column
  - Implements lazy caching of mapping and buffer to avoid repeated allocations
  - Updated documentation to clarify the log-frequency remapping step

- **Recording buffer** (`RecordingBuffer.ts`):
  - Now applies logarithmic frequency mapping when adding frames
  - Maintains consistency with offline tile rendering convention

- **Cleanup**:
  - Removed duplicate `createLogFrequencyMapping()` from `OfflineAnalyser.ts`
  - Removed duplicate `createLogFrequencyMapping()` from `spectrogram.worker.ts`
  - Updated imports across affected modules

- **Test coverage**:
  - Added comprehensive unit tests for `dbToByte()` and `drawLiveColumn()` with logarithmic mapping verification
  - Added integration test for `RecordingBuffer` to verify log-frequency mapping behavior

## Implementation Details
The logarithmic mapping expands the low-frequency region (each output bin maps to a single input bin) while compressing the high-frequency region (multiple input bins pool into single output bins). When multiple input bins map to one output bin, the maximum value is preserved to maintain the strongest frequency component in each band. This matches human pitch perception and provides better musical relevance in the visualization.

https://claude.ai/code/session_0188UCd93ft7uDGDwJsTnPyq