### PR TITLE
Fix static spectrogram frequency bin overflow in log mapping

### DIFF
--- a/src/services/OfflineAnalyser.ts
+++ b/src/services/OfflineAnalyser.ts
@@ -1,4 +1,7 @@
-import { createLogFrequencyMapping } from './logFrequencyMapping';
+import {
+  applyLogFrequencyMapping,
+  createLogFrequencyMapping,
+} from './logFrequencyMapping';
 
 export type SpectrogramData = {
   frequencyFrames: Uint8Array[];
@@ -148,17 +151,8 @@ class OfflineAnalyser {
         mergedData[lowBinCount + i - highBinStart] = highFrames[f][i];
       }
 
-      for (let i = 0; i < mergedBinCount; i++) {
-        tempBuffer[i] = mergedData[i];
-      }
-      for (let i = 0; i < mergedBinCount; i++) {
-        const pool = logMapping[i];
-        let max = tempBuffer[pool[0]];
-        for (let j = 1; j < pool.length; j++) {
-          if (tempBuffer[pool[j]] > max) max = tempBuffer[pool[j]];
-        }
-        mergedData[i] = max;
-      }
+      tempBuffer.set(mergedData);
+      applyLogFrequencyMapping(tempBuffer, logMapping, mergedData);
       frequencyFrames.push(new Uint8Array(mergedData));
     }
 
@@ -328,18 +322,12 @@ class OfflineAnalyser {
     frequencyData: Uint8Array,
     frequencyMapping: number[][],
   ) {
-    for (let i = 0, binCount = this.frequencyBinCount; i < binCount; i++) {
-      this.frequencyDataCopy[i] = frequencyData[i];
-    }
-    for (let i = 0, binCount = this.frequencyBinCount; i < binCount; i++) {
-      const pool = frequencyMapping[i];
-      let max = this.frequencyDataCopy[pool[0]];
-      for (let j = 1, poolCount = pool.length; j < poolCount; j++) {
-        if (this.frequencyDataCopy[pool[j]] > max)
-          max = this.frequencyDataCopy[pool[j]];
-      }
-      frequencyData[i] = max;
-    }
+    this.frequencyDataCopy.set(frequencyData);
+    applyLogFrequencyMapping(
+      this.frequencyDataCopy,
+      frequencyMapping,
+      frequencyData,
+    );
     return frequencyData;
   }
 }

--- a/src/services/OfflineAnalyser.ts
+++ b/src/services/OfflineAnalyser.ts
@@ -152,11 +152,12 @@ class OfflineAnalyser {
         tempBuffer[i] = mergedData[i];
       }
       for (let i = 0; i < mergedBinCount; i++) {
-        mergedData[i] = 0;
         const pool = logMapping[i];
-        for (let j = 0; j < pool.length; j++) {
-          mergedData[i] += tempBuffer[pool[j]];
+        let max = tempBuffer[pool[0]];
+        for (let j = 1; j < pool.length; j++) {
+          if (tempBuffer[pool[j]] > max) max = tempBuffer[pool[j]];
         }
+        mergedData[i] = max;
       }
       frequencyFrames.push(new Uint8Array(mergedData));
     }
@@ -331,14 +332,13 @@ class OfflineAnalyser {
       this.frequencyDataCopy[i] = frequencyData[i];
     }
     for (let i = 0, binCount = this.frequencyBinCount; i < binCount; i++) {
-      frequencyData[i] = 0;
-      for (
-        let j = 0, poolCount = frequencyMapping[i].length;
-        j < poolCount;
-        j++
-      ) {
-        frequencyData[i] += this.frequencyDataCopy[frequencyMapping[i][j]];
+      const pool = frequencyMapping[i];
+      let max = this.frequencyDataCopy[pool[0]];
+      for (let j = 1, poolCount = pool.length; j < poolCount; j++) {
+        if (this.frequencyDataCopy[pool[j]] > max)
+          max = this.frequencyDataCopy[pool[j]];
       }
+      frequencyData[i] = max;
     }
     return frequencyData;
   }

--- a/src/services/__tests__/OfflineAnalyser.test.ts
+++ b/src/services/__tests__/OfflineAnalyser.test.ts
@@ -668,11 +668,64 @@ describe('analyseToFrames (script processor fallback)', () => {
 });
 
 describe('analyseToFrames merge logic', () => {
+  it('uses maximum when pooling bins in log frequency mapping', async () => {
+    const FILL_VALUE = 200;
+    const contexts: IndependentMockContext[] = [];
+    let contextIndex = 0;
+
+    vi.stubGlobal(
+      'OfflineAudioContext',
+      vi.fn().mockImplementation(function () {
+        const ctx = createIndependentMockContext(true);
+        if (contextIndex > 0) {
+          ctx.createAnalyser = vi.fn().mockImplementation(() => ({
+            _fftSize: 1024,
+            get fftSize() {
+              return this._fftSize;
+            },
+            set fftSize(value: number) {
+              this._fftSize = value;
+            },
+            get frequencyBinCount() {
+              return this._fftSize / 2;
+            },
+            smoothingTimeConstant: 0,
+            minDecibels: -80,
+            maxDecibels: -30,
+            numberOfOutputs: 1,
+            getByteFrequencyData: vi
+              .fn()
+              .mockImplementation((arr: Uint8Array) => {
+                arr.fill(FILL_VALUE);
+              }),
+            connect: vi.fn(),
+          }));
+        }
+        contextIndex++;
+        contexts.push(ctx);
+        return ctx;
+      }),
+    );
+
+    const sampleRate = 44100;
+    const audioBuffer = createAudioBuffer(0.05, sampleRate);
+    const analyser = new OfflineAnalyser(audioBuffer);
+
+    const result = await analyser.analyseToFrames();
+
+    const frame = result.frequencyFrames[0];
+    expect(frame).toBeDefined();
+
+    // Every output bin should be exactly FILL_VALUE (the max of its pooled
+    // inputs), not a sum that overflows Uint8Array.
+    for (let i = 0; i < MERGED_BIN_COUNT; i++) {
+      expect(frame[i]).toBe(FILL_VALUE);
+    }
+  });
+
   it('merges low-frequency bins from low band and high-frequency bins from high band', async () => {
-    // Use value 1 for low band to avoid Uint8Array overflow when log-mapping
-    // pools multiple bins (poolSize × value must stay ≤ 255)
-    const LOW_VALUE = 1;
-    const HIGH_VALUE = 2;
+    const LOW_VALUE = 100;
+    const HIGH_VALUE = 200;
     const contexts: IndependentMockContext[] = [];
     let contextIndex = 0;
 
@@ -728,7 +781,7 @@ describe('analyseToFrames merge logic', () => {
     expect(frame[MERGED_BIN_COUNT - 1]).toBeGreaterThan(0);
 
     // Verify the split: output bins mapped entirely from the low band
-    // should be non-zero (sum of LOW_VALUE=1 per pooled bin)
+    // should carry the low band value
     const logMapping = createLogFrequencyMapping(MERGED_BIN_COUNT);
     const lowBinCount = 301; // at 44100 Hz
     const firstHighOutputBin = logMapping.findIndex((pool) =>

--- a/src/services/__tests__/spectrogram.worker.test.ts
+++ b/src/services/__tests__/spectrogram.worker.test.ts
@@ -353,10 +353,62 @@ describe('analyseToFrames', () => {
     }
   });
 
+  it('uses maximum when pooling bins in log frequency mapping', async () => {
+    const FILL_VALUE = 200;
+    const contexts: MockOfflineContext[] = [];
+
+    vi.stubGlobal(
+      'OfflineAudioContext',
+      vi.fn().mockImplementation(function () {
+        const ctx = createMockOfflineContext();
+        ctx.createAnalyser = vi.fn().mockImplementation(() => ({
+          _fftSize: 0,
+          get fftSize() {
+            return this._fftSize;
+          },
+          set fftSize(value: number) {
+            this._fftSize = value;
+          },
+          get frequencyBinCount() {
+            return this._fftSize / 2;
+          },
+          smoothingTimeConstant: 0,
+          minDecibels: -80,
+          maxDecibels: -30,
+          numberOfOutputs: 1,
+          getByteFrequencyData: vi
+            .fn()
+            .mockImplementation((arr: Uint8Array) => {
+              arr.fill(FILL_VALUE);
+            }),
+          connect: vi.fn(),
+        }));
+        contexts.push(ctx);
+        return ctx;
+      }),
+    );
+
+    const sampleRate = 44100;
+    const { mergedBinCount } = calculateMergeParams(sampleRate);
+    const length = Math.ceil(0.05 * sampleRate);
+    const result = await analyseToFrames(
+      [new Float32Array(length)],
+      sampleRate,
+      length,
+    );
+
+    const frame = result.frequencyFrames[0];
+    expect(frame).toBeDefined();
+
+    // Every output bin should be exactly FILL_VALUE (the max of its pooled
+    // inputs), not a sum that overflows Uint8Array.
+    for (let i = 0; i < mergedBinCount; i++) {
+      expect(frame[i]).toBe(FILL_VALUE);
+    }
+  });
+
   it('merges low-frequency bins from lowpass and high-frequency bins from highpass', async () => {
-    // Use value 1 for low band to avoid Uint8Array overflow when log-mapping
-    // pools multiple bins (poolSize × value must stay ≤ 255)
-    const LOW_VALUE = 1;
+    const LOW_VALUE = 100;
     const HIGH_VALUE = 200;
     const contexts: MockOfflineContext[] = [];
     let contextIndex = 0;
@@ -413,7 +465,7 @@ describe('analyseToFrames', () => {
     expect(frame[mergedBinCount - 1]).toBeGreaterThan(0);
 
     // Verify the split: output bins mapped entirely from the low band
-    // should be non-zero (sum of LOW_VALUE=1 per pooled bin)
+    // should carry the low band value
     const logMapping = createLogFrequencyMapping(mergedBinCount);
     const firstHighOutputBin = logMapping.findIndex((pool) =>
       pool.some((idx) => idx >= lowBinCount),

--- a/src/services/logFrequencyMapping.ts
+++ b/src/services/logFrequencyMapping.ts
@@ -44,9 +44,9 @@ export function createLogFrequencyMapping(
  * is kept, preserving the strongest frequency component in each band.
  */
 export function applyLogFrequencyMapping(
-  input: Float32Array,
+  input: Float32Array | Uint8Array,
   mapping: number[][],
-  output: Float32Array,
+  output: Float32Array | Uint8Array,
 ): void {
   for (let i = 0; i < mapping.length; i++) {
     const pool = mapping[i];

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -1,5 +1,8 @@
 import { type TrackColor } from '../types/track';
-import { createLogFrequencyMapping } from './logFrequencyMapping';
+import {
+  applyLogFrequencyMapping,
+  createLogFrequencyMapping,
+} from './logFrequencyMapping';
 import { type SpectrogramData } from './OfflineAnalyser';
 import { renderTiles } from './SpectrogramTileRenderer';
 
@@ -175,17 +178,8 @@ export async function analyseToFrames(
       mergedData[lowBinCount + i - highBinStart] = highFrames[f][i];
     }
 
-    for (let i = 0; i < mergedBinCount; i++) {
-      tempBuffer[i] = mergedData[i];
-    }
-    for (let i = 0; i < mergedBinCount; i++) {
-      const pool = logMapping[i];
-      let max = tempBuffer[pool[0]];
-      for (let j = 1; j < pool.length; j++) {
-        if (tempBuffer[pool[j]] > max) max = tempBuffer[pool[j]];
-      }
-      mergedData[i] = max;
-    }
+    tempBuffer.set(mergedData);
+    applyLogFrequencyMapping(tempBuffer, logMapping, mergedData);
     frequencyFrames.push(new Uint8Array(mergedData));
   }
 

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -179,11 +179,12 @@ export async function analyseToFrames(
       tempBuffer[i] = mergedData[i];
     }
     for (let i = 0; i < mergedBinCount; i++) {
-      mergedData[i] = 0;
       const pool = logMapping[i];
-      for (let j = 0; j < pool.length; j++) {
-        mergedData[i] += tempBuffer[pool[j]];
+      let max = tempBuffer[pool[0]];
+      for (let j = 1; j < pool.length; j++) {
+        if (tempBuffer[pool[j]] > max) max = tempBuffer[pool[j]];
       }
+      mergedData[i] = max;
     }
     frequencyFrames.push(new Uint8Array(mergedData));
   }


### PR DESCRIPTION
The log frequency mapping pooled multiple input bins using summation
(+=) on Uint8Array values. When high-frequency output bins pooled
several inputs (e.g. 3 bins at 200 each = 600), the result overflowed
mod 256, corrupting the rendered spectrogram. Changed to use maximum
instead, matching the live recording spectrogram (applyLogFrequencyMapping).

Fixed in three places: OfflineAnalyser.analyseToFrames,
spectrogram.worker.analyseToFrames, and OfflineAnalyser.transformFrequencies.

https://claude.ai/code/session_01Bc4AQdzBhe9UScsCT33y12