### PR TITLE
Update CLAUDE.md to document three-tier signal access pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,35 +67,47 @@ UI Components & Effects    Read signals for rendering, call service functions fo
 
 These principles guide architectural decisions. Apply them when adding features, refactoring, or reviewing changes:
 
-- **Signal ownership.** Every signal has exactly one owning service. Only the owner writes to the signal. Other modules read signals or call the owner's public functions to request state changes. Never write to a signal you don't own.
+- **Signal ownership.** Every signal has exactly one owning service. Only the owner writes to the signal. Other modules call the owner's public functions to request state changes. Never write to a signal you don't own. Signals are private to their owning module — consumers access state through one of two channels:
+  - **Plain getters** (`service.playbackState`, `getPixelsPerSecond()`) — return the current value without reactive subscription. Use in tests, workflows, event handlers, and any non-rendering code.
+  - **`signals` accessor** (`service.signals.playbackState`) — exposes the underlying `ReadonlySignal` for reactive consumers (bridge hooks). Only used inside `use*Service` / `useWorkstation` hooks that call `useSignals()`.
 
 - **Services as state machines.** Services (`PlaybackService`, `RecordingService`) define their own state, transitions, and guards. They reject invalid transitions silently. Components and hooks call service functions (`play()`, `arm()`, `stopRecording()`) rather than manipulating state directly.
 
 - **Sync hooks for signal-to-engine translation.** Services are pure state machines with no audio engine dependency. Sync hooks (`usePlaybackSync`, `useTrackSync`) subscribe to signals via `effect()` and apply state changes to the Tone.js audio engine. They are deliberately simple — they translate, they don't decide.
 
+- **Bridge hooks translate signals to React.** Each signal-owning service has a corresponding bridge hook (`usePlaybackService`, `useRecordingService`, `useTrackService`, `useWorkstation`). The hook calls `useSignals()`, reads from `service.signals.*` via lazy getters, and returns plain values and action callbacks. Components never import signals directly. This keeps the reactive boundary in one place per service and makes signal refactors invisible to components.
+
 - **Workflows coordinate, services don't.** When a user action spans multiple services (e.g., recording stop needs to end the recording, create a track, and pause playback), the workflow hook (`useMicrophone`, `useCountIn`) coordinates those calls in sequence. Services stay focused on their own domain. Don't add a reactive intermediary when a direct function call in the workflow is simpler and more readable.
 
 - **Single responsibility per module.** Each module does one thing. `useMicrophone` manages the full recording lifecycle — starting/stopping the audio engine, creating tracks, transitioning recording state, and pausing playback on completion. `usePlaybackSync` translates playback state to audio engine commands. When a module accumulates unrelated concerns, split it. But don't split a cohesive workflow into pieces just because it touches multiple services — that adds indirection without adding clarity.
 
-- **Encapsulation.** Services expose a public API of functions and signals. Internal state (like `pendingSeekTime` in PlaybackService) is module-scoped and never exported. Repositories inside services are private. Consumers interact through the defined interface.
+- **Encapsulation.** Services expose a public API of functions, plain getters, and a narrow `signals` accessor. Raw writable signals are private. Internal state (like `pendingSeekTime` in PlaybackService) is module-scoped and never exported. Repositories inside services are private. Consumers interact through the defined interface — never by reading `.value` on a signal they obtained outside a bridge hook.
 
 - **Prefer simple over indirect.** A direct call (`pause()`) in a workflow is better than a reactive chain (signal change → effect → service call → another effect → engine call) when the intent is clear and the trigger is already known. Reserve reactive patterns for cases where the producer genuinely shouldn't know about the consumer, such as the sync hooks that decouple services from the audio engine.
 
 ### Services (`src/services/`)
 
-Services own state and signals. They define valid transitions and guard against invalid ones.
+Services own state as private signals, expose plain getters for non-reactive reads, and provide a `signals` accessor for bridge hooks. They define valid transitions and guard against invalid ones.
 
 **PlaybackService** — Owns the playback state machine and transport signals.
 - State machine: `stopped → playing ⇄ paused → stopped`
-- Signals owned: `playbackState`, `transportTime`, `totalTime`, `loudness`
+- Signals owned (private): `playbackState`, `transportTime`, `totalTime`, `loudness`, `isPlaying`
+- Plain getters: `playbackState`, `transportTime`, `totalTime`, `loudness`, `isPlaying`
 - Public API: `play()`, `pause()`, `stop()`, `togglePlayback()`, `rewind()`, `seekTo()`, `consumePendingSeek()`
 - Auto-rewinds when playing from end of timeline
 
 **RecordingService** — Owns the recording state machine and count-in signal.
 - State machine: `idle → armed → recording → idle`
-- Signals owned: `recordingState`, `isCountingIn`
+- Signals owned (private): `recordingState`, `isCountingIn`, `isRecording`
+- Plain getters: `recordingState`, `isCountingIn`, `isRecording`
 - Public API: `arm()`, `disarm()`, `startRecording()`, `stopRecording()`, `toggleArm()`, `startCountIn()`, `stopCountIn()`, `isTransportLocked()`
 - The `armed` state models the GarageBand workflow: arm, position, then play to record
+
+**TrackService** — Owns track creation, per-track signals, and the mixer.
+- Signals owned (private): `mutedTracks` (computed from per-track mute/solo)
+- Plain getter: `mutedTracks`
+- Per-track `volume`/`mute`/`solo` signals are auto-synced to mixer channels via internal effects
+- Public API: `createTrack()`, `createRecordedTrack()`, `getSignals()`, `createSignals()`, `disposeSignals()`
 
 **AudioService** — Singleton wrapping Tone.js. Imperative audio engine, no signals.
 - Owns `Mixer` (Tone.Player + Tone.Channel chains per track; mute, solo, volume)
@@ -106,28 +118,26 @@ Audio flow: upload → decode `AudioBuffer` + create Blob URL → `Mixer.createC
 
 ### Signals (`src/signals/`)
 
-Signals are the reactive backbone. Services own their signals; the `signals/` directory holds cross-cutting computed signals and signal stores.
+The `signals/` directory holds cross-cutting signal modules that don't belong to a class-based service. Each module keeps its raw signal private and exports a `signals` accessor (for hooks), plain getter functions (for tests/workflows), and mutation functions.
 
-- **`transportSignals.ts`** — Backward-compatible facade. Re-exports canonical signals from PlaybackService and RecordingService. Provides computed boolean signals (`isPlaying`, `isRecording`) so older consumers that read `.value` as a boolean continue to work. New code should import from the owning service directly when it needs the full state (e.g., `playbackState` for three-state logic).
-- **`trackSignals.ts`** — Per-track signal store (`TrackSignalStore`). Each track has `volume`, `mute`, `solo` signals. Computed `mutedTracks` derives which tracks are muted from per-track mute/solo state.
-- **`focusSignals.ts`** — Focused track IDs with debounced unfocus.
-- **`workstationSignals.ts`** — Zoom level (`pixelsPerSecond`).
+- **`focusSignals.ts`** — Focused track IDs. Exports `getFocusedTracks()`, `focusTrack()`, `unfocusTrack()`, and `signals.focusedTracks`.
+- **`workstationSignals.ts`** — Zoom level. Exports `getPixelsPerSecond()`, `zoomIn()`, `zoomOut()`, `setZoom()`, and `signals.pixelsPerSecond`.
 
-### Sync Hooks (`src/hooks/use*Sync.ts`)
+### Bridge Hooks (`src/hooks/use*Service.ts`, `useWorkstation.ts`)
 
-Sync hooks subscribe to service signals via `effect()` and translate state changes into audio engine commands. They exist because services are pure state machines with no Tone.js dependency — something needs to drive the imperative audio engine.
+Bridge hooks are the boundary between the signal-based service layer and React components. Each hook calls `useSignals()`, reads from its service's `signals` accessor via lazy getters, and returns plain values and action callbacks. Components never import signals directly.
 
-- **`usePlaybackSync`** — Watches `playbackState` → calls `audioService.startPlayback()` / `pausePlayback()` / `stopPlayback()`. Consumes pending seeks atomically with state transitions.
-- **`useTrackSync`** — Watches per-track `volume`/`mute`/`solo` signals → applies changes to `Tone.Channel` instances.
-
-Both are wired in `Workstation.tsx`.
+- **`usePlaybackService`** — Bridges PlaybackService: `playbackState`, `isPlaying`, `transportTime`, `totalTime`, `loudness` + action callbacks.
+- **`useRecordingService`** — Bridges RecordingService: `recordingState`, `isCountingIn`, `isRecording` + action callbacks.
+- **`useTrackService`** — Bridges TrackService + focusSignals: `mutedTracks`, `focusedTracks` + track creation/retrieval callbacks.
+- **`useWorkstation`** — Bridges workstationSignals: `pixelsPerSecond`, `isMaxZoom`, `isMinZoom` + zoom actions.
 
 ### State Management
 
 - **Project state** (`projectPageReducer.ts`): Track list, track metadata (color, filename). Dispatch via `useProjectDispatch`.
 - **Workstation state**: `isMixerOpen` and `isRecording` are local `useState` in `Workstation.tsx`. `pixelsPerSecond` (zoom level) is a signal.
 - **Playback/recording state**: Owned by PlaybackService and RecordingService (see above).
-- **Track signals**: Per-track volume, mute, solo in `TrackSignalStore`.
+- **Track signals**: Per-track volume, mute, solo owned by `TrackService`. Auto-synced to mixer channels.
 
 ### Component Structure
 
@@ -163,19 +173,23 @@ src/
 │   └── OfflineAnalyser.ts             # OfflineAudioContext + AnalyserNode for waveform/spectrogram data
 │
 ├── signals/
-│   ├── transportSignals.ts            # Facade: re-exports service signals + computed isPlaying, isRecording
-│   ├── trackSignals.ts                # Per-track signal store: volume, mute, solo + computed mutedTracks
-│   ├── focusSignals.ts                # Focused track IDs with debounced unfocus
-│   └── workstationSignals.ts          # Zoom level: pixelsPerSecond
+│   ├── focusSignals.ts                # Focused track IDs: getFocusedTracks(), focusTrack(), signals.focusedTracks
+│   └── workstationSignals.ts          # Zoom level: getPixelsPerSecond(), zoomIn/Out(), signals.pixelsPerSecond
 │
 ├── hooks/
-│   ├── usePlaybackSync.ts             # Sync: playbackState signal → AudioService playback commands
-│   ├── useTrackSync.ts                # Sync: per-track volume/mute/solo signals → Tone.Channel
+│   ├── usePlaybackService.ts          # Bridge hook: PlaybackService signals → React components
+│   ├── useRecordingService.ts         # Bridge hook: RecordingService signals → React components
+│   ├── useTrackService.ts             # Bridge hook: TrackService + focusSignals → React components
+│   ├── useWorkstation.ts              # Bridge hook: workstationSignals → React components
 │   ├── useAudioService.tsx            # Context hook providing AudioService singleton
-│   ├── useAnimation.tsx               # requestAnimationFrame wrapper with FPS throttling
+│   ├── useAnimationFrame.ts           # requestAnimationFrame wrapper
 │   ├── useKeypress.tsx                # Window keyup listener (default: spacebar → play/pause)
 │   ├── useDebounced.tsx               # Trailing debounce wrapper
-│   └── useThrottled.tsx               # Leading throttle wrapper
+│   ├── useThrottled.tsx               # Leading throttle wrapper
+│   ├── useTimelineZoom.ts             # Timeline zoom interaction
+│   ├── useTrackVolume.ts              # Track volume control
+│   ├── useContainerHeight.ts          # Container height measurement
+│   └── useUndoReducer.ts             # Undo/redo reducer wrapper
 │
 ├── components/
 │   ├── App.tsx                        # Route definitions: /, /project, 404
@@ -212,7 +226,7 @@ src/
 ## Non-Obvious Patterns
 
 ### Pending seek pattern
-`seekTo(time)` sets a module-scoped `pendingSeekTime` and updates `transportTime.value`. The sync hook calls `consumePendingSeek()` when `playbackState` changes, reads the buffered seek, and applies it to the audio engine atomically with the state transition. This avoids race conditions between signal writes and effect execution.
+`seekTo(time)` sets a module-scoped `pendingSeekTime` and updates the private `_transportTime` signal. `consumePendingSeek()` reads the buffered seek and applies it to the audio engine atomically with the state transition. This avoids race conditions between signal writes and effect execution.
 
 ### Workflow hooks coordinate across services
 `useMicrophone` and `useCountIn` are workflow hooks that coordinate multiple services to complete a user-facing interaction. When recording stops, `useMicrophone` calls `endRecording()` (RecordingService), then `pause()` (PlaybackService), then syncs `transportTime` — all in sequence. This is simpler and more readable than routing through reactive intermediaries. Workflows call service functions directly; they don't introduce signal-to-signal relays.
@@ -231,8 +245,8 @@ dispatch(['MOVE_TRACK', { fromIndex, toIndex }]);
 `Mixer.tsx` reverses the track array for visual stacking. Drag-and-drop indices are converted back before dispatching `MOVE_TRACK`, so callers always deal with logical (non-reversed) indices.
 
 ### Muting uses signals
-- Per-track `mute`/`solo` signals live in `TrackSignalStore` (user intent)
-- `mutedTracks` is a computed signal that derives the currently muted track IDs from per-track mute/solo state
+- Per-track `mute`/`solo` signals live in `TrackService`'s private signal store (user intent)
+- `mutedTracks` is a computed signal (private to TrackService) that derives the currently muted track IDs; exposed via plain getter and `signals` accessor
 - `Timeline` and `Mixer` both read from signals for visual styling and audio routing
 
 ### AudioService initialisation on app boot
@@ -253,6 +267,14 @@ Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value 
 
 ### @dnd-kit is PointerSensor only
 `Mixer` registers only `PointerSensor` (not `MouseSensor` or `TouchSensor`). This is intentional to unify pointer events across devices.
+
+### Signal access pattern
+Every signal owner (service or signal module) provides three tiers of access:
+1. **Private signal** (`_playbackState`, `_pixelsPerSecond`) — only the owner writes
+2. **Plain getter** (`service.playbackState`, `getPixelsPerSecond()`) — snapshot read, no subscription. Used in tests, workflows, event handlers
+3. **`signals` accessor** (`service.signals.playbackState`, `signals.pixelsPerSecond`) — `ReadonlySignal` for reactive consumers. Only used inside bridge hooks that call `useSignals()`
+
+Tests should use plain getters (e.g., `service.playbackState` not `service.signals.playbackState.value`). Components should use bridge hooks (e.g., `usePlaybackService().playbackState`), never import signals directly.
 
 ## Code Conventions
 
@@ -287,4 +309,6 @@ Vitest + React Testing Library. Test setup (`setupTests.ts`) globally mocks:
 - `react-router-dom` — mock `useNavigate` and `useLocation`
 
 `clearMocks: true` in `vite.config.ts` resets mock call counts between tests.
+
+Tests read service state through plain getters (`service.playbackState`, `getFocusedTracks()`, `getPixelsPerSecond()`), not through `.signals.*.value`. This keeps tests decoupled from signal internals and makes assertions more readable.
 


### PR DESCRIPTION
Reflect the refactored architecture: signals are private, consumers use
plain getters or bridge hooks. Remove stale references to deleted files
(transportSignals, trackSignals, sync hooks) and add documentation for
new bridge hooks, TrackService, and signal access conventions.

https://claude.ai/code/session_01G4VE3w92CyjkMbkBPunep9