### PR TITLE
Color playhead mist by dominant track and drift left only

### DIFF
--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -73,6 +73,7 @@ const Workstation = (props: WorkstationProps) => {
               drawerHeight={mixerHeight}
               isMixerOpen={isMixerOpen}
               pixelsPerSecond={pixelsPerSecond}
+              tracks={tracks}
             >
               <Timeline
                 pixelsPerSecond={pixelsPerSecond}

--- a/src/components/workstation/scrubber/PlasmaPlayhead.tsx
+++ b/src/components/workstation/scrubber/PlasmaPlayhead.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import {
+  type TrackFrequencyInput,
   createPlasmaState,
   renderIdleFrame,
   renderPlasmaFrame,
@@ -12,6 +13,7 @@ export type PlasmaPlayheadHandle = {
     frequencyData: Float32Array | null,
     loudness: number,
     scrollLeft: number,
+    trackFrequencyInputs: TrackFrequencyInput[],
   ) => void;
   renderIdle: () => void;
   resize: (height: number) => void;
@@ -34,6 +36,7 @@ const PlasmaPlayhead = forwardRef<PlasmaPlayheadHandle, PlasmaPlayheadProps>(
         frequencyData: Float32Array | null,
         loudness: number,
         scrollLeft: number,
+        trackFrequencyInputs: TrackFrequencyInput[],
       ) {
         const canvas = canvasRef.current;
         if (!canvas) return;
@@ -58,6 +61,7 @@ const PlasmaPlayhead = forwardRef<PlasmaPlayheadHandle, PlasmaPlayheadProps>(
           centerX,
           now,
           deltaTime,
+          trackFrequencyInputs,
         );
       },
 

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -4,6 +4,7 @@ import { Button } from 'antd';
 import classNames from 'classnames';
 import { PropsWithChildren } from 'react';
 import { togglePlayback } from '../../../signals/transportSignals';
+import { type Track } from '../../../types/track';
 import PlasmaPlayhead from './PlasmaPlayhead';
 import './Scrubber.css';
 import { useScrubber } from './useScrubber';
@@ -12,11 +13,12 @@ type ScrubberProps = PropsWithChildren<{
   drawerHeight: number;
   isMixerOpen: boolean;
   pixelsPerSecond: number;
+  tracks: Track[];
 }>;
 
 const Scrubber = (props: ScrubberProps) => {
   useSignals();
-  const { drawerHeight, isMixerOpen, pixelsPerSecond } = props;
+  const { drawerHeight, isMixerOpen, pixelsPerSecond, tracks } = props;
 
   const {
     timelineScrollRef,
@@ -30,7 +32,7 @@ const Scrubber = (props: ScrubberProps) => {
     handleWheel,
     handleTouchMove,
     handleStopAndRewind,
-  } = useScrubber({ drawerHeight, isMixerOpen, pixelsPerSecond });
+  } = useScrubber({ drawerHeight, isMixerOpen, pixelsPerSecond, tracks });
 
   const handleTogglePlayback = () => {
     togglePlayback();

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -13,6 +13,7 @@ const defaultProps = {
   drawerHeight: 0,
   isMixerOpen: false,
   pixelsPerSecond: 200,
+  tracks: [] as import('../../../../types/track').Track[],
 };
 
 afterEach(() => {
@@ -114,6 +115,9 @@ it('feeds plasma renderer with loudness during playback', () => {
   vi.spyOn(audioService.mixer, 'getCombinedFrequencyData').mockReturnValue(
     null,
   );
+  vi.spyOn(audioService.mixer, 'getActiveTrackFrequencyData').mockReturnValue(
+    [],
+  );
 
   let rafCallback: FrameRequestCallback = () => {};
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -139,6 +143,9 @@ it('does not stop playback at end of scroll during recording', () => {
   vi.spyOn(audioService.mixer, 'getLoudness').mockReturnValue(0);
   vi.spyOn(audioService.mixer, 'getCombinedFrequencyData').mockReturnValue(
     null,
+  );
+  vi.spyOn(audioService.mixer, 'getActiveTrackFrequencyData').mockReturnValue(
+    [],
   );
 
   let rafCallback: FrameRequestCallback = () => {};

--- a/src/components/workstation/scrubber/__tests__/plasmaRenderer.test.ts
+++ b/src/components/workstation/scrubber/__tests__/plasmaRenderer.test.ts
@@ -170,7 +170,7 @@ describe('spawnMistParticles', () => {
     const state = createPlasmaState();
     const intensities = new Float32Array(10).fill(1.0);
 
-    spawnMistParticles(state, 120, 10, intensities, 0.01);
+    spawnMistParticles(state, 120, 10, intensities, [], 0.01);
 
     expect(state.mistParticles).toHaveLength(0);
   });
@@ -194,7 +194,7 @@ describe('spawnMistParticles', () => {
     }
     const intensities = new Float32Array(10).fill(1.0);
 
-    spawnMistParticles(state, 120, 10, intensities, 1.0);
+    spawnMistParticles(state, 120, 10, intensities, [], 1.0);
 
     expect(state.mistParticles).toHaveLength(150);
   });
@@ -203,7 +203,7 @@ describe('spawnMistParticles', () => {
     const state = createPlasmaState();
     const intensities = new Float32Array(100).fill(1.0);
 
-    spawnMistParticles(state, 120, 100, intensities, 1.0);
+    spawnMistParticles(state, 120, 100, intensities, [], 1.0);
 
     // At max loudness and intensity, most spawn attempts should succeed
     expect(state.mistParticles.length).toBeGreaterThan(0);

--- a/src/components/workstation/scrubber/plasmaRenderer.ts
+++ b/src/components/workstation/scrubber/plasmaRenderer.ts
@@ -54,14 +54,8 @@ const MIST_SIZE_MAX = 18;
 const MIST_VERTICAL_WANDER = 8;
 const MIST_DECELERATION = 0.5;
 
-// Mist color palette interpolated by vertical position (frequency band)
-const MIST_COLORS: [number, number, number][] = [
-  [130, 40, 255], // Bass: deep purple
-  [60, 120, 255], // Low-mid: blue
-  [0, 210, 255], // Mid: cyan
-  [100, 255, 200], // High-mid: teal
-  [255, 180, 255], // High: pink
-];
+// Default mist color when no track is dominant (cyan-blue)
+const MIST_DEFAULT_COLOR: [number, number, number] = [100, 200, 255];
 
 // --- Log-frequency mapping cache ---
 
@@ -82,6 +76,13 @@ function getLogMapping(binCount: number): {
 }
 
 // --- Types ---
+
+export type TrackFrequencyInput = {
+  r: number;
+  g: number;
+  b: number;
+  data: Float32Array;
+};
 
 export type EtchMark = {
   scrollPx: number;
@@ -199,18 +200,33 @@ export function updateSparks(state: PlasmaState, deltaTime: number): void {
 
 // --- Mist management ---
 
-function getMistColor(normalizedY: number): [number, number, number] {
-  // normalizedY: 0 = top (high freq), 1 = bottom (low freq)
-  const bandIndex = normalizedY * (MIST_COLORS.length - 1);
-  const lower = Math.floor(bandIndex);
-  const upper = Math.min(MIST_COLORS.length - 1, lower + 1);
-  const t = bandIndex - lower;
+type TrackMistInput = {
+  r: number;
+  g: number;
+  b: number;
+  intensities: Float32Array;
+};
 
-  return [
-    MIST_COLORS[lower][0] + t * (MIST_COLORS[upper][0] - MIST_COLORS[lower][0]),
-    MIST_COLORS[lower][1] + t * (MIST_COLORS[upper][1] - MIST_COLORS[lower][1]),
-    MIST_COLORS[lower][2] + t * (MIST_COLORS[upper][2] - MIST_COLORS[lower][2]),
-  ];
+function getDominantTrackColor(
+  trackInputs: TrackMistInput[],
+  rowIndex: number,
+): [number, number, number] {
+  let maxIntensity = 0;
+  let r = MIST_DEFAULT_COLOR[0];
+  let g = MIST_DEFAULT_COLOR[1];
+  let b = MIST_DEFAULT_COLOR[2];
+
+  for (const track of trackInputs) {
+    const intensity = track.intensities[rowIndex] || 0;
+    if (intensity > maxIntensity) {
+      maxIntensity = intensity;
+      r = track.r;
+      g = track.g;
+      b = track.b;
+    }
+  }
+
+  return [r, g, b];
 }
 
 export function spawnMistParticles(
@@ -218,6 +234,7 @@ export function spawnMistParticles(
   centerX: number,
   height: number,
   intensities: Float32Array,
+  trackMistInputs: TrackMistInput[],
   loudness: number,
 ): void {
   if (state.mistParticles.length >= MIST_MAX_PARTICLES) return;
@@ -232,20 +249,19 @@ export function spawnMistParticles(
 
     if (Math.random() > intensity * loudness * MIST_SPAWN_PROBABILITY) continue;
 
-    const direction = Math.random() > 0.5 ? 1 : -1;
+    // Drift right-to-left, following the timeline scroll direction
     const speed =
       MIST_DRIFT_SPEED_MIN +
       Math.random() * (MIST_DRIFT_SPEED_MAX - MIST_DRIFT_SPEED_MIN);
     const life =
       MIST_LIFE_MIN + Math.random() * (MIST_LIFE_MAX - MIST_LIFE_MIN);
     const size = MIST_SIZE_MIN + intensity * (MIST_SIZE_MAX - MIST_SIZE_MIN);
-    const normalizedY = y / height;
-    const [r, g, b] = getMistColor(normalizedY);
+    const [r, g, b] = getDominantTrackColor(trackMistInputs, rowIndex);
 
     state.mistParticles.push({
       x: centerX + (Math.random() - 0.5) * 4,
       y,
-      vx: direction * speed * (0.7 + intensity * 0.3),
+      vx: -speed * (0.7 + intensity * 0.3),
       vy: (Math.random() - 0.5) * MIST_VERTICAL_WANDER,
       life,
       maxLife: life,
@@ -589,10 +605,11 @@ export function renderPlasmaFrame(
   playheadScreenX: number,
   now: number,
   deltaTime: number,
+  trackFrequencyInputs: TrackFrequencyInput[],
 ): void {
   ctx.clearRect(0, 0, canvasWidth, height);
 
-  // State updates
+  // State updates — beat detection and glow react to the master loudness only
   const isBeat = updateBeatDetection(state, loudness, deltaTime);
   if (isBeat) {
     spawnSparks(state, playheadScreenX, height, loudness);
@@ -601,11 +618,28 @@ export function renderPlasmaFrame(
   updateSparks(state, deltaTime);
   pruneEtchMarks(state, now);
 
-  // Build per-row frequency intensities
+  // Build per-row frequency intensities from combined master data (for beam)
   const intensities = getFrequencyIntensities(frequencyData, height);
 
-  // Spawn and update mist particles (frequency-responsive smoke)
-  spawnMistParticles(state, playheadScreenX, height, intensities, loudness);
+  // Build per-track intensities for mist coloring
+  const trackMistInputs: TrackMistInput[] = trackFrequencyInputs.map(
+    (input) => ({
+      r: input.r,
+      g: input.g,
+      b: input.b,
+      intensities: getFrequencyIntensities(input.data, height),
+    }),
+  );
+
+  // Spawn and update mist particles — colored by dominant track per frequency band
+  spawnMistParticles(
+    state,
+    playheadScreenX,
+    height,
+    intensities,
+    trackMistInputs,
+    loudness,
+  );
   updateMistParticles(state, deltaTime);
 
   // Pulsation — beam breathes with slow and fast rhythms

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -14,12 +14,15 @@ import {
   stopAndRewindPlayback,
   transportTime,
 } from '../../../signals/transportSignals';
+import { type Track } from '../../../types/track';
 import { type PlasmaPlayheadHandle } from './PlasmaPlayhead';
+import { type TrackFrequencyInput } from './plasmaRenderer';
 
 type UseScrubberOptions = {
   drawerHeight: number;
   isMixerOpen: boolean;
   pixelsPerSecond: number;
+  tracks: Track[];
 };
 
 // Keep in sync with --timeline-margin in index.css
@@ -30,6 +33,7 @@ export function useScrubber({
   drawerHeight,
   isMixerOpen,
   pixelsPerSecond,
+  tracks,
 }: UseScrubberOptions) {
   const playing = isPlaying.value;
 
@@ -44,6 +48,8 @@ export function useScrubber({
   const plasmaRef = useRef<PlasmaPlayheadHandle>(null);
   const isProgrammaticScrollRef = useRef(false);
   const shouldResumeRef = useRef(false);
+  const tracksRef = useRef(tracks);
+  tracksRef.current = tracks;
 
   // Keep plasma canvas height in sync with the cursor container
   useLayoutEffect(() => {
@@ -92,8 +98,21 @@ export function useScrubber({
         loudnessSignal.value = currentLoudness;
 
         const frequencyData = audioService.mixer.getCombinedFrequencyData();
+        const perTrackData = audioService.mixer.getActiveTrackFrequencyData();
+        const trackFrequencyInputs: TrackFrequencyInput[] = perTrackData.map(
+          ({ trackId, data }) => {
+            const track = tracksRef.current.find((t) => t.trackId === trackId);
+            const color = track?.color ?? { r: 100, g: 200, b: 255 };
+            return { r: color.r, g: color.g, b: color.b, data };
+          },
+        );
         const scrollLeft = timelineScrollRef.current?.scrollLeft ?? 0;
-        plasmaRef.current?.render(frequencyData, currentLoudness, scrollLeft);
+        plasmaRef.current?.render(
+          frequencyData,
+          currentLoudness,
+          scrollLeft,
+          trackFrequencyInputs,
+        );
 
         // Skip end-of-scroll detection while recording — the recording
         // spectrogram grows its container width progressively, so scrollWidth

--- a/src/services/Mixer.ts
+++ b/src/services/Mixer.ts
@@ -46,6 +46,19 @@ class Mixer {
     return this.audioChannelRepository.get(trackId)?.getFrequencyData();
   }
 
+  getActiveTrackFrequencyData(): { trackId: string; data: Float32Array }[] {
+    const channels = this.audioChannelRepository.getAll();
+    const hasSoloChannels = this.hasSoloChannels();
+    const result: { trackId: string; data: Float32Array }[] = [];
+
+    for (const channel of channels) {
+      if (this.isChannelMuted(channel, hasSoloChannels)) continue;
+      result.push({ trackId: channel.id, data: channel.getFrequencyData() });
+    }
+
+    return result;
+  }
+
   getCombinedFrequencyData(): Float32Array | null {
     const channels = this.audioChannelRepository.getAll();
     const hasSoloChannels = this.hasSoloChannels();


### PR DESCRIPTION
Mist particles now take the color of whichever audio track is loudest
in their frequency band instead of using a fixed palette. Each track's
FFT data is individually mapped to per-row intensities; the track with
the highest energy at a given row determines the particle color.

Mist drift direction is locked to right-to-left to follow the timeline
scroll. Beat detection, beam glow, and pulsation remain driven by the
combined master loudness — only the mist reacts per-track.

https://claude.ai/code/session_011p2XWd1KG8UGbmZ9YxS3Pb