### PR TITLE
Finalize service architecture: *Service naming and encapsulation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,9 @@ The architecture is organized in layers with clear ownership boundaries. Depende
 UI Components & Effects    Read signals for rendering, call service functions for commands,
       │                    coordinate workflows (count-in, recording lifecycle)
       │
-  Sync Hooks               Subscribe to signals via effect(), translate state changes
-      │                    into audio engine calls
+  Bridge Hooks             Call useSignals(), translate service signals into React props
       │
-  Services & Signals       State machines that own and guard their signals
-      │
-  Audio Engine             Tone.js / Web Audio API (imperative, side-effectful)
+  Services & Signals       State machines that own signals and encapsulate audio engine
 ```
 
 ### Design Principles
@@ -73,17 +70,15 @@ These principles guide architectural decisions. Apply them when adding features,
 
 - **Services as state machines.** Services (`PlaybackService`, `RecordingService`) define their own state, transitions, and guards. They reject invalid transitions silently. Components and hooks call service functions (`play()`, `arm()`, `stopRecording()`) rather than manipulating state directly.
 
-- **Sync hooks for signal-to-engine translation.** Services are pure state machines with no audio engine dependency. Sync hooks (`usePlaybackSync`, `useTrackSync`) subscribe to signals via `effect()` and apply state changes to the Tone.js audio engine. They are deliberately simple — they translate, they don't decide.
-
 - **Bridge hooks translate signals to React.** Each signal-owning service has a corresponding bridge hook (`usePlaybackService`, `useRecordingService`, `useTrackService`, `useWorkstation`). The hook calls `useSignals()`, reads from `service.signals.*` via lazy getters, and returns plain values and action callbacks. Components never import signals directly. This keeps the reactive boundary in one place per service and makes signal refactors invisible to components.
 
 - **Workflows coordinate, services don't.** When a user action spans multiple services (e.g., recording stop needs to end the recording, create a track, and pause playback), the workflow hook (`useMicrophone`, `useCountIn`) coordinates those calls in sequence. Services stay focused on their own domain. Don't add a reactive intermediary when a direct function call in the workflow is simpler and more readable.
 
-- **Single responsibility per module.** Each module does one thing. `useMicrophone` manages the full recording lifecycle — starting/stopping the audio engine, creating tracks, transitioning recording state, and pausing playback on completion. `usePlaybackSync` translates playback state to audio engine commands. When a module accumulates unrelated concerns, split it. But don't split a cohesive workflow into pieces just because it touches multiple services — that adds indirection without adding clarity.
+- **Single responsibility per module.** Each module does one thing. `useMicrophone` manages the full recording lifecycle — starting/stopping the audio engine, creating tracks, transitioning recording state, and pausing playback on completion. When a module accumulates unrelated concerns, split it. But don't split a cohesive workflow into pieces just because it touches multiple services — that adds indirection without adding clarity.
 
 - **Encapsulation.** Services expose a public API of functions, plain getters, and a narrow `signals` accessor. Raw writable signals are private. Internal state (like `pendingSeekTime` in PlaybackService) is module-scoped and never exported. Repositories inside services are private. Consumers interact through the defined interface — never by reading `.value` on a signal they obtained outside a bridge hook.
 
-- **Prefer simple over indirect.** A direct call (`pause()`) in a workflow is better than a reactive chain (signal change → effect → service call → another effect → engine call) when the intent is clear and the trigger is already known. Reserve reactive patterns for cases where the producer genuinely shouldn't know about the consumer, such as the sync hooks that decouple services from the audio engine.
+- **Prefer simple over indirect.** A direct call (`pause()`) in a workflow is better than a reactive chain (signal change → effect → service call → another effect → engine call) when the intent is clear and the trigger is already known. Reserve reactive patterns for cases where the producer genuinely shouldn't know about the consumer.
 
 ### Services (`src/services/`)
 
@@ -93,28 +88,30 @@ Services own state as private signals, expose plain getters for non-reactive rea
 - State machine: `stopped → playing ⇄ paused → stopped`
 - Signals owned (private): `playbackState`, `transportTime`, `totalTime`, `loudness`, `isPlaying`
 - Plain getters: `playbackState`, `transportTime`, `totalTime`, `loudness`, `isPlaying`
-- Public API: `play()`, `pause()`, `stop()`, `togglePlayback()`, `rewind()`, `seekTo()`, `consumePendingSeek()`
+- Public API: `play()`, `pause()`, `stop()`, `togglePlayback()`, `rewind()`, `seekTo()`
 - Auto-rewinds when playing from end of timeline
 
-**RecordingService** — Owns the recording state machine and count-in signal.
+**RecordingService** — Owns the recording state machine, count-in signal, and microphone.
 - State machine: `idle → armed → recording → idle`
 - Signals owned (private): `recordingState`, `isCountingIn`, `isRecording`
 - Plain getters: `recordingState`, `isCountingIn`, `isRecording`
-- Public API: `arm()`, `disarm()`, `startRecording()`, `stopRecording()`, `toggleArm()`, `startCountIn()`, `stopCountIn()`, `isTransportLocked()`
+- Encapsulates `MicrophoneService` (private) — Tone.UserMedia wrapper for microphone input
+- Public API: `arm()`, `disarm()`, `startRecording()`, `stopRecording()`, `toggleArm()`, `startCountIn()`, `stopCountIn()`, `isTransportLocked()`, `prepareMicrophone()`, `closeMicrophone()`, `getLoudness()`, `getMicrophoneSource()`
 - The `armed` state models the GarageBand workflow: arm, position, then play to record
 
 **TrackService** — Owns track creation, per-track signals, and the mixer.
 - Signals owned (private): `mutedTracks` (computed from per-track mute/solo)
 - Plain getter: `mutedTracks`
+- Encapsulates `MixerService` (private) — Tone.Player + Tone.Channel chains per track
 - Per-track `volume`/`mute`/`solo` signals are auto-synced to mixer channels via internal effects
-- Public API: `createTrack()`, `createRecordedTrack()`, `getSignals()`, `createSignals()`, `disposeSignals()`
+- Public API: `createTrack()`, `createRecordedTrack()`, `getSignals()`, `createSignals()`, `disposeSignals()`, `getLoudness()`, `retrieveChannel()`, `recreateChannel()`, `deleteChannel()`
 
-**AudioService** — Singleton wrapping Tone.js. Imperative audio engine, no signals.
-- Owns `Mixer` (Tone.Player + Tone.Channel chains per track; mute, solo, volume)
-- Owns `MicrophoneUserMedia` (Tone.UserMedia wrapper for recording)
-- Owns `OfflineAnalyser` (waveform/spectrogram data via offline rendering)
+**AudioService** — Singleton that bootstraps the Tone.js audio context and creates sub-services.
+- Creates and owns: `PlaybackService`, `RecordingService`, `TrackService`, `SpectrogramCache`
+- Configures shared Tone.js context (interactive latency, reduced look-ahead for recording)
+- Static: `startAudio()` (context startup on user gesture), `getInstance()` (singleton access)
 
-Audio flow: upload → decode `AudioBuffer` + create Blob URL → `Mixer.createChannel()` → `Tone.Transport` controls playback → WaveSurfer 7 renders waveform via `load(blobUrl)`.
+Audio flow: upload → decode `AudioBuffer` + create Blob URL → `TrackService.createTrack()` → `Tone.Transport` controls playback.
 
 ### Signals (`src/signals/`)
 
@@ -145,7 +142,7 @@ Bridge hooks are the boundary between the signal-based service layer and React c
 - `src/components/project/` — Project page container, header with file upload
 - `src/components/workstation/` — Core editor: `Timeline`, `Waveform`, `Scrubber`, `Toolbar`, `Mixer`, `Channel`
 - `src/components/dropzone/` — Drag-and-drop file upload
-- `src/hooks/` — Shared hooks and sync hooks
+- `src/hooks/` — Bridge hooks and shared utility hooks
 
 ### Routing
 
@@ -163,14 +160,16 @@ src/
 ├── testUtils.ts                       # Shared test utilities
 │
 ├── services/
+│   ├── AudioService.ts                # Singleton: bootstraps Tone.js context, creates sub-services
 │   ├── PlaybackService.ts             # Playback state machine (stopped/playing/paused); owns playbackState,
 │   │                                  #   transportTime, totalTime, loudness signals
 │   ├── RecordingService.ts            # Recording state machine (idle/armed/recording); owns recordingState,
-│   │                                  #   isCountingIn signals
-│   ├── AudioService.ts                # Singleton Tone.js wrapper: track creation, transport, recording
-│   ├── Mixer.ts                       # Tone.Player + Tone.Channel chain per track; mute/solo/volume
-│   ├── MicrophoneUserMedia.ts         # Tone.UserMedia wrapper + meter for microphone input
-│   └── OfflineAnalyser.ts             # OfflineAudioContext + AnalyserNode for waveform/spectrogram data
+│   │                                  #   isCountingIn signals; encapsulates MicrophoneService
+│   ├── TrackService.ts                # Track creation, per-track signals, audio sources;
+│   │                                  #   encapsulates MixerService
+│   ├── MixerService.ts                # Tone.Player + Tone.Channel chain per track (private to TrackService)
+│   ├── MicrophoneService.ts           # Tone.UserMedia wrapper + meter (private to RecordingService)
+│   └── OfflineAnalyser.ts             # OfflineAudioContext + AnalyserNode for spectrogram data
 │
 ├── signals/
 │   ├── focusSignals.ts                # Focused track IDs: getFocusedTracks(), focusTrack(), signals.focusedTracks
@@ -201,23 +200,22 @@ src/
 │   ├── project/
 │   │   ├── ProjectPage.tsx            # Provides ProjectDispatch context + Fullscreen wrapper
 │   │   ├── ProjectPageHeader.tsx      # Title, file upload button, fullscreen toggle
-│   │   ├── projectPageReducer.ts      # Track list state: ADD_TRACK, MOVE_TRACK, SET_TRACK_MUTE/SOLO/VOLUME
+│   │   ├── projectPageReducer.ts      # Track list state: ADD_TRACK, DELETE_TRACK, MOVE_TRACK
 │   │   ├── projectPageEffects.ts      # useUploadFile (File → AudioService.createTrack), useFullscreen
 │   │   ├── useProjectReducer.tsx      # useReducer wrapper with initial state
 │   │   └── useProjectDispatch.tsx     # Context consumer hook for project dispatch
 │   │
 │   └── workstation/
-│       ├── Workstation.tsx            # Editor layout; wires sync hooks and effect hooks
+│       ├── Workstation.tsx            # Editor layout; wires effect hooks
 │       ├── Toolbar.tsx                # Playback/record/rewind/mixer toggle controls
-│       ├── Timeline.tsx               # Track list: renders Waveform or Spectrogram per track (memoized)
-│       ├── Waveform.tsx               # WaveSurfer.js integration per track
-│       ├── Spectrogram.tsx            # OfflineAnalyser frequency data visualization
-│       ├── Scrubber.tsx               # Playhead indicator + scrubbing interaction
+│       ├── Timeline.tsx               # Track list: renders Spectrogram per track (memoized)
 │       ├── Mixer.tsx                  # @dnd-kit drag-and-drop container for track reordering
 │       ├── Channel.tsx                # Single track controls: mute/solo buttons, volume slider
 │       ├── EmptyTimeline.tsx          # Placeholder shown when no tracks exist
-│       └── workstationEffects.ts      # useSpacebarPlaybackToggle, useCountIn, useMicrophone, useMixerHeight,
-│                                      #   useTotalTime
+│       ├── workstationEffects.ts      # useSpacebarPlaybackToggle, useCountIn, useMicrophone, useMixerHeight,
+│       │                              #   useTotalTime
+│       ├── scrubber/Scrubber.tsx      # Playhead indicator + scrubbing interaction
+│       └── spectrogram/Spectrogram.tsx # Spectrogram frequency data visualization
 │
 └── types/
     └── track.ts                       # Track, TrackColor type definitions
@@ -225,11 +223,8 @@ src/
 
 ## Non-Obvious Patterns
 
-### Pending seek pattern
-`seekTo(time)` sets a module-scoped `pendingSeekTime` and updates the private `_transportTime` signal. `consumePendingSeek()` reads the buffered seek and applies it to the audio engine atomically with the state transition. This avoids race conditions between signal writes and effect execution.
-
 ### Workflow hooks coordinate across services
-`useMicrophone` and `useCountIn` are workflow hooks that coordinate multiple services to complete a user-facing interaction. When recording stops, `useMicrophone` calls `endRecording()` (RecordingService), then `pause()` (PlaybackService), then syncs `transportTime` — all in sequence. This is simpler and more readable than routing through reactive intermediaries. Workflows call service functions directly; they don't introduce signal-to-signal relays.
+`useMicrophone` and `useCountIn` are workflow hooks that coordinate multiple services to complete a user-facing interaction. When recording stops, `useMicrophone` calls `stopRecording()` (RecordingService), then `pause()` (PlaybackService), then syncs `transportTime` — all in sequence. This is simpler and more readable than routing through reactive intermediaries. Workflows call service functions directly; they don't introduce signal-to-signal relays.
 
 ### Project reducer action format is tuple-based
 Actions are `[ACTION_TYPE, payload?]` tuples, **not** `{ type, payload }` objects:
@@ -239,7 +234,7 @@ dispatch(['MOVE_TRACK', { fromIndex, toIndex }]);
 ```
 
 ### Repository pattern inside services
-`AudioService` owns an `AudioSourceRepository` (decoded `AudioBuffer`s); `Mixer` owns an `AudioChannelRepository` (`Tone.Channel` instances). Both are private and accessed only through their parent service.
+`TrackService` owns an `AudioSourceRepository` (decoded `AudioBuffer`s); `MixerService` owns an `AudioChannelRepository` (`Tone.Channel` instances). Both are private and accessed only through their parent service.
 
 ### Mixer displays tracks in reverse order
 `Mixer.tsx` reverses the track array for visual stacking. Drag-and-drop indices are converted back before dispatching `MOVE_TRACK`, so callers always deal with logical (non-reversed) indices.
@@ -256,7 +251,7 @@ dispatch(['MOVE_TRACK', { fromIndex, toIndex }]);
 `useEffect`/`useCallback` deps arrays intentionally omit `audioService` and `dispatch` refs with inline comments. These are stable across renders; adding them would cause spurious re-runs.
 
 ### Volume slider uses dB conversion
-Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value + 1) / 101)`. This is applied inside `Mixer.setVolume()`, not in the component.
+Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value + 1) / 101)`. This is applied inside `AudioChannel.volume` (in MixerService), not in the component.
 
 ### Throttle vs. debounce in Channel
 - Volume slider → `useThrottled(100ms)` — limits audio engine calls while dragging
@@ -266,7 +261,7 @@ Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value 
 `OfflineAnalyser` auto-detects API support at runtime: uses `OfflineAudioContext.suspend()` if available, otherwise falls back to `ScriptProcessorNode`. This is why `browserSupport.tsx` exists as a context.
 
 ### @dnd-kit is PointerSensor only
-`Mixer` registers only `PointerSensor` (not `MouseSensor` or `TouchSensor`). This is intentional to unify pointer events across devices.
+`Mixer.tsx` registers only `PointerSensor` (not `MouseSensor` or `TouchSensor`). This is intentional to unify pointer events across devices.
 
 ### Signal access pattern
 Every signal owner (service or signal module) provides three tiers of access:

--- a/src/components/project/projectPageEffects.ts
+++ b/src/components/project/projectPageEffects.ts
@@ -56,14 +56,8 @@ export const useTrackSideEffects = (tracks: Track[]) => {
           const initialVolume = trackHook.retrieveInitialVolume(track.trackId);
           trackHook.createSignals(track.trackId, initialVolume);
         }
-        if (!trackHook.retrieveMixerChannel(track.trackId)) {
-          const buffer = trackHook.retrieveAudioBuffer(track.trackId);
-          if (buffer) {
-            const normGainDb = trackHook.retrieveNormalizationGainDb(
-              track.trackId,
-            );
-            trackHook.createMixerChannel(track.trackId, buffer, normGainDb);
-          }
+        if (!trackHook.retrieveChannel(track.trackId)) {
+          trackHook.recreateChannel(track.trackId);
         }
       }
     }

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -113,7 +113,7 @@ it('renders plasma playhead canvas in the cursor container', () => {
 });
 
 it('feeds plasma renderer with loudness during playback', () => {
-  vi.spyOn(trackService.mixer, 'getLoudness').mockReturnValue(0.75);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0.75);
 
   let rafCallback: FrameRequestCallback = () => {};
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -129,12 +129,12 @@ it('feeds plasma renderer with loudness during playback', () => {
     rafCallback(0);
   });
 
-  expect(trackService.mixer.getLoudness).toHaveBeenCalled();
+  expect(trackService.getLoudness).toHaveBeenCalled();
 });
 
 it('does not stop playback at end of scroll during recording', () => {
   vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.5);
-  vi.spyOn(trackService.mixer, 'getLoudness').mockReturnValue(0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
 
   let rafCallback: FrameRequestCallback = () => {};
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -160,7 +160,7 @@ it('does not stop playback at end of scroll during recording', () => {
 });
 
 it('does not call getLoudness when playback is stopped', () => {
-  const getLoudnessSpy = vi.spyOn(trackService.mixer, 'getLoudness');
+  const getLoudnessSpy = vi.spyOn(trackService, 'getLoudness');
 
   render(<Scrubber {...defaultProps} />);
 
@@ -231,7 +231,7 @@ it('does not rewind when rewind button is clicked during recording', () => {
 
 it('does not update transportTime during count-in', () => {
   vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(3.5);
-  vi.spyOn(trackService.mixer, 'getLoudness').mockReturnValue(0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
 
   let rafCallback: FrameRequestCallback = () => {};
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -119,7 +119,7 @@ export function useScrubber({
           setScrollPosition(time);
         }
 
-        const currentLoudness = trackHook.getMixerLoudness();
+        const currentLoudness = trackHook.getLoudness();
         playback.setLoudness(currentLoudness);
 
         const frequencyData =

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -109,7 +109,7 @@ vi.mock('../../../../hooks/useRecordingService', () => ({
     startRecording: () => recordingService.startRecording(),
     stopRecording: () => recordingService.stopRecording(),
     getRecordingStartTime: () => recordingService.getRecordingStartTime(),
-    getMicrophoneSource: () => recordingService.microphone.source,
+    getMicrophoneSource: () => recordingService.getMicrophoneSource(),
     reset: () => recordingService.reset(),
   }),
 }));

--- a/src/hooks/useRecordingService.ts
+++ b/src/hooks/useRecordingService.ts
@@ -52,7 +52,7 @@ export function useRecordingService() {
     prepareMicrophone: () => service.prepareMicrophone(),
     closeMicrophone: () => service.closeMicrophone(),
     getLoudness: () => service.getLoudness(),
-    getMicrophoneSource: () => service.microphone.source,
+    getMicrophoneSource: () => service.getMicrophoneSource(),
 
     // --- Overdub recording ---
 

--- a/src/hooks/useTrackService.ts
+++ b/src/hooks/useTrackService.ts
@@ -69,14 +69,9 @@ export function useTrackService() {
 
     // --- Audio engine ---
 
-    getMixerLoudness: () => service.mixer.getLoudness(),
-    createMixerChannel: (
-      trackId: string,
-      buffer: AudioBuffer,
-      normGainDb: number,
-    ) => service.mixer.createChannel(trackId, buffer, normGainDb),
-    retrieveMixerChannel: (trackId: string) =>
-      service.mixer.retrieveChannel(trackId),
+    getLoudness: () => service.getLoudness(),
+    retrieveChannel: (trackId: string) => service.retrieveChannel(trackId),
+    recreateChannel: (trackId: string) => service.recreateChannel(trackId),
 
     // --- Cleanup ---
 

--- a/src/services/MicrophoneService.ts
+++ b/src/services/MicrophoneService.ts
@@ -1,6 +1,6 @@
 import * as Tone from 'tone';
 
-class MicrophoneUserMedia {
+class MicrophoneService {
   private microphone: Tone.UserMedia;
   private meter: Tone.Meter;
 
@@ -43,4 +43,4 @@ class MicrophoneUserMedia {
   }
 }
 
-export default MicrophoneUserMedia;
+export default MicrophoneService;

--- a/src/services/MixerService.ts
+++ b/src/services/MixerService.ts
@@ -3,7 +3,7 @@ import * as Tone from 'tone';
 const SMOOTHING = 0.8;
 const POWER_CURVE_EXPONENT = 0.6;
 
-class Mixer {
+class MixerService {
   private audioChannelRepository: AudioChannelRepository;
   private meter: Tone.Meter;
 
@@ -140,4 +140,4 @@ class AudioChannelRepository {
   }
 }
 
-export default Mixer;
+export default MixerService;

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -2,12 +2,12 @@
 //
 // State machine: idle → armed → recording → idle
 //
-// Encapsulates Tone.Recorder and MicrophoneUserMedia so the rest of the
+// Encapsulates Tone.Recorder and MicrophoneService so the rest of the
 // app interacts with recording through signals and service methods.
 
 import * as Tone from 'tone';
 import { computed, signal, type ReadonlySignal } from '@preact/signals-react';
-import MicrophoneUserMedia from './MicrophoneUserMedia';
+import MicrophoneService from './MicrophoneService';
 
 export type RecordingState = 'idle' | 'armed' | 'recording';
 
@@ -47,7 +47,7 @@ class RecordingService {
     readonly isRecording: ReadonlySignal<boolean>;
   };
 
-  readonly microphone: MicrophoneUserMedia;
+  private readonly microphone: MicrophoneService;
 
   private recorder: Tone.Recorder;
   private transport: Transport;
@@ -57,7 +57,7 @@ class RecordingService {
   constructor(transport: Transport, context: Context) {
     this.transport = transport;
     this.context = context;
-    this.microphone = new MicrophoneUserMedia();
+    this.microphone = new MicrophoneService();
     this.recorder = new Tone.Recorder();
     this._isRecording = computed(
       () => this._recordingState.value !== 'idle' || this._isCountingIn.value,
@@ -162,6 +162,10 @@ class RecordingService {
 
   getLoudness(): number {
     return this.microphone.getLoudness();
+  }
+
+  getMicrophoneSource(): Tone.ToneAudioNode {
+    return this.microphone.source;
   }
 
   // --- Overdub recording ---

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -1,6 +1,6 @@
 // TrackService — owns track creation, per-track signals, and the mixer.
 //
-// Encapsulates the Mixer (Tone.Player + Tone.Channel chains) and the
+// Encapsulates MixerService (Tone.Player + Tone.Channel chains) and the
 // audio source repository. Per-track volume/mute/solo signals are synced
 // to the mixer channels automatically via effects, so consumers never
 // need to bridge signals to the audio engine themselves.
@@ -14,7 +14,7 @@ import {
   type Signal,
 } from '@preact/signals-react';
 import { LoudnessNormalizer } from './LoudnessNormalizer';
-import Mixer, { type AudioChannel } from './Mixer';
+import MixerService, { type AudioChannel } from './MixerService';
 import { type TrackId } from '../types/track';
 
 export type TrackSignals = {
@@ -44,7 +44,7 @@ type Context = {
 const DEFAULT_VOLUME = 100;
 
 class TrackService {
-  readonly mixer: Mixer;
+  private readonly mixer: MixerService;
 
   // --- Private signals (only the service writes these) ---
 
@@ -68,7 +68,7 @@ class TrackService {
   constructor(context: Context) {
     this.context = context;
     this.audioSourceRepository = new AudioSourceRepository();
-    this.mixer = new Mixer();
+    this.mixer = new MixerService();
     this._mutedTracks = computed(() => {
       // Subscribe to store membership changes
       void this.storeVersion.value;
@@ -222,6 +222,30 @@ class TrackService {
       .reduce((prev, curr) => (prev >= curr ? prev : curr), 0);
   }
 
+  // --- Mixer delegates ---
+
+  getLoudness(): number {
+    return this.mixer.getLoudness();
+  }
+
+  retrieveChannel(trackId: string): AudioChannel | undefined {
+    return this.mixer.retrieveChannel(trackId);
+  }
+
+  // Recreates a mixer channel for a track whose audio source is already
+  // stored (e.g. after undo/redo removes and re-adds a track).
+  recreateChannel(trackId: string): boolean {
+    const source = this.audioSourceRepository.get(trackId);
+    if (!source) return false;
+    this.mixer.createChannel(
+      trackId,
+      source.audioBuffer,
+      source.normalizationGainDb,
+      source.startTime,
+    );
+    return true;
+  }
+
   // --- Cleanup ---
 
   deleteChannel(trackId: string): void {
@@ -283,6 +307,6 @@ class AudioSourceRepository {
   }
 }
 
-export { AudioChannel } from './Mixer';
+export { AudioChannel } from './MixerService';
 
 export default TrackService;

--- a/src/services/__tests__/MicrophoneService.test.ts
+++ b/src/services/__tests__/MicrophoneService.test.ts
@@ -1,11 +1,11 @@
 import { vi } from 'vitest';
 import * as Tone from 'tone';
-import MicrophoneUserMedia from '../MicrophoneUserMedia';
+import MicrophoneService from '../MicrophoneService';
 
-let mic: MicrophoneUserMedia;
+let mic: MicrophoneService;
 
 beforeEach(() => {
-  mic = new MicrophoneUserMedia();
+  mic = new MicrophoneService();
 });
 
 describe('constructor', () => {

--- a/src/services/__tests__/MixerService.test.ts
+++ b/src/services/__tests__/MixerService.test.ts
@@ -1,11 +1,11 @@
 import { vi } from 'vitest';
 import * as Tone from 'tone';
-import Mixer, { AudioChannel } from '../Mixer';
+import MixerService, { AudioChannel } from '../MixerService';
 
-let mixer: Mixer;
+let mixer: MixerService;
 
 beforeEach(() => {
-  mixer = new Mixer();
+  mixer = new MixerService();
 });
 
 describe('constructor', () => {

--- a/src/services/__tests__/TrackService.test.ts
+++ b/src/services/__tests__/TrackService.test.ts
@@ -230,17 +230,12 @@ describe('TrackService', () => {
       expect(service.getSignals(trackId)).toBeDefined();
     });
 
-    it('creates a mixer channel with normalization gain', async () => {
-      const createChannelSpy = vi.spyOn(service.mixer, 'createChannel');
+    it('creates a mixer channel for the new track', async () => {
       const arrayBuffer = new ArrayBuffer(16);
 
       const { trackId } = await service.createTrack(arrayBuffer);
 
-      expect(createChannelSpy).toHaveBeenCalledWith(
-        trackId,
-        expect.anything(),
-        expect.any(Number),
-      );
+      expect(service.retrieveChannel(trackId)).toBeDefined();
     });
 
     it('stores the blob URL for the track', async () => {


### PR DESCRIPTION
## Summary
- Rename `Mixer` → `MixerService` and `MicrophoneUserMedia` → `MicrophoneService` to follow the `*Service` naming convention
- Encapsulate internal services: make `mixer` private in `TrackService` and `microphone` private in `RecordingService`, add delegate methods (`getLoudness`, `retrieveChannel`, `recreateChannel`, `getMicrophoneSource`) so bridge hooks access functionality through the owning service's public API
- Update CLAUDE.md: remove stale sync hook references, fix architecture diagram, update file map and service descriptions

## Test plan
- [x] All 466 tests pass
- [x] Build succeeds (`npm run build`)
- [x] Lint clean (`npm run lint`)
- [ ] Verify no runtime regressions in playback, recording, and undo/redo workflows

https://claude.ai/code/session_01BN2oCE1fCufaR6crybKQvy