### PR TITLE
Fix e2e selector conflicts from toolbar rewind button

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -350,8 +350,8 @@ test.describe('Scrubber', () => {
     await page.waitForTimeout(400);
     await expect(rewindButton).not.toHaveClass(/scrubber__rewind--hidden/);
 
-    // Click the rewind button
-    await page.getByTitle('Rewind').click();
+    // Click the scrubber's rewind button (scoped to avoid the toolbar's)
+    await page.locator('.scrubber__rewind').getByTitle('Rewind').click();
 
     // Rewind button should hide (transport time reset to 0 → scrollLeft = 0)
     await expect(rewindButton).toHaveClass(/scrubber__rewind--hidden/);
@@ -378,11 +378,11 @@ test.describe('Rewind control', () => {
     // Pause
     await page.getByTitle('Pause').click();
 
-    // The rewind button should become visible after scrolling
-    const rewindButton = page.getByTitle('Rewind');
+    // The toolbar rewind button (scoped to avoid the scrubber's)
+    const rewindButton = page.locator('.toolbar').getByTitle('Rewind');
 
-    // Click rewind if visible (scrolled position)
-    if (await rewindButton.isVisible()) {
+    // Click rewind if enabled
+    if (await rewindButton.isEnabled()) {
       await rewindButton.click();
 
       // Should stop playback and rewind

--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -7,7 +7,9 @@ test.describe('Project page', () => {
 
   test.describe('header', () => {
     test('displays a back button', async ({ page }) => {
-      await expect(page.getByRole('button', { name: 'Back' })).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Back', exact: true })
+      ).toBeVisible();
     });
 
     test('back button navigates to the home page', async ({ page }) => {
@@ -15,7 +17,7 @@ test.describe('Project page', () => {
       await page.goto('/');
       await page.getByRole('button', { name: 'Create Project' }).click();
       await expect(page).toHaveURL('/project');
-      await page.getByRole('button', { name: 'Back' }).click();
+      await page.getByRole('button', { name: 'Back', exact: true }).click();
       await expect(page).toHaveURL('/');
     });
 


### PR DESCRIPTION
## Summary
- Fix 4 failing e2e tests caused by the new toolbar rewind button conflicting with existing selectors
- `project.spec.ts`: Use `{ name: 'Back', exact: true }` to avoid matching the `StepBackwardOutlined` icon's accessible name "step-backward" (contains "back" as substring)
- `audio.spec.ts`: Scope `getByTitle('Rewind')` to `.scrubber__rewind` and `.toolbar` to disambiguate the two rewind buttons

## Test plan
- [x] All 517 unit tests pass
- [x] All 36 e2e tests in `project.spec.ts` and `audio.spec.ts` pass (including the 4 previously failing)
- [x] Build and lint pass

https://claude.ai/code/session_01WV82AdwaZRPHYwoyZYSxgH