### PR TITLE
Fix spectrogram scroll freezing during first-track recording

### DIFF
--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import AudioService from '../../../../services/AudioService';
 import {
   isPlaying,
+  isRecording,
   resetTransportSignals,
   transportTime,
 } from '../../../../signals/transportSignals';
@@ -121,6 +122,33 @@ it('sets --loudness CSS variable on cursor during playback', () => {
   const cursor = container.querySelector('.cursor');
   expect(getLoudnessSpy).toHaveBeenCalled();
   expect(cursor?.getAttribute('style')).toContain('--loudness: 0.75');
+});
+
+it('does not stop playback at end of scroll during recording', () => {
+  const audioService = AudioService.getInstance();
+  vi.spyOn(audioService, 'getTransportTime').mockReturnValue(1.5);
+  vi.spyOn(audioService.mixer, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  isPlaying.value = true;
+  isRecording.value = true;
+
+  render(<Scrubber {...defaultProps} />);
+
+  // In jsdom, scrollWidth equals clientWidth (no overflow), so the
+  // end-of-scroll condition is satisfied. During recording this must NOT
+  // trigger stopAndRewindPlayback.
+  act(() => {
+    rafCallback(0);
+  });
+
+  expect(isPlaying.value).toBe(true);
+  expect(transportTime.value).toBe(1.5);
 });
 
 it('does not set --loudness when playback is stopped', () => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -9,6 +9,7 @@ import { useAudioService } from '../../../hooks/useAudioService';
 import useDebounced from '../../../hooks/useDebounced';
 import {
   isPlaying,
+  isRecording,
   loudness as loudnessSignal,
   stopAndRewindPlayback,
   transportTime,
@@ -77,7 +78,12 @@ export function useScrubber({
           String(currentLoudness),
         );
 
-        if (timelineScrollRef.current) {
+        // Skip end-of-scroll detection while recording — the recording
+        // spectrogram grows its container width progressively, so scrollWidth
+        // can momentarily equal clientWidth before new content is laid out.
+        // Stopping playback here would freeze transportTime updates and halt
+        // the live spectrogram scroll.
+        if (timelineScrollRef.current && !isRecording.value) {
           const isEndOfScroll =
             timelineScrollRef.current.scrollLeft +
               timelineScrollRef.current.clientWidth >=


### PR DESCRIPTION
The end-of-scroll check in useScrubber's animation loop was triggering
immediately when recording the first track because scrollWidth equaled
clientWidth (no existing content to overflow). This stopped the
animation loop, froze transportTime updates, and halted spectrogram
scrolling while recording continued in the background.

Skip the end-of-scroll check during recording since the recording
spectrogram grows progressively and has its own lifecycle management.

https://claude.ai/code/session_01WiK1xfqFJ7fm7FdKtMe6v6