### PR TITLE
Fix spectrogram parallax scroll bug for offset tracks

### DIFF
--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -168,9 +168,10 @@ function drawRecordingFrame(
   const paddingLeft = timeline
     ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
     : 0;
+  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
   const maxContentOffset = Math.max(0, contentWidth - viewportWidth);
   const contentOffset = Math.min(
-    Math.max(0, scrollLeft - paddingLeft),
+    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
     maxContentOffset,
   );
 
@@ -233,9 +234,10 @@ function drawTilesFrame(
   const paddingLeft = timeline
     ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
     : 0;
+  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
   const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
   const contentOffset = Math.min(
-    Math.max(0, scrollLeft - paddingLeft),
+    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
     maxContentOffset,
   );
 
@@ -290,7 +292,10 @@ function drawTilesFrame(
   if (playing) {
     const frequencyData = audioService.mixer.getFrequencyData(trackId);
     if (frequencyData) {
-      const playheadX = transportTime.value * pixelsPerSecond - contentOffset;
+      const playheadX =
+        transportTime.value * pixelsPerSecond -
+        containerMarginLeft -
+        contentOffset;
       drawLiveColumn(ctx, frequencyData, playheadX, height, color);
     }
   }

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -216,10 +216,96 @@ it('sets container width to zero when no audio buffer', () => {
   expect(spectrogram).toHaveStyle({ width: '0px' });
 });
 
-// Scroll-offset tile drawing tests (correct offset, max-offset capping,
-// redraw on scroll change) are covered by the e2e suite in
-// e2e/spectrogram-timeline.spec.ts which verifies actual rendered pixels
-// across the full scroll range, including past the sticky boundary.
+describe('scroll offset for tracks with non-zero start time', () => {
+  const START_TIME = 3.0;
+  const DURATION = 5.0;
+  const VIEWPORT_WIDTH = 800;
+
+  const mockCtx = {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    getImageData: vi.fn(),
+    putImageData: vi.fn(),
+    globalCompositeOperation: 'source-over' as string,
+    fillStyle: '' as string,
+    canvas: { width: VIEWPORT_WIDTH, height: 128 },
+  };
+
+  const tileImageBitmap = { close: vi.fn(), width: 4096, height: 1024 };
+
+  const cachedEntry = {
+    data: {
+      frequencyFrames: Array.from({ length: 100 }, () => new Uint8Array(1024)),
+      timeResolution: 0.025,
+      frequencyBinCount: 1024,
+      sampleRate: 44100,
+      duration: DURATION,
+    },
+    tiles: [tileImageBitmap],
+  };
+
+  beforeEach(() => {
+    const audioBuffer = { duration: DURATION } as AudioBuffer;
+    mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
+    mockRetrieveStartTime.mockReturnValue(START_TIME);
+    mockGetEntry.mockReturnValue(cachedEntry);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+    mockCtx.drawImage.mockClear();
+    mockCtx.clearRect.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function setScrollPosition(container: HTMLElement, scrollLeft: number): void {
+    const scrollContainer = container.querySelector('.scrubber__timeline')!;
+    Object.defineProperty(scrollContainer, 'scrollLeft', {
+      value: scrollLeft,
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, 'clientWidth', {
+      value: VIEWPORT_WIDTH,
+      configurable: true,
+    });
+  }
+
+  function invokeAnimationCallback() {
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+  }
+
+  it('draws first tile at x=0 when viewport is aligned with track start', () => {
+    const containerMarginLeft = START_TIME * defaultProps.pixelsPerSecond;
+
+    const { container } = render(
+      <div className="timeline">
+        <div className="scrubber__timeline">
+          <Spectrogram {...defaultProps} />
+        </div>
+      </div>,
+    );
+
+    setScrollPosition(container, containerMarginLeft);
+    invokeAnimationCallback();
+
+    // When scrolled exactly to the track's start position, content offset
+    // should be 0, so the first tile is drawn at x=0 on the canvas.
+    expect(mockCtx.drawImage).toHaveBeenCalledWith(
+      tileImageBitmap,
+      0,
+      0,
+      expect.any(Number),
+      128,
+    );
+  });
+});
 
 describe('live playback overlay', () => {
   const mockCtx = {


### PR DESCRIPTION
## Summary
- The `contentOffset` calculation in `drawTilesFrame` and `drawRecordingFrame` did not account for the track container's `marginLeft` (`startTime * pixelsPerSecond`), causing a parallax scroll effect for tracks recorded at non-zero positions
- The spectrogram content scrolled faster than its container initially, then locked in at the correct speed, then stopped early to wait for the container — because the offset into the content was computed relative to the timeline origin rather than the track's start position
- Fixed by subtracting `containerMarginLeft` from the `contentOffset` formula in both draw functions, and correcting the playhead overlay position to be track-relative

## Test plan
- [x] Added unit test verifying the first tile is drawn at x=0 when the viewport is aligned with the track's start position
- [ ] Manual: upload two audio files, record the second one starting mid-timeline, verify both spectrograms scroll in sync without parallax
- [ ] Manual: verify the live playhead overlay appears at the correct position during playback of offset tracks

https://claude.ai/code/session_01UbwNUxXckqaVLKDWXQfpLW