### PR TITLE
Fix overdub spectrogram not aligned with audio when recording starts mid-timeline

### DIFF
--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -46,6 +46,10 @@ const Spectrogram = ({
 
   const entry = useSpectrogramCache(trackId, audioBuffer, color);
 
+  const startTime = isRecordingTrack
+    ? 0
+    : (audioService.retrieveStartTime(trackId) ?? 0);
+
   const duration = audioBuffer?.duration ?? 0;
 
   const timeResolution = entry?.data.timeResolution ?? 0.025;
@@ -111,12 +115,17 @@ const Spectrogram = ({
   // For recording tracks, width is updated in the rAF loop directly on the
   // DOM node to avoid React re-renders at 60fps.
   const containerWidth = isRecordingTrack ? 0 : duration * pixelsPerSecond;
+  const containerMarginLeft = startTime * pixelsPerSecond;
 
   return (
     <div
       ref={containerRef}
       className="spectrogram"
-      style={{ opacity, width: containerWidth }}
+      style={{
+        opacity,
+        width: containerWidth,
+        marginLeft: containerMarginLeft,
+      }}
     >
       <canvas ref={canvasRef} className="spectrogram__canvas" />
     </div>
@@ -139,8 +148,9 @@ function drawRecordingFrame(
   const elapsed = Math.max(0, transportTime.value - recordingStartTime);
   const contentWidth = elapsed * pixelsPerSecond;
 
-  // Update container width directly to avoid React re-renders
+  // Update container width and offset directly to avoid React re-renders
   container.style.width = `${contentWidth}px`;
+  container.style.marginLeft = `${recordingStartTime * pixelsPerSecond}px`;
 
   // Accumulate a new frame while recording is active
   if (recording) {

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -46,13 +46,15 @@ const mockGetFrequencyData = vi.fn();
 const mockMicGetFrequencyData = vi.fn();
 const mockGetRecordingStartTime = vi.fn().mockReturnValue(0);
 
-const { mockRetrieveAudioBuffer } = vi.hoisted(() => ({
+const { mockRetrieveAudioBuffer, mockRetrieveStartTime } = vi.hoisted(() => ({
   mockRetrieveAudioBuffer: vi.fn(),
+  mockRetrieveStartTime: vi.fn().mockReturnValue(0),
 }));
 
 vi.mock('../../../../hooks/useAudioService', () => ({
   useAudioService: () => ({
     retrieveAudioBuffer: mockRetrieveAudioBuffer,
+    retrieveStartTime: mockRetrieveStartTime,
     spectrogramCache: {
       analyse: mockAnalyse,
       getEntry: mockGetEntry,
@@ -77,6 +79,7 @@ const defaultProps = {
 
 beforeEach(() => {
   mockRetrieveAudioBuffer.mockReturnValue(undefined);
+  mockRetrieveStartTime.mockReturnValue(0);
   mockAnalyse.mockClear();
   mockGetEntry.mockReturnValue(undefined);
   mockGetFrequencyData.mockReset();
@@ -176,6 +179,32 @@ it('sets container width from duration and pixelsPerSecond', () => {
   const spectrogram = container.querySelector('.spectrogram');
   // containerWidth = duration * pixelsPerSecond = 2.5 * 200 = 500
   expect(spectrogram).toHaveStyle({ width: '500px' });
+});
+
+it('offsets container by startTime for tracks recorded at non-zero position', () => {
+  const duration = 2.5;
+  const startTime = 3.0;
+  const audioBuffer = { duration } as AudioBuffer;
+  mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
+  mockRetrieveStartTime.mockReturnValue(startTime);
+
+  const { container } = render(<Spectrogram {...defaultProps} />);
+
+  const spectrogram = container.querySelector('.spectrogram');
+  // marginLeft = startTime * pixelsPerSecond = 3.0 * 200 = 600
+  expect(spectrogram).toHaveStyle({ marginLeft: '600px' });
+});
+
+it('has no margin offset for tracks starting at position zero', () => {
+  const duration = 2.5;
+  const audioBuffer = { duration } as AudioBuffer;
+  mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
+  mockRetrieveStartTime.mockReturnValue(0);
+
+  const { container } = render(<Spectrogram {...defaultProps} />);
+
+  const spectrogram = container.querySelector('.spectrogram');
+  expect(spectrogram).toHaveStyle({ marginLeft: '0px' });
 });
 
 it('sets container width to zero when no audio buffer', () => {
@@ -405,6 +434,39 @@ describe('recording mode', () => {
     callback?.();
 
     expect(mockGetFrequencyData).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('offsets container by recording start time during overdub', () => {
+    isRecording.value = true;
+    transportTime.value = 5.0;
+    mockGetRecordingStartTime.mockReturnValue(3.0);
+    mockMicGetFrequencyData.mockReturnValue(new Float32Array(1024).fill(-50));
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: 800, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
+    const { container } = render(<Spectrogram {...recordingProps} />);
+
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    const spectrogram = container.querySelector('.spectrogram');
+    // marginLeft = recordingStartTime * pixelsPerSecond = 3.0 * 200 = 600
+    expect(spectrogram).toHaveStyle({ marginLeft: '600px' });
 
     vi.restoreAllMocks();
   });

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -130,6 +130,10 @@ class AudioService {
     return this.audioSourceRepository.get(trackId)?.initialVolume;
   }
 
+  retrieveStartTime(trackId: string): number | undefined {
+    return this.audioSourceRepository.get(trackId)?.startTime;
+  }
+
   startPlayback(transportTime?: number): void {
     if (transportTime !== undefined) {
       this.setTransportTime(transportTime);

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -116,10 +116,19 @@ describe('createTrack', () => {
     );
   });
 
+  it('stores start time of zero for uploaded tracks', async () => {
+    const arrayBuffer = new ArrayBuffer(16);
+
+    const { trackId } = await audioService.createTrack(arrayBuffer);
+
+    expect(audioService.retrieveStartTime(trackId)).toBe(0);
+  });
+
   it('returns undefined for unknown track IDs', () => {
     expect(audioService.retrieveBlobUrl('nonexistent')).toBeUndefined();
     expect(audioService.retrieveAudioBuffer('nonexistent')).toBeUndefined();
     expect(audioService.retrieveInitialVolume('nonexistent')).toBeUndefined();
+    expect(audioService.retrieveStartTime('nonexistent')).toBeUndefined();
   });
 
   it('returns initial volume of 100 for a buffer at target RMS', async () => {
@@ -426,6 +435,18 @@ describe('overdub recording', () => {
 
     expect(blobUrl).toBeDefined();
     expect(blobUrl).toContain('blob:');
+  });
+
+  it('stores recording start time retrievable after stop', async () => {
+    Tone.getTransport().seconds = 5.0;
+    await audioService.startOverdubRecording();
+
+    const recorderInstance = vi.mocked(Tone.Recorder).mock.results[0].value;
+    Object.assign(recorderInstance, { state: 'started' });
+
+    const { trackId } = await audioService.stopOverdubRecording();
+
+    expect(audioService.retrieveStartTime(trackId)).toBe(5.0);
   });
 
   it('stores a retrievable audioBuffer for the recorded track', async () => {


### PR DESCRIPTION
The spectrogram for overdub recordings always rendered from position 0 on the
timeline, while the audio was correctly offset by the recording start time.
Add marginLeft to the spectrogram container based on the track's startTime so
the visualization aligns with the actual audio position.

https://claude.ai/code/session_01QTN7mi7W3Nf2WzmTuv4JWK