### PR TITLE
Refactor services to separate reactive and non-reactive APIs

### DIFF
--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 
-import { focusedTracks } from '../../../signals/focusSignals';
+import { getFocusedTracks } from '../../../signals/focusSignals';
 import AudioService from '../../../services/AudioService';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
@@ -155,5 +155,5 @@ it('focuses track when volume slider is clicked without moving', () => {
   const volumeSlider = container.querySelector('.channel__volume')!;
   fireEvent.pointerDown(volumeSlider);
 
-  expect(focusedTracks.value).toContain('track-1');
+  expect(getFocusedTracks()).toContain('track-1');
 });

--- a/src/components/workstation/__tests__/Toolbar.test.tsx
+++ b/src/components/workstation/__tests__/Toolbar.test.tsx
@@ -97,7 +97,7 @@ it('toggles playback when play/pause button is clicked', () => {
   const playButton = getByTitle('Play');
   fireEvent.click(playButton);
 
-  expect(playbackService.isPlaying.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('toggles mixer when mixer show/hide is clicked', () => {

--- a/src/components/workstation/__tests__/ZoomControls.test.tsx
+++ b/src/components/workstation/__tests__/ZoomControls.test.tsx
@@ -3,7 +3,8 @@ import AudioService from '../../../services/AudioService';
 import {
   MAX_PIXELS_PER_SECOND,
   MIN_PIXELS_PER_SECOND,
-  pixelsPerSecond,
+  getPixelsPerSecond,
+  setZoom,
   resetWorkstationSignals,
 } from '../../../signals/workstationSignals';
 import ZoomControls from '../ZoomControls';
@@ -26,32 +27,32 @@ it('renders zoom in and zoom out buttons', () => {
 });
 
 it('increases zoom when zoom in is clicked', () => {
-  const before = pixelsPerSecond.value;
+  const before = getPixelsPerSecond();
   const { getByTitle } = render(<ZoomControls />);
 
   fireEvent.click(getByTitle('Zoom in'));
 
-  expect(pixelsPerSecond.value).toBeGreaterThan(before);
+  expect(getPixelsPerSecond()).toBeGreaterThan(before);
 });
 
 it('decreases zoom when zoom out is clicked', () => {
-  const before = pixelsPerSecond.value;
+  const before = getPixelsPerSecond();
   const { getByTitle } = render(<ZoomControls />);
 
   fireEvent.click(getByTitle('Zoom out'));
 
-  expect(pixelsPerSecond.value).toBeLessThan(before);
+  expect(getPixelsPerSecond()).toBeLessThan(before);
 });
 
 it('disables zoom in at maximum zoom', () => {
-  pixelsPerSecond.value = MAX_PIXELS_PER_SECOND;
+  setZoom(MAX_PIXELS_PER_SECOND);
   const { getByTitle } = render(<ZoomControls />);
 
   expect(getByTitle('Zoom in')).toBeDisabled();
 });
 
 it('disables zoom out at minimum zoom', () => {
-  pixelsPerSecond.value = MIN_PIXELS_PER_SECOND;
+  setZoom(MIN_PIXELS_PER_SECOND);
   const { getByTitle } = render(<ZoomControls />);
 
   expect(getByTitle('Zoom out')).toBeDisabled();

--- a/src/components/workstation/__tests__/useChannelControls.test.ts
+++ b/src/components/workstation/__tests__/useChannelControls.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
-import { focusedTracks } from '../../../signals/focusSignals';
+import { getFocusedTracks } from '../../../signals/focusSignals';
 import AudioService from '../../../services/AudioService';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { useChannelControls } from '../useChannelControls';
@@ -31,7 +31,7 @@ describe('useChannelControls', () => {
 
       result.current.updateVolume(80);
 
-      expect(focusedTracks.value).toContain('track-1');
+      expect(getFocusedTracks()).toContain('track-1');
     });
 
     it('keeps track focused after volume stops changing', () => {
@@ -41,7 +41,7 @@ describe('useChannelControls', () => {
 
       vi.advanceTimersByTime(250);
 
-      expect(focusedTracks.value).toContain('track-1');
+      expect(getFocusedTracks()).toContain('track-1');
     });
   });
 
@@ -52,7 +52,7 @@ describe('useChannelControls', () => {
       result.current.updateVolume(80);
       result.current.commitVolume();
 
-      expect(focusedTracks.value).not.toContain('track-1');
+      expect(getFocusedTracks()).not.toContain('track-1');
     });
   });
 });

--- a/src/components/workstation/__tests__/useCountIn.test.ts
+++ b/src/components/workstation/__tests__/useCountIn.test.ts
@@ -61,8 +61,8 @@ it('sets isPlaying and isRecording signals during count-in with full lead-in', a
 
   await act(async () => {});
 
-  expect(playbackService.isPlaying.value).toBe(true);
-  expect(recordingService.isRecording.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
+  expect(recordingService.isRecording).toBe(true);
 });
 
 it('returns beat numbers 1 through 4', async () => {
@@ -144,8 +144,8 @@ it('cleans up microphone and signals when cancelled', async () => {
   rerender({ active: false });
 
   expect(closeMicSpy).toHaveBeenCalledOnce();
-  expect(playbackService.isPlaying.value).toBe(false);
-  expect(recordingService.isRecording.value).toBe(false);
+  expect(playbackService.isPlaying).toBe(false);
+  expect(recordingService.isRecording).toBe(false);
   expect(onComplete).not.toHaveBeenCalled();
 });
 
@@ -198,9 +198,9 @@ it('does not start playback when transport is at position 0', async () => {
 
   // At position 0, there is no lead-in audio available.
   // Playback should not start during count-in.
-  expect(playbackService.isPlaying.value).toBe(false);
-  expect(recordingService.isRecording.value).toBe(true);
-  expect(recordingService.isCountingIn.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(false);
+  expect(recordingService.isRecording).toBe(true);
+  expect(recordingService.isCountingIn).toBe(true);
 });
 
 it('delays playback start when lead-in is shorter than count-in duration', async () => {
@@ -217,14 +217,14 @@ it('delays playback start when lead-in is shorter than count-in duration', async
   // Playback should not start immediately — it should be delayed
   // by (2.0 - 0.5) = 1.5s so the transport arrives at 0.5s when
   // the count-in ends
-  expect(playbackService.isPlaying.value).toBe(false);
+  expect(playbackService.isPlaying).toBe(false);
 
   // Advance past the delay (1500ms)
   await act(async () => {
     vi.advanceTimersByTime(1500);
   });
 
-  expect(playbackService.isPlaying.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('seeks transport back by count-in duration before starting playback', async () => {
@@ -265,7 +265,7 @@ it('sets isCountingIn signal during count-in', async () => {
 
   await act(async () => {});
 
-  expect(recordingService.isCountingIn.value).toBe(true);
+  expect(recordingService.isCountingIn).toBe(true);
 });
 
 it('clears isCountingIn signal after count-in completes', async () => {
@@ -283,7 +283,7 @@ it('clears isCountingIn signal after count-in completes', async () => {
     });
   }
 
-  expect(recordingService.isCountingIn.value).toBe(false);
+  expect(recordingService.isCountingIn).toBe(false);
 });
 
 it('clears isCountingIn signal when cancelled', async () => {
@@ -295,9 +295,9 @@ it('clears isCountingIn signal when cancelled', async () => {
   );
 
   await act(async () => {});
-  expect(recordingService.isCountingIn.value).toBe(true);
+  expect(recordingService.isCountingIn).toBe(true);
 
   rerender({ active: false });
 
-  expect(recordingService.isCountingIn.value).toBe(false);
+  expect(recordingService.isCountingIn).toBe(false);
 });

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -39,11 +39,11 @@ describe('useSpacebarPlaybackToggle', () => {
   it('toggles playback with spacebar', () => {
     renderHook(() => useSpacebarPlaybackToggle());
 
-    expect(playbackService.isPlaying.value).toBe(false);
+    expect(playbackService.isPlaying).toBe(false);
 
     fireEvent.keyUp(window, { key: ' ', code: 'Space' });
 
-    expect(playbackService.isPlaying.value).toBe(true);
+    expect(playbackService.isPlaying).toBe(true);
   });
 
   it('does not toggle playback with spacebar while recording', () => {
@@ -54,7 +54,7 @@ describe('useSpacebarPlaybackToggle', () => {
 
     fireEvent.keyUp(window, { key: ' ', code: 'Space' });
 
-    expect(playbackService.isPlaying.value).toBe(false);
+    expect(playbackService.isPlaying).toBe(false);
   });
 });
 
@@ -124,7 +124,7 @@ describe('useMicrophone', () => {
     rerender({ isRec: false });
     await act(async () => {});
 
-    expect(recordingService.recordingState.value).toBe('idle');
+    expect(recordingService.recordingState).toBe('idle');
   });
 
   it('does not start playback when recording starts', async () => {
@@ -135,7 +135,7 @@ describe('useMicrophone', () => {
     await act(async () => {});
 
     // Count-in handles playback start, not useMicrophone
-    expect(playbackService.isPlaying.value).toBe(false);
+    expect(playbackService.isPlaying).toBe(false);
   });
 
   it('pauses at current position when recording stops', async () => {
@@ -150,7 +150,7 @@ describe('useMicrophone', () => {
     rerender({ isRec: false });
     await act(async () => {});
 
-    expect(playbackService.isPlaying.value).toBe(false);
-    expect(playbackService.transportTime.value).toBe(5.0);
+    expect(playbackService.isPlaying).toBe(false);
+    expect(playbackService.transportTime).toBe(5.0);
   });
 });

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -34,7 +34,7 @@ it('hides rewind button at start of playback', () => {
 });
 
 it('shows rewind button when playback has progressed', () => {
-  playbackService.transportTime.value = 100;
+  playbackService.setTransportTime(100);
 
   const { getByTitle } = render(<Scrubber {...defaultProps} />);
 
@@ -48,15 +48,15 @@ it('shows rewind button when playback has progressed', () => {
 
 it('stops and rewinds playback when rewind button is clicked', () => {
   playbackService.play();
-  playbackService.transportTime.value = 5.0;
+  playbackService.setTransportTime(5.0);
 
   const { getByTitle } = render(<Scrubber {...defaultProps} />);
 
   const rewindButton = getByTitle('Rewind');
   fireEvent.click(rewindButton);
 
-  expect(playbackService.isPlaying.value).toBe(false);
-  expect(playbackService.transportTime.value).toBe(0);
+  expect(playbackService.isPlaying).toBe(false);
+  expect(playbackService.transportTime).toBe(0);
 });
 
 it('pauses playback when timeline is scrolled while playing', () => {
@@ -67,7 +67,7 @@ it('pauses playback when timeline is scrolled while playing', () => {
   const timeline = container.querySelector('.scrubber__timeline')!;
   fireEvent.scroll(timeline);
 
-  expect(playbackService.isPlaying.value).toBe(false);
+  expect(playbackService.isPlaying).toBe(false);
 });
 
 it('does not pause playback when timeline is scrolled while paused', () => {
@@ -76,7 +76,7 @@ it('does not pause playback when timeline is scrolled while paused', () => {
   const timeline = container.querySelector('.scrubber__timeline')!;
   fireEvent.scroll(timeline);
 
-  expect(playbackService.isPlaying.value).toBe(false);
+  expect(playbackService.isPlaying).toBe(false);
 });
 
 it('transforms timeline vertical scale when drawer is open', () => {
@@ -155,8 +155,8 @@ it('does not stop playback at end of scroll during recording', () => {
     rafCallback(0);
   });
 
-  expect(playbackService.isPlaying.value).toBe(true);
-  expect(playbackService.transportTime.value).toBe(1.5);
+  expect(playbackService.isPlaying).toBe(true);
+  expect(playbackService.transportTime).toBe(1.5);
 });
 
 it('does not call getLoudness when playback is stopped', () => {
@@ -181,7 +181,7 @@ it('stops recording when timeline is clicked during recording', () => {
   fireEvent.click(timeline);
 
   expect(onStopRecording).toHaveBeenCalledOnce();
-  expect(playbackService.isPlaying.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('cancels count-in when timeline is clicked during count-in', () => {
@@ -199,7 +199,7 @@ it('cancels count-in when timeline is clicked during count-in', () => {
   fireEvent.click(timeline);
 
   expect(onStopRecording).toHaveBeenCalledOnce();
-  expect(playbackService.isPlaying.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('does not pause playback when timeline is scrolled during recording', () => {
@@ -212,21 +212,21 @@ it('does not pause playback when timeline is scrolled during recording', () => {
   const timeline = container.querySelector('.scrubber__timeline')!;
   fireEvent.scroll(timeline);
 
-  expect(playbackService.isPlaying.value).toBe(true);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('does not rewind when rewind button is clicked during recording', () => {
   playbackService.play();
   recordingService.arm();
   recordingService.startRecording();
-  playbackService.transportTime.value = 5.0;
+  playbackService.setTransportTime(5.0);
 
   const { getByTitle } = render(<Scrubber {...defaultProps} />);
 
   fireEvent.click(getByTitle('Rewind'));
 
-  expect(playbackService.isPlaying.value).toBe(true);
-  expect(playbackService.transportTime.value).toBe(5.0);
+  expect(playbackService.isPlaying).toBe(true);
+  expect(playbackService.transportTime).toBe(5.0);
 });
 
 it('does not update transportTime during count-in', () => {
@@ -239,7 +239,7 @@ it('does not update transportTime during count-in', () => {
     return 1;
   });
 
-  playbackService.transportTime.value = 5.0;
+  playbackService.setTransportTime(5.0);
   playbackService.play();
   recordingService.arm();
   recordingService.startRecording();
@@ -253,5 +253,5 @@ it('does not update transportTime during count-in', () => {
 
   // transportTime should stay at the pre-count-in value, not update
   // to the current transport position (3.5) during count-in
-  expect(playbackService.transportTime.value).toBe(5.0);
+  expect(playbackService.transportTime).toBe(5.0);
 });

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -71,13 +71,13 @@ vi.mock('../../../../hooks/useAudioService', () => ({
 vi.mock('../../../../hooks/usePlaybackService', () => ({
   usePlaybackService: () => ({
     get isPlaying() {
-      return playbackService.isPlaying.value;
+      return playbackService.signals.isPlaying.value;
     },
     get transportTime() {
-      return playbackService.transportTime.value;
+      return playbackService.signals.transportTime.value;
     },
     get playbackState() {
-      return playbackService.playbackState.value;
+      return playbackService.signals.playbackState.value;
     },
     play: () => playbackService.play(),
     pause: () => playbackService.pause(),
@@ -85,12 +85,8 @@ vi.mock('../../../../hooks/usePlaybackService', () => ({
     togglePlayback: () => playbackService.togglePlayback(),
     seekTo: (t: number) => playbackService.seekTo(t),
     getEngineTime: () => playbackService.getEngineTime(),
-    setTransportTime: (t: number) => {
-      playbackService.transportTime.value = t;
-    },
-    setLoudness: (v: number) => {
-      playbackService.loudness.value = v;
-    },
+    setTransportTime: (t: number) => playbackService.setTransportTime(t),
+    setLoudness: (v: number) => playbackService.setLoudness(v),
     reset: () => playbackService.reset(),
   }),
 }));
@@ -98,16 +94,16 @@ vi.mock('../../../../hooks/usePlaybackService', () => ({
 vi.mock('../../../../hooks/useRecordingService', () => ({
   useRecordingService: () => ({
     get isRecording() {
-      return recordingService.isRecording.value;
+      return recordingService.signals.isRecording.value;
     },
     get isCountingIn() {
-      return recordingService.isCountingIn.value;
+      return recordingService.signals.isCountingIn.value;
     },
     get isActivelyRecording() {
       return recordingService.isActivelyRecording();
     },
     get recordingState() {
-      return recordingService.recordingState.value;
+      return recordingService.signals.recordingState.value;
     },
     arm: () => recordingService.arm(),
     startRecording: () => recordingService.startRecording(),
@@ -409,7 +405,7 @@ describe('recording mode', () => {
   it('reads visualization data from FrequencyVisualizer during recording', () => {
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.transportTime.value = 1.5;
+    playbackService.setTransportTime(1.5);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {
@@ -440,7 +436,7 @@ describe('recording mode', () => {
   it('offsets container by recording start time during overdub', () => {
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.transportTime.value = 5.0;
+    playbackService.setTransportTime(5.0);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {
@@ -476,7 +472,7 @@ describe('recording mode', () => {
   it('updates container width based on elapsed recording time', () => {
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.transportTime.value = 2.0;
+    playbackService.setTransportTime(2.0);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -120,7 +120,7 @@ vi.mock('../../../../hooks/useTrackService', () => ({
     retrieveStartTime: mockRetrieveStartTime,
     getSignals: (id: string) => trackService.getSignals(id),
     get mutedTracks() {
-      return trackService.mutedTracks.value;
+      return trackService.signals.mutedTracks.value;
     },
   }),
 }));

--- a/src/hooks/usePlaybackService.ts
+++ b/src/hooks/usePlaybackService.ts
@@ -19,25 +19,25 @@ export function usePlaybackService() {
   const service = useContext(AudioServiceContext).playbackService;
 
   return {
-    // --- Reactive state (getters → lazy signal subscription) ---
+    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
 
     get playbackState(): PlaybackState {
-      return service.playbackState.value;
+      return service.signals.playbackState.value;
     },
     get isPlaying(): boolean {
-      return service.isPlaying.value;
+      return service.signals.isPlaying.value;
     },
     get isStopped(): boolean {
-      return service.playbackState.value === 'stopped';
+      return service.signals.playbackState.value === 'stopped';
     },
     get transportTime(): number {
-      return service.transportTime.value;
+      return service.signals.transportTime.value;
     },
     get totalTime(): number {
-      return service.totalTime.value;
+      return service.signals.totalTime.value;
     },
     get loudness(): number {
-      return service.loudness.value;
+      return service.signals.loudness.value;
     },
 
     // --- State machine transitions ---
@@ -53,15 +53,9 @@ export function usePlaybackService() {
 
     getEngineTime: () => service.getEngineTime(),
     setEngineTime: (time: number) => service.setEngineTime(time),
-    setTransportTime: (time: number) => {
-      service.transportTime.value = time;
-    },
-    setTotalTime: (time: number) => {
-      service.totalTime.value = time;
-    },
-    setLoudness: (value: number) => {
-      service.loudness.value = value;
-    },
+    setTransportTime: (time: number) => service.setTransportTime(time),
+    setTotalTime: (time: number) => service.setTotalTime(time),
+    setLoudness: (value: number) => service.setLoudness(value),
 
     // --- Reset ---
 

--- a/src/hooks/useRecordingService.ts
+++ b/src/hooks/useRecordingService.ts
@@ -13,16 +13,16 @@ export function useRecordingService() {
   const service = useContext(AudioServiceContext).recordingService;
 
   return {
-    // --- Reactive state ---
+    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
 
     get recordingState(): RecordingState {
-      return service.recordingState.value;
+      return service.signals.recordingState.value;
     },
     get isCountingIn(): boolean {
-      return service.isCountingIn.value;
+      return service.signals.isCountingIn.value;
     },
     get isRecording(): boolean {
-      return service.isRecording.value;
+      return service.signals.isRecording.value;
     },
     get isTransportLocked(): boolean {
       return service.isTransportLocked();

--- a/src/hooks/useTrackService.ts
+++ b/src/hooks/useTrackService.ts
@@ -7,7 +7,7 @@ import { useSignals } from '@preact/signals-react/runtime';
 import { useContext } from 'react';
 import { AudioServiceContext } from './useAudioService';
 import {
-  focusedTracks as focusedTracksSignal,
+  signals as focusSignals,
   focusTrack,
   unfocusTrack,
 } from '../signals/focusSignals';
@@ -18,13 +18,13 @@ export function useTrackService() {
   const service = useContext(AudioServiceContext).trackService;
 
   return {
-    // --- Reactive state ---
+    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
 
     get mutedTracks(): TrackId[] {
-      return service.mutedTracks.value;
+      return service.signals.mutedTracks.value;
     },
     get focusedTracks(): TrackId[] {
-      return focusedTracksSignal.value;
+      return focusSignals.focusedTracks.value;
     },
 
     // --- Focus actions ---

--- a/src/hooks/useWorkstation.ts
+++ b/src/hooks/useWorkstation.ts
@@ -7,7 +7,7 @@ import { useSignals } from '@preact/signals-react/runtime';
 import {
   MAX_PIXELS_PER_SECOND,
   MIN_PIXELS_PER_SECOND,
-  pixelsPerSecond as pixelsPerSecondSignal,
+  signals as workstationSignals,
   zoomIn,
   zoomOut,
   setZoom,
@@ -17,16 +17,16 @@ export function useWorkstation() {
   useSignals();
 
   return {
-    // --- Reactive state ---
+    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
 
     get pixelsPerSecond(): number {
-      return pixelsPerSecondSignal.value;
+      return workstationSignals.pixelsPerSecond.value;
     },
     get isMaxZoom(): boolean {
-      return pixelsPerSecondSignal.value >= MAX_PIXELS_PER_SECOND;
+      return workstationSignals.pixelsPerSecond.value >= MAX_PIXELS_PER_SECOND;
     },
     get isMinZoom(): boolean {
-      return pixelsPerSecondSignal.value <= MIN_PIXELS_PER_SECOND;
+      return workstationSignals.pixelsPerSecond.value <= MIN_PIXELS_PER_SECOND;
     },
 
     // --- Actions ---

--- a/src/services/PlaybackService.ts
+++ b/src/services/PlaybackService.ts
@@ -19,48 +19,103 @@ type Transport = {
 };
 
 class PlaybackService {
-  readonly playbackState = signal<PlaybackState>('stopped');
-  readonly transportTime = signal(0);
-  readonly totalTime = signal(0);
-  readonly loudness = signal(0);
-  readonly isPlaying: ReadonlySignal<boolean>;
+  // --- Private signals (only the service writes these) ---
+
+  private readonly _playbackState = signal<PlaybackState>('stopped');
+  private readonly _transportTime = signal(0);
+  private readonly _totalTime = signal(0);
+  private readonly _loudness = signal(0);
+  private readonly _isPlaying: ReadonlySignal<boolean>;
+
+  // --- Narrow channel for reactive consumers (hooks) ---
+
+  readonly signals: {
+    readonly playbackState: ReadonlySignal<PlaybackState>;
+    readonly transportTime: ReadonlySignal<number>;
+    readonly totalTime: ReadonlySignal<number>;
+    readonly loudness: ReadonlySignal<number>;
+    readonly isPlaying: ReadonlySignal<boolean>;
+  };
 
   private transport: Transport;
 
   constructor(transport: Transport) {
     this.transport = transport;
-    this.isPlaying = computed(() => this.playbackState.value === 'playing');
+    this._isPlaying = computed(() => this._playbackState.value === 'playing');
+    this.signals = {
+      playbackState: this._playbackState,
+      transportTime: this._transportTime,
+      totalTime: this._totalTime,
+      loudness: this._loudness,
+      isPlaying: this._isPlaying,
+    };
+  }
+
+  // --- Plain getters for non-reactive consumers (tests, workflows) ---
+
+  get playbackState(): PlaybackState {
+    return this._playbackState.value;
+  }
+
+  get transportTime(): number {
+    return this._transportTime.value;
+  }
+
+  get totalTime(): number {
+    return this._totalTime.value;
+  }
+
+  get loudness(): number {
+    return this._loudness.value;
+  }
+
+  get isPlaying(): boolean {
+    return this._isPlaying.value;
+  }
+
+  // --- Setters for values that external code needs to update ---
+
+  setTransportTime(time: number): void {
+    this._transportTime.value = time;
+  }
+
+  setTotalTime(time: number): void {
+    this._totalTime.value = time;
+  }
+
+  setLoudness(value: number): void {
+    this._loudness.value = value;
   }
 
   // --- State machine transitions (with integrated transport control) ---
 
   play(): void {
-    const state = this.playbackState.value;
+    const state = this._playbackState.value;
     if (state === 'playing') return;
 
     if (state === 'stopped' && this.isAtEndOfTimeline()) {
-      this.transportTime.value = 0;
+      this._transportTime.value = 0;
       this.transport.seconds = 0;
     }
 
-    this.playbackState.value = 'playing';
+    this._playbackState.value = 'playing';
     this.transport.start();
   }
 
   pause(): void {
-    if (this.playbackState.value !== 'playing') return;
-    this.playbackState.value = 'paused';
+    if (this._playbackState.value !== 'playing') return;
+    this._playbackState.value = 'paused';
     this.transport.pause();
   }
 
   stop(): void {
-    if (this.playbackState.value === 'stopped') return;
-    this.playbackState.value = 'stopped';
+    if (this._playbackState.value === 'stopped') return;
+    this._playbackState.value = 'stopped';
     this.transport.stop();
   }
 
   togglePlayback(): void {
-    if (this.playbackState.value === 'playing') {
+    if (this._playbackState.value === 'playing') {
       this.pause();
     } else {
       this.play();
@@ -70,12 +125,12 @@ class PlaybackService {
   rewind(): void {
     this.transport.stop();
     this.transport.seconds = 0;
-    this.playbackState.value = 'stopped';
-    this.transportTime.value = 0;
+    this._playbackState.value = 'stopped';
+    this._transportTime.value = 0;
   }
 
   seekTo(time: number): void {
-    this.transportTime.value = time;
+    this._transportTime.value = time;
     this.transport.seconds = time;
   }
 
@@ -92,26 +147,26 @@ class PlaybackService {
   // --- Derived queries ---
 
   isPaused(): boolean {
-    return this.playbackState.value === 'paused';
+    return this._playbackState.value === 'paused';
   }
 
   isStopped(): boolean {
-    return this.playbackState.value === 'stopped';
+    return this._playbackState.value === 'stopped';
   }
 
   // --- Reset (used in tests and when navigating away) ---
 
   reset(): void {
-    this.playbackState.value = 'stopped';
-    this.transportTime.value = 0;
-    this.totalTime.value = 0;
-    this.loudness.value = 0;
+    this._playbackState.value = 'stopped';
+    this._transportTime.value = 0;
+    this._totalTime.value = 0;
+    this._loudness.value = 0;
   }
 
   private isAtEndOfTimeline(): boolean {
     return (
-      this.transportTime.value.toFixed(1) === this.totalTime.value.toFixed(1) &&
-      this.totalTime.value > 0
+      this._transportTime.value.toFixed(1) ===
+        this._totalTime.value.toFixed(1) && this._totalTime.value > 0
     );
   }
 }

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -33,9 +33,20 @@ export type OverdubResult = {
 };
 
 class RecordingService {
-  readonly recordingState = signal<RecordingState>('idle');
-  readonly isCountingIn = signal(false);
-  readonly isRecording: ReadonlySignal<boolean>;
+  // --- Private signals (only the service writes these) ---
+
+  private readonly _recordingState = signal<RecordingState>('idle');
+  private readonly _isCountingIn = signal(false);
+  private readonly _isRecording: ReadonlySignal<boolean>;
+
+  // --- Narrow channel for reactive consumers (hooks) ---
+
+  readonly signals: {
+    readonly recordingState: ReadonlySignal<RecordingState>;
+    readonly isCountingIn: ReadonlySignal<boolean>;
+    readonly isRecording: ReadonlySignal<boolean>;
+  };
+
   readonly microphone: MicrophoneUserMedia;
 
   private recorder: Tone.Recorder;
@@ -48,37 +59,56 @@ class RecordingService {
     this.context = context;
     this.microphone = new MicrophoneUserMedia();
     this.recorder = new Tone.Recorder();
-    this.isRecording = computed(
-      () => this.recordingState.value !== 'idle' || this.isCountingIn.value,
+    this._isRecording = computed(
+      () => this._recordingState.value !== 'idle' || this._isCountingIn.value,
     );
+    this.signals = {
+      recordingState: this._recordingState,
+      isCountingIn: this._isCountingIn,
+      isRecording: this._isRecording,
+    };
+  }
+
+  // --- Plain getters for non-reactive consumers (tests, workflows) ---
+
+  get recordingState(): RecordingState {
+    return this._recordingState.value;
+  }
+
+  get isCountingIn(): boolean {
+    return this._isCountingIn.value;
+  }
+
+  get isRecording(): boolean {
+    return this._isRecording.value;
   }
 
   // --- State machine transitions ---
 
   arm(): void {
-    if (this.recordingState.value !== 'idle') return;
-    this.recordingState.value = 'armed';
+    if (this._recordingState.value !== 'idle') return;
+    this._recordingState.value = 'armed';
   }
 
   disarm(): void {
-    if (this.recordingState.value !== 'armed') return;
-    this.recordingState.value = 'idle';
+    if (this._recordingState.value !== 'armed') return;
+    this._recordingState.value = 'idle';
   }
 
   startRecording(): void {
-    if (this.recordingState.value !== 'armed') return;
-    this.recordingState.value = 'recording';
+    if (this._recordingState.value !== 'armed') return;
+    this._recordingState.value = 'recording';
   }
 
   stopRecording(): void {
-    if (this.recordingState.value !== 'recording') return;
-    this.recordingState.value = 'idle';
+    if (this._recordingState.value !== 'recording') return;
+    this._recordingState.value = 'idle';
   }
 
   toggleArm(): void {
-    if (this.recordingState.value === 'idle') {
+    if (this._recordingState.value === 'idle') {
       this.arm();
-    } else if (this.recordingState.value === 'armed') {
+    } else if (this._recordingState.value === 'armed') {
       this.disarm();
     }
     // If recording, toggleArm is a no-op — use stopRecording instead
@@ -87,31 +117,33 @@ class RecordingService {
   // --- Count-in helpers ---
 
   startCountIn(): void {
-    this.isCountingIn.value = true;
+    this._isCountingIn.value = true;
   }
 
   stopCountIn(): void {
-    this.isCountingIn.value = false;
+    this._isCountingIn.value = false;
   }
 
   // --- Derived queries ---
 
   isIdle(): boolean {
-    return this.recordingState.value === 'idle';
+    return this._recordingState.value === 'idle';
   }
 
   isArmed(): boolean {
-    return this.recordingState.value === 'armed';
+    return this._recordingState.value === 'armed';
   }
 
   isActivelyRecording(): boolean {
-    return this.recordingState.value === 'recording';
+    return this._recordingState.value === 'recording';
   }
 
   // True when the transport should be locked from user playback control
   // (during count-in or active recording).
   isTransportLocked(): boolean {
-    return this.recordingState.value === 'recording' || this.isCountingIn.value;
+    return (
+      this._recordingState.value === 'recording' || this._isCountingIn.value
+    );
   }
 
   // --- Microphone management ---
@@ -199,8 +231,8 @@ class RecordingService {
   // --- Reset ---
 
   reset(): void {
-    this.recordingState.value = 'idle';
-    this.isCountingIn.value = false;
+    this._recordingState.value = 'idle';
+    this._isCountingIn.value = false;
   }
 }
 

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -45,7 +45,16 @@ const DEFAULT_VOLUME = 100;
 
 class TrackService {
   readonly mixer: Mixer;
-  readonly mutedTracks: ReadonlySignal<TrackId[]>;
+
+  // --- Private signals (only the service writes these) ---
+
+  private readonly _mutedTracks: ReadonlySignal<TrackId[]>;
+
+  // --- Narrow channel for reactive consumers (hooks) ---
+
+  readonly signals: {
+    readonly mutedTracks: ReadonlySignal<TrackId[]>;
+  };
 
   private context: Context;
   private audioSourceRepository: AudioSourceRepository;
@@ -60,7 +69,7 @@ class TrackService {
     this.context = context;
     this.audioSourceRepository = new AudioSourceRepository();
     this.mixer = new Mixer();
-    this.mutedTracks = computed(() => {
+    this._mutedTracks = computed(() => {
       // Subscribe to store membership changes
       void this.storeVersion.value;
 
@@ -71,6 +80,15 @@ class TrackService {
         return s.mute.value || (hasSolo && !s.solo.value);
       });
     });
+    this.signals = {
+      mutedTracks: this._mutedTracks,
+    };
+  }
+
+  // --- Plain getter for non-reactive consumers (tests, workflows) ---
+
+  get mutedTracks(): TrackId[] {
+    return this._mutedTracks.value;
   }
 
   // --- Track creation ---

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -46,7 +46,7 @@ describe('sub-services', () => {
 
   it('creates a TrackService', () => {
     expect(audioService.trackService).toBeDefined();
-    expect(audioService.trackService.mutedTracks.value).toEqual([]);
+    expect(audioService.trackService.mutedTracks).toEqual([]);
   });
 
   it('creates a SpectrogramCache', () => {

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -36,12 +36,12 @@ describe('singleton', () => {
 describe('sub-services', () => {
   it('creates a PlaybackService', () => {
     expect(audioService.playbackService).toBeDefined();
-    expect(audioService.playbackService.playbackState.value).toBe('stopped');
+    expect(audioService.playbackService.playbackState).toBe('stopped');
   });
 
   it('creates a RecordingService', () => {
     expect(audioService.recordingService).toBeDefined();
-    expect(audioService.recordingService.recordingState.value).toBe('idle');
+    expect(audioService.recordingService.recordingState).toBe('idle');
   });
 
   it('creates a TrackService', () => {

--- a/src/services/__tests__/PlaybackService.test.ts
+++ b/src/services/__tests__/PlaybackService.test.ts
@@ -15,23 +15,23 @@ beforeEach(() => {
 describe('PlaybackService', () => {
   describe('initial state', () => {
     it('starts in stopped state', () => {
-      expect(service.playbackState.value).toBe('stopped');
+      expect(service.playbackState).toBe('stopped');
     });
 
     it('has transportTime at 0', () => {
-      expect(service.transportTime.value).toBe(0);
+      expect(service.transportTime).toBe(0);
     });
 
     it('has totalTime at 0', () => {
-      expect(service.totalTime.value).toBe(0);
+      expect(service.totalTime).toBe(0);
     });
 
     it('has loudness at 0', () => {
-      expect(service.loudness.value).toBe(0);
+      expect(service.loudness).toBe(0);
     });
 
     it('reports isPlaying as false', () => {
-      expect(service.isPlaying.value).toBe(false);
+      expect(service.isPlaying).toBe(false);
     });
   });
 
@@ -39,8 +39,8 @@ describe('PlaybackService', () => {
     it('transitions from stopped to playing', () => {
       service.play();
 
-      expect(service.playbackState.value).toBe('playing');
-      expect(service.isPlaying.value).toBe(true);
+      expect(service.playbackState).toBe('playing');
+      expect(service.isPlaying).toBe(true);
     });
 
     it('calls transport.start()', () => {
@@ -64,38 +64,38 @@ describe('PlaybackService', () => {
 
       service.play();
 
-      expect(service.playbackState.value).toBe('playing');
+      expect(service.playbackState).toBe('playing');
     });
 
     it('rewinds when playing from end of timeline', () => {
-      service.transportTime.value = 10.0;
-      service.totalTime.value = 10.0;
+      service.setTransportTime(10.0);
+      service.setTotalTime(10.0);
 
       service.play();
 
-      expect(service.transportTime.value).toBe(0);
+      expect(service.transportTime).toBe(0);
       expect(Tone.getTransport().seconds).toBe(0);
-      expect(service.isPlaying.value).toBe(true);
+      expect(service.isPlaying).toBe(true);
     });
 
     it('handles end-of-playback comparison with toFixed(1) rounding', () => {
-      service.transportTime.value = 10.04;
-      service.totalTime.value = 10.0;
+      service.setTransportTime(10.04);
+      service.setTotalTime(10.0);
 
       service.play();
 
-      expect(service.transportTime.value).toBe(0);
-      expect(service.isPlaying.value).toBe(true);
+      expect(service.transportTime).toBe(0);
+      expect(service.isPlaying).toBe(true);
     });
 
     it('does not restart when not quite at end of playback', () => {
-      service.transportTime.value = 9.8;
-      service.totalTime.value = 10.0;
+      service.setTransportTime(9.8);
+      service.setTotalTime(10.0);
 
       service.play();
 
-      expect(service.transportTime.value).toBe(9.8);
-      expect(service.isPlaying.value).toBe(true);
+      expect(service.transportTime).toBe(9.8);
+      expect(service.isPlaying).toBe(true);
     });
   });
 
@@ -105,7 +105,7 @@ describe('PlaybackService', () => {
 
       service.pause();
 
-      expect(service.playbackState.value).toBe('paused');
+      expect(service.playbackState).toBe('paused');
       expect(service.isPaused()).toBe(true);
     });
 
@@ -120,7 +120,7 @@ describe('PlaybackService', () => {
     it('is a no-op when stopped', () => {
       service.pause();
 
-      expect(service.playbackState.value).toBe('stopped');
+      expect(service.playbackState).toBe('stopped');
     });
 
     it('is a no-op when already paused', () => {
@@ -140,7 +140,7 @@ describe('PlaybackService', () => {
 
       service.stop();
 
-      expect(service.playbackState.value).toBe('stopped');
+      expect(service.playbackState).toBe('stopped');
       expect(service.isStopped()).toBe(true);
     });
 
@@ -158,7 +158,7 @@ describe('PlaybackService', () => {
 
       service.stop();
 
-      expect(service.playbackState.value).toBe('stopped');
+      expect(service.playbackState).toBe('stopped');
     });
 
     it('is a no-op when already stopped', () => {
@@ -172,7 +172,7 @@ describe('PlaybackService', () => {
     it('starts playback when stopped', () => {
       service.togglePlayback();
 
-      expect(service.isPlaying.value).toBe(true);
+      expect(service.isPlaying).toBe(true);
     });
 
     it('pauses playback when playing', () => {
@@ -180,31 +180,31 @@ describe('PlaybackService', () => {
 
       service.togglePlayback();
 
-      expect(service.isPlaying.value).toBe(false);
-      expect(service.playbackState.value).toBe('paused');
+      expect(service.isPlaying).toBe(false);
+      expect(service.playbackState).toBe('paused');
     });
 
     it('restarts from beginning when at end of playback', () => {
-      service.transportTime.value = 10.0;
-      service.totalTime.value = 10.0;
+      service.setTransportTime(10.0);
+      service.setTotalTime(10.0);
 
       service.togglePlayback();
 
-      expect(service.isPlaying.value).toBe(true);
-      expect(service.transportTime.value).toBe(0);
+      expect(service.isPlaying).toBe(true);
+      expect(service.transportTime).toBe(0);
     });
   });
 
   describe('rewind', () => {
     it('stops playback and rewinds to beginning', () => {
       service.play();
-      service.transportTime.value = 5.0;
+      service.setTransportTime(5.0);
 
       service.rewind();
 
-      expect(service.isPlaying.value).toBe(false);
-      expect(service.playbackState.value).toBe('stopped');
-      expect(service.transportTime.value).toBe(0);
+      expect(service.isPlaying).toBe(false);
+      expect(service.playbackState).toBe('stopped');
+      expect(service.transportTime).toBe(0);
       expect(Tone.getTransport().seconds).toBe(0);
     });
   });
@@ -213,7 +213,7 @@ describe('PlaybackService', () => {
     it('updates both transportTime signal and engine time', () => {
       service.seekTo(5.0);
 
-      expect(service.transportTime.value).toBe(5.0);
+      expect(service.transportTime).toBe(5.0);
       expect(Tone.getTransport().seconds).toBe(5.0);
     });
   });
@@ -235,16 +235,16 @@ describe('PlaybackService', () => {
   describe('reset', () => {
     it('resets all state to defaults', () => {
       service.play();
-      service.transportTime.value = 99;
-      service.totalTime.value = 120;
-      service.loudness.value = -6;
+      service.setTransportTime(99);
+      service.setTotalTime(120);
+      service.setLoudness(-6);
 
       service.reset();
 
-      expect(service.playbackState.value).toBe('stopped');
-      expect(service.transportTime.value).toBe(0);
-      expect(service.totalTime.value).toBe(0);
-      expect(service.loudness.value).toBe(0);
+      expect(service.playbackState).toBe('stopped');
+      expect(service.transportTime).toBe(0);
+      expect(service.totalTime).toBe(0);
+      expect(service.loudness).toBe(0);
     });
   });
 });

--- a/src/services/__tests__/RecordingService.test.ts
+++ b/src/services/__tests__/RecordingService.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 describe('RecordingService', () => {
   describe('initial state', () => {
     it('starts in idle state', () => {
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
     });
 
     it('reports isIdle as true', () => {
@@ -23,11 +23,11 @@ describe('RecordingService', () => {
     });
 
     it('is not counting in', () => {
-      expect(service.isCountingIn.value).toBe(false);
+      expect(service.isCountingIn).toBe(false);
     });
 
     it('reports isRecording as false', () => {
-      expect(service.isRecording.value).toBe(false);
+      expect(service.isRecording).toBe(false);
     });
   });
 
@@ -35,7 +35,7 @@ describe('RecordingService', () => {
     it('transitions from idle to armed', () => {
       service.arm();
 
-      expect(service.recordingState.value).toBe('armed');
+      expect(service.recordingState).toBe('armed');
       expect(service.isArmed()).toBe(true);
     });
 
@@ -44,7 +44,7 @@ describe('RecordingService', () => {
 
       service.arm();
 
-      expect(service.recordingState.value).toBe('armed');
+      expect(service.recordingState).toBe('armed');
     });
 
     it('is a no-op when recording', () => {
@@ -53,7 +53,7 @@ describe('RecordingService', () => {
 
       service.arm();
 
-      expect(service.recordingState.value).toBe('recording');
+      expect(service.recordingState).toBe('recording');
     });
   });
 
@@ -63,14 +63,14 @@ describe('RecordingService', () => {
 
       service.disarm();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
       expect(service.isIdle()).toBe(true);
     });
 
     it('is a no-op when idle', () => {
       service.disarm();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
     });
 
     it('is a no-op when recording', () => {
@@ -79,7 +79,7 @@ describe('RecordingService', () => {
 
       service.disarm();
 
-      expect(service.recordingState.value).toBe('recording');
+      expect(service.recordingState).toBe('recording');
     });
   });
 
@@ -89,14 +89,14 @@ describe('RecordingService', () => {
 
       service.startRecording();
 
-      expect(service.recordingState.value).toBe('recording');
+      expect(service.recordingState).toBe('recording');
       expect(service.isActivelyRecording()).toBe(true);
     });
 
     it('is a no-op when idle', () => {
       service.startRecording();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
     });
 
     it('is a no-op when already recording', () => {
@@ -105,7 +105,7 @@ describe('RecordingService', () => {
 
       service.startRecording();
 
-      expect(service.recordingState.value).toBe('recording');
+      expect(service.recordingState).toBe('recording');
     });
   });
 
@@ -116,14 +116,14 @@ describe('RecordingService', () => {
 
       service.stopRecording();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
       expect(service.isIdle()).toBe(true);
     });
 
     it('is a no-op when idle', () => {
       service.stopRecording();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
     });
 
     it('is a no-op when armed', () => {
@@ -131,7 +131,7 @@ describe('RecordingService', () => {
 
       service.stopRecording();
 
-      expect(service.recordingState.value).toBe('armed');
+      expect(service.recordingState).toBe('armed');
     });
   });
 
@@ -139,7 +139,7 @@ describe('RecordingService', () => {
     it('arms when idle', () => {
       service.toggleArm();
 
-      expect(service.recordingState.value).toBe('armed');
+      expect(service.recordingState).toBe('armed');
     });
 
     it('disarms when armed', () => {
@@ -147,7 +147,7 @@ describe('RecordingService', () => {
 
       service.toggleArm();
 
-      expect(service.recordingState.value).toBe('idle');
+      expect(service.recordingState).toBe('idle');
     });
 
     it('is a no-op when recording', () => {
@@ -156,7 +156,7 @@ describe('RecordingService', () => {
 
       service.toggleArm();
 
-      expect(service.recordingState.value).toBe('recording');
+      expect(service.recordingState).toBe('recording');
     });
   });
 
@@ -164,7 +164,7 @@ describe('RecordingService', () => {
     it('starts count-in', () => {
       service.startCountIn();
 
-      expect(service.isCountingIn.value).toBe(true);
+      expect(service.isCountingIn).toBe(true);
     });
 
     it('stops count-in', () => {
@@ -172,7 +172,7 @@ describe('RecordingService', () => {
 
       service.stopCountIn();
 
-      expect(service.isCountingIn.value).toBe(false);
+      expect(service.isCountingIn).toBe(false);
     });
   });
 
@@ -205,24 +205,24 @@ describe('RecordingService', () => {
     it('is true when armed', () => {
       service.arm();
 
-      expect(service.isRecording.value).toBe(true);
+      expect(service.isRecording).toBe(true);
     });
 
     it('is true when recording', () => {
       service.arm();
       service.startRecording();
 
-      expect(service.isRecording.value).toBe(true);
+      expect(service.isRecording).toBe(true);
     });
 
     it('is true during count-in', () => {
       service.startCountIn();
 
-      expect(service.isRecording.value).toBe(true);
+      expect(service.isRecording).toBe(true);
     });
 
     it('is false when idle and not counting in', () => {
-      expect(service.isRecording.value).toBe(false);
+      expect(service.isRecording).toBe(false);
     });
   });
 
@@ -234,8 +234,8 @@ describe('RecordingService', () => {
 
       service.reset();
 
-      expect(service.recordingState.value).toBe('idle');
-      expect(service.isCountingIn.value).toBe(false);
+      expect(service.recordingState).toBe('idle');
+      expect(service.isCountingIn).toBe(false);
     });
   });
 });

--- a/src/services/__tests__/TrackService.test.ts
+++ b/src/services/__tests__/TrackService.test.ts
@@ -131,14 +131,14 @@ describe('TrackService', () => {
 
   describe('mutedTracks computed signal', () => {
     it('returns empty array when no tracks exist', () => {
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
     });
 
     it('returns empty array when no tracks are muted or soloed', () => {
       service.createSignals('track-1');
       service.createSignals('track-2');
 
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
     });
 
     it('includes muted tracks', () => {
@@ -146,7 +146,7 @@ describe('TrackService', () => {
       service.createSignals('track-2');
       service.getSignals('track-1')!.mute.value = true;
 
-      expect(service.mutedTracks.value).toEqual(['track-1']);
+      expect(service.mutedTracks).toEqual(['track-1']);
     });
 
     it('mutes non-solo tracks when any track is soloed', () => {
@@ -155,7 +155,7 @@ describe('TrackService', () => {
       service.createSignals('track-3');
       service.getSignals('track-1')!.solo.value = true;
 
-      expect(service.mutedTracks.value).toEqual(['track-2', 'track-3']);
+      expect(service.mutedTracks).toEqual(['track-2', 'track-3']);
     });
 
     it('mutes a track that is both muted and soloed', () => {
@@ -165,7 +165,7 @@ describe('TrackService', () => {
       service.getSignals('track-1')!.solo.value = true;
 
       // track-1 is muted (mute overrides solo), track-2 is muted (no solo)
-      expect(service.mutedTracks.value).toEqual(['track-1', 'track-2']);
+      expect(service.mutedTracks).toEqual(['track-1', 'track-2']);
     });
 
     it('handles multiple soloed tracks', () => {
@@ -176,22 +176,22 @@ describe('TrackService', () => {
       service.getSignals('track-2')!.solo.value = true;
 
       // Only track-3 is muted (not soloed while others are)
-      expect(service.mutedTracks.value).toEqual(['track-3']);
+      expect(service.mutedTracks).toEqual(['track-3']);
     });
 
     it('updates when track signals change', () => {
       service.createSignals('track-1');
       service.createSignals('track-2');
 
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
 
       service.getSignals('track-1')!.mute.value = true;
 
-      expect(service.mutedTracks.value).toEqual(['track-1']);
+      expect(service.mutedTracks).toEqual(['track-1']);
 
       service.getSignals('track-1')!.mute.value = false;
 
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
     });
 
     it('updates when tracks are added or removed', () => {
@@ -199,16 +199,16 @@ describe('TrackService', () => {
       service.getSignals('track-1')!.solo.value = true;
 
       // Only track-1 is soloed, no other tracks to mute
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
 
       service.createSignals('track-2');
 
       // Now track-2 should be muted (not soloed while track-1 is)
-      expect(service.mutedTracks.value).toEqual(['track-2']);
+      expect(service.mutedTracks).toEqual(['track-2']);
 
       service.disposeSignals('track-2');
 
-      expect(service.mutedTracks.value).toEqual([]);
+      expect(service.mutedTracks).toEqual([]);
     });
   });
 

--- a/src/signals/__tests__/focusSignals.test.ts
+++ b/src/signals/__tests__/focusSignals.test.ts
@@ -1,5 +1,5 @@
 import {
-  focusedTracks,
+  getFocusedTracks,
   focusTrack,
   unfocusTrack,
   resetFocusSignals,
@@ -12,7 +12,7 @@ afterEach(() => {
 describe('focusSignals', () => {
   describe('initial values', () => {
     it('has empty focusedTracks', () => {
-      expect(focusedTracks.value).toEqual([]);
+      expect(getFocusedTracks()).toEqual([]);
     });
   });
 
@@ -20,21 +20,21 @@ describe('focusSignals', () => {
     it('adds a track to focusedTracks', () => {
       focusTrack('track-1');
 
-      expect(focusedTracks.value).toEqual(['track-1']);
+      expect(getFocusedTracks()).toEqual(['track-1']);
     });
 
     it('adds multiple tracks', () => {
       focusTrack('track-1');
       focusTrack('track-2');
 
-      expect(focusedTracks.value).toEqual(['track-1', 'track-2']);
+      expect(getFocusedTracks()).toEqual(['track-1', 'track-2']);
     });
 
     it('does not add duplicate tracks', () => {
       focusTrack('track-1');
       focusTrack('track-1');
 
-      expect(focusedTracks.value).toEqual(['track-1']);
+      expect(getFocusedTracks()).toEqual(['track-1']);
     });
   });
 
@@ -45,7 +45,7 @@ describe('focusSignals', () => {
 
       unfocusTrack('track-1');
 
-      expect(focusedTracks.value).toEqual(['track-2']);
+      expect(getFocusedTracks()).toEqual(['track-2']);
     });
 
     it('handles unfocusing a track that is not focused', () => {
@@ -53,7 +53,7 @@ describe('focusSignals', () => {
 
       unfocusTrack('track-2');
 
-      expect(focusedTracks.value).toEqual(['track-1']);
+      expect(getFocusedTracks()).toEqual(['track-1']);
     });
   });
 
@@ -64,7 +64,7 @@ describe('focusSignals', () => {
 
       resetFocusSignals();
 
-      expect(focusedTracks.value).toEqual([]);
+      expect(getFocusedTracks()).toEqual([]);
     });
   });
 });

--- a/src/signals/__tests__/workstationSignals.test.ts
+++ b/src/signals/__tests__/workstationSignals.test.ts
@@ -1,9 +1,9 @@
 import {
   MAX_PIXELS_PER_SECOND,
   MIN_PIXELS_PER_SECOND,
-  pixelsPerSecond,
-  resetWorkstationSignals,
+  getPixelsPerSecond,
   setZoom,
+  resetWorkstationSignals,
   zoomIn,
   zoomOut,
 } from '../workstationSignals';
@@ -14,37 +14,37 @@ afterEach(() => {
 
 describe('zoomIn', () => {
   it('increases pixelsPerSecond', () => {
-    const before = pixelsPerSecond.value;
+    const before = getPixelsPerSecond();
 
     zoomIn();
 
-    expect(pixelsPerSecond.value).toBeGreaterThan(before);
+    expect(getPixelsPerSecond()).toBeGreaterThan(before);
   });
 
   it('clamps at maximum', () => {
-    pixelsPerSecond.value = MAX_PIXELS_PER_SECOND;
+    setZoom(MAX_PIXELS_PER_SECOND);
 
     zoomIn();
 
-    expect(pixelsPerSecond.value).toBe(MAX_PIXELS_PER_SECOND);
+    expect(getPixelsPerSecond()).toBe(MAX_PIXELS_PER_SECOND);
   });
 });
 
 describe('zoomOut', () => {
   it('decreases pixelsPerSecond', () => {
-    const before = pixelsPerSecond.value;
+    const before = getPixelsPerSecond();
 
     zoomOut();
 
-    expect(pixelsPerSecond.value).toBeLessThan(before);
+    expect(getPixelsPerSecond()).toBeLessThan(before);
   });
 
   it('clamps at minimum', () => {
-    pixelsPerSecond.value = MIN_PIXELS_PER_SECOND;
+    setZoom(MIN_PIXELS_PER_SECOND);
 
     zoomOut();
 
-    expect(pixelsPerSecond.value).toBe(MIN_PIXELS_PER_SECOND);
+    expect(getPixelsPerSecond()).toBe(MIN_PIXELS_PER_SECOND);
   });
 });
 
@@ -52,18 +52,18 @@ describe('setZoom', () => {
   it('sets pixelsPerSecond to the given value', () => {
     setZoom(400);
 
-    expect(pixelsPerSecond.value).toBe(400);
+    expect(getPixelsPerSecond()).toBe(400);
   });
 
   it('clamps below minimum', () => {
     setZoom(10);
 
-    expect(pixelsPerSecond.value).toBe(MIN_PIXELS_PER_SECOND);
+    expect(getPixelsPerSecond()).toBe(MIN_PIXELS_PER_SECOND);
   });
 
   it('clamps above maximum', () => {
     setZoom(2000);
 
-    expect(pixelsPerSecond.value).toBe(MAX_PIXELS_PER_SECOND);
+    expect(getPixelsPerSecond()).toBe(MAX_PIXELS_PER_SECOND);
   });
 });

--- a/src/signals/focusSignals.ts
+++ b/src/signals/focusSignals.ts
@@ -1,18 +1,28 @@
-import { signal } from '@preact/signals-react';
+import { signal, type ReadonlySignal } from '@preact/signals-react';
 import { type TrackId } from '../types/track';
 
-export const focusedTracks = signal<TrackId[]>([]);
+const _focusedTracks = signal<TrackId[]>([]);
+
+// Narrow channel for reactive consumers (hooks)
+export const signals = {
+  focusedTracks: _focusedTracks as ReadonlySignal<TrackId[]>,
+};
+
+// Plain getter for non-reactive consumers (tests, workflows)
+export function getFocusedTracks(): TrackId[] {
+  return _focusedTracks.value;
+}
 
 export function focusTrack(trackId: TrackId): void {
-  if (!focusedTracks.value.includes(trackId)) {
-    focusedTracks.value = [...focusedTracks.value, trackId];
+  if (!_focusedTracks.value.includes(trackId)) {
+    _focusedTracks.value = [..._focusedTracks.value, trackId];
   }
 }
 
 export function unfocusTrack(trackId: TrackId): void {
-  focusedTracks.value = focusedTracks.value.filter((id) => id !== trackId);
+  _focusedTracks.value = _focusedTracks.value.filter((id) => id !== trackId);
 }
 
 export function resetFocusSignals(): void {
-  focusedTracks.value = [];
+  _focusedTracks.value = [];
 }

--- a/src/signals/workstationSignals.ts
+++ b/src/signals/workstationSignals.ts
@@ -1,26 +1,36 @@
-import { signal } from '@preact/signals-react';
+import { signal, type ReadonlySignal } from '@preact/signals-react';
 
 const DEFAULT_PIXELS_PER_SECOND = 200;
 export const MIN_PIXELS_PER_SECOND = 50;
 export const MAX_PIXELS_PER_SECOND = 800;
 const ZOOM_STEP_FACTOR = 1.5;
 
-export const pixelsPerSecond = signal(DEFAULT_PIXELS_PER_SECOND);
+const _pixelsPerSecond = signal(DEFAULT_PIXELS_PER_SECOND);
+
+// Narrow channel for reactive consumers (hooks)
+export const signals = {
+  pixelsPerSecond: _pixelsPerSecond as ReadonlySignal<number>,
+};
+
+// Plain getter for non-reactive consumers (tests, workflows)
+export function getPixelsPerSecond(): number {
+  return _pixelsPerSecond.value;
+}
 
 export function zoomIn(): void {
-  pixelsPerSecond.value = clampZoom(pixelsPerSecond.value * ZOOM_STEP_FACTOR);
+  _pixelsPerSecond.value = clampZoom(_pixelsPerSecond.value * ZOOM_STEP_FACTOR);
 }
 
 export function zoomOut(): void {
-  pixelsPerSecond.value = clampZoom(pixelsPerSecond.value / ZOOM_STEP_FACTOR);
+  _pixelsPerSecond.value = clampZoom(_pixelsPerSecond.value / ZOOM_STEP_FACTOR);
 }
 
 export function setZoom(value: number): void {
-  pixelsPerSecond.value = clampZoom(value);
+  _pixelsPerSecond.value = clampZoom(value);
 }
 
 export function resetWorkstationSignals(): void {
-  pixelsPerSecond.value = DEFAULT_PIXELS_PER_SECOND;
+  _pixelsPerSecond.value = DEFAULT_PIXELS_PER_SECOND;
 }
 
 function clampZoom(value: number): number {


### PR DESCRIPTION
## Summary

This PR refactors `PlaybackService` and `RecordingService` to provide two distinct APIs: a reactive API for components that need signal subscriptions, and a non-reactive API for tests and workflows that just need plain values.

## Key Changes

- **Private signals with public accessors**: Converted public signals to private (`_playbackState`, `_transportTime`, etc.) and exposed them through:
  - A `signals` object containing `ReadonlySignal` references for reactive consumers (hooks)
  - Plain getter properties returning current values for non-reactive consumers (tests, workflows)

- **Setter methods for mutable state**: Added explicit setter methods (`setTransportTime()`, `setTotalTime()`, `setLoudness()`) to replace direct signal value assignment in tests

- **Updated hook implementations**: Modified `usePlaybackService()` and `useRecordingService()` hooks to access signals via the `signals` accessor, making the reactive subscription pattern explicit

- **Test updates**: Updated all test files to use:
  - Plain getters (e.g., `service.playbackState` instead of `service.playbackState.value`)
  - Setter methods (e.g., `service.setTransportTime(5.0)` instead of `service.transportTime.value = 5.0`)

## Implementation Details

- The `signals` object is a readonly namespace containing all reactive signals, making it clear when code is subscribing to reactive updates
- Plain getters provide a simpler API for non-reactive code paths (tests, workflows, direct state queries)
- This separation improves code clarity by distinguishing between reactive and non-reactive consumption patterns
- All existing functionality is preserved; this is purely an API restructuring

https://claude.ai/code/session_01WZgfPPZQfbQMr7YcZtnxMw