### PR TITLE
Fix click listener leak in AudioService.startAudio()

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -16,18 +16,14 @@ import SpectrogramCache from './SpectrogramCache';
 // with many concurrent players (Tone.js issue #711).
 const RECORDING_LOOK_AHEAD = 0.05;
 
-type AudioContextStarter = {
-  resolve: () => void;
-  reject: () => void;
-};
-
-function startAudioContext(this: AudioContextStarter, event: Event): void {
+function startAudioContext(
+  resolve: () => void,
+  reject: () => void,
+  event: Event,
+): void {
   event.preventDefault();
   event.stopPropagation();
-  Tone.start()
-    .then(() => this.resolve())
-    .catch(() => this.reject());
-  window.removeEventListener('click', startAudioContext);
+  Tone.start().then(resolve).catch(reject);
 }
 
 class AudioService {
@@ -71,7 +67,8 @@ class AudioService {
     return new Promise((resolve, reject) => {
       clickElement.addEventListener(
         'click',
-        startAudioContext.bind({ resolve, reject }),
+        (event) => startAudioContext(resolve, reject, event),
+        { once: true },
       );
     });
   }

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -77,6 +77,21 @@ describe('startAudio', () => {
     expect(Tone.context.state).toBe('running');
   });
 
+  it('removes the click listener after the first click', async () => {
+    const el = document.createElement('div');
+    const spy = vi.spyOn(el, 'addEventListener');
+
+    const promise = AudioService.startAudio(
+      el as unknown as Window & typeof globalThis,
+    );
+    el.dispatchEvent(new Event('click'));
+    await promise;
+
+    expect(spy).toHaveBeenCalledWith('click', expect.any(Function), {
+      once: true,
+    });
+  });
+
   it('rejects when Tone.start() fails', async () => {
     vi.mocked(Tone.start).mockImplementationOnce(() =>
       Promise.reject(new Error('not allowed')),
@@ -88,6 +103,6 @@ describe('startAudio', () => {
     );
     el.dispatchEvent(new Event('click'));
 
-    await expect(promise).rejects.toBeUndefined();
+    await expect(promise).rejects.toThrow('not allowed');
   });
 });


### PR DESCRIPTION
The listener registered via .bind() could never be removed because
removeEventListener received the original function reference, not the
bound copy. Use { once: true } instead so the browser removes the
listener automatically after the first click.

Also corrects the rejection test: .catch(reject) now forwards the
original error instead of swallowing it.

https://claude.ai/code/session_01W2yd2pmhRTWCUzP7obtn2M