### PR TITLE
Add AudioWorklet recording, latency compensation service, and worklet analyser (#169, #170, #178)

### DIFF
--- a/src/services/AnalysisProcessor.ts
+++ b/src/services/AnalysisProcessor.ts
@@ -1,0 +1,70 @@
+// AnalysisProcessor — AudioWorkletProcessor that computes RMS loudness
+// on the audio thread, replacing Tone.Analyser (AnalyserNode) for
+// lowest-latency real-time metering.
+//
+// Runs inside an AudioWorklet scope on a dedicated thread, eliminating
+// main-thread contention during complex playback with many tracks.
+//
+// Message protocol:
+//   Processor → Main:  { type: 'loudness', rms: number }
+//   Main → Processor:  { type: 'configure', smoothing: number }
+
+export type AnalysisMessage = { type: 'loudness'; rms: number };
+
+export type AnalysisCommand = { type: 'configure'; smoothing: number };
+
+// Exponential moving average coefficient. Higher values = smoother but
+// more latent meter response.
+const DEFAULT_SMOOTHING = 0.8;
+
+// How often to post loudness updates. Every N-th process() call.
+// At 128 samples / 44100 Hz ≈ 2.9ms per call, 8 calls ≈ 23ms ≈ 43 Hz
+// update rate — sufficient for smooth meter animation.
+const REPORT_INTERVAL = 8;
+
+class AnalysisProcessor extends AudioWorkletProcessor {
+  private smoothing = DEFAULT_SMOOTHING;
+  private smoothedRms = 0;
+  private callCount = 0;
+
+  constructor() {
+    super();
+    this.port.onmessage = (event: MessageEvent<AnalysisCommand>) => {
+      if (event.data.type === 'configure') {
+        this.smoothing = event.data.smoothing;
+      }
+    };
+  }
+
+  process(inputs: Float32Array[][]): boolean {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    const channelData = input[0];
+    if (!channelData || channelData.length === 0) return true;
+
+    // RMS calculation on the audio thread
+    let sumSquares = 0;
+    for (let i = 0; i < channelData.length; i++) {
+      sumSquares += channelData[i] * channelData[i];
+    }
+    const instantRms = Math.sqrt(sumSquares / channelData.length);
+
+    // Exponential moving average for smoothing
+    this.smoothedRms =
+      this.smoothing * this.smoothedRms + (1 - this.smoothing) * instantRms;
+
+    this.callCount++;
+    if (this.callCount >= REPORT_INTERVAL) {
+      this.callCount = 0;
+      this.port.postMessage({
+        type: 'loudness',
+        rms: this.smoothedRms,
+      } satisfies AnalysisMessage);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('analysis-processor', AnalysisProcessor);

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -42,6 +42,10 @@ class AudioService {
     this.recordingService = new RecordingService(transport, context);
     this.trackService = new TrackService(context);
     this.spectrogramCache = new SpectrogramCache();
+
+    // Attempt to initialize the AudioWorklet-based recorder for
+    // sample-accurate capture. Falls back to Tone.Recorder silently.
+    this.recordingService.initializeWorkletRecorder();
   }
 
   static getInstance(): AudioService {

--- a/src/services/LatencyCompensation.ts
+++ b/src/services/LatencyCompensation.ts
@@ -1,0 +1,88 @@
+// LatencyCompensation — measures round-trip audio latency and provides
+// buffer trimming to align recorded audio with the transport timeline.
+//
+// Extracts latency estimation from RecordingService into a dedicated module
+// with explicit getters for each latency component and a trimBuffer utility.
+
+// One render quantum at 44.1 kHz (~2.9 ms). Conservative estimate for input
+// latency when no hardware-specific measurement is available.
+const RENDER_QUANTUM_FRAMES = 128;
+
+type RawContext = {
+  sampleRate: number;
+  outputLatency?: number;
+  baseLatency?: number;
+};
+
+class LatencyCompensation {
+  private rawContext: RawContext;
+  private lookAhead: number;
+
+  constructor(rawContext: RawContext, lookAhead: number) {
+    this.rawContext = rawContext;
+    this.lookAhead = lookAhead;
+  }
+
+  // Hardware output latency (speaker buffer). Zero when the browser does not
+  // expose it (e.g. Firefox < 119).
+  getOutputLatency(): number {
+    return this.rawContext.outputLatency ?? 0;
+  }
+
+  // Platform base latency (OS audio subsystem overhead).
+  getBaseLatency(): number {
+    return this.rawContext.baseLatency ?? 0;
+  }
+
+  // Estimated input latency from microphone capture. Uses one render quantum
+  // as a conservative lower bound per Web Audio API latency research.
+  getInputLatency(): number {
+    return RENDER_QUANTUM_FRAMES / this.rawContext.sampleRate;
+  }
+
+  // Tone.js scheduling look-ahead passed through AudioService configuration.
+  getLookAhead(): number {
+    return this.lookAhead;
+  }
+
+  // Total round-trip compensation in seconds: the sum of output latency,
+  // base latency, scheduling look-ahead, and estimated input latency.
+  getTotalCompensation(): number {
+    return (
+      this.getOutputLatency() +
+      this.getBaseLatency() +
+      this.getLookAhead() +
+      this.getInputLatency()
+    );
+  }
+
+  // Total compensation expressed as an integer sample count at the given
+  // sample rate.
+  compensationInSamples(sampleRate: number): number {
+    return Math.floor(this.getTotalCompensation() * sampleRate);
+  }
+
+  // Trim leading latency samples from a recorded buffer. Returns the original
+  // buffer unchanged when the compensation would remove all or no samples.
+  trimBuffer(buffer: AudioBuffer, compensationSeconds: number): AudioBuffer {
+    const samplesToTrim = Math.floor(compensationSeconds * buffer.sampleRate);
+    if (samplesToTrim <= 0 || samplesToTrim >= buffer.length) return buffer;
+
+    const newLength = buffer.length - samplesToTrim;
+    const trimmed = new AudioBuffer({
+      numberOfChannels: buffer.numberOfChannels,
+      length: newLength,
+      sampleRate: buffer.sampleRate,
+    });
+
+    for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+      const sourceData = buffer.getChannelData(ch);
+      const destData = trimmed.getChannelData(ch);
+      destData.set(sourceData.subarray(samplesToTrim));
+    }
+
+    return trimmed;
+  }
+}
+
+export default LatencyCompensation;

--- a/src/services/MicrophoneService.ts
+++ b/src/services/MicrophoneService.ts
@@ -1,5 +1,15 @@
 import * as Tone from 'tone';
 
+// Low-latency getUserMedia constraints for recording. Disables browser
+// processing (echo cancellation, noise suppression, AGC) that adds latency
+// and degrades audio quality for music recording.
+export const LOW_LATENCY_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: false,
+  noiseSuppression: false,
+  autoGainControl: false,
+  channelCount: 1,
+};
+
 class MicrophoneService {
   private microphone: Tone.UserMedia;
   private meter: Tone.Meter;
@@ -25,8 +35,8 @@ class MicrophoneService {
     this.microphone.close();
   }
 
-  connect(destination: Tone.ToneAudioNode): void {
-    this.microphone.connect(destination);
+  connect(destination: Tone.ToneAudioNode | AudioNode): void {
+    this.microphone.connect(destination as Tone.ToneAudioNode);
   }
 
   getLoudness(): number {

--- a/src/services/RecordingProcessor.ts
+++ b/src/services/RecordingProcessor.ts
@@ -1,0 +1,62 @@
+// RecordingProcessor — AudioWorkletProcessor that captures raw PCM
+// Float32Array chunks on the audio thread.
+//
+// Runs inside an AudioWorklet scope, immune to main-thread jank.
+// Communicates with the main-thread WorkletRecorder via MessagePort.
+//
+// Message protocol:
+//   Main → Processor:  { type: 'start' }  — begin capturing
+//   Main → Processor:  { type: 'stop' }   — stop and report sample count
+//   Processor → Main:  { type: 'chunk', data: Float32Array }
+//   Processor → Main:  { type: 'stopped', sampleCount: number }
+
+export type ProcessorMessage =
+  | { type: 'chunk'; data: Float32Array }
+  | { type: 'stopped'; sampleCount: number };
+
+export type ProcessorCommand = { type: 'start' } | { type: 'stop' };
+
+class RecordingProcessor extends AudioWorkletProcessor {
+  private capturing = false;
+  private sampleCount = 0;
+
+  constructor() {
+    super();
+    this.port.onmessage = (event: MessageEvent<ProcessorCommand>) => {
+      if (event.data.type === 'start') {
+        this.capturing = true;
+        this.sampleCount = 0;
+      } else if (event.data.type === 'stop') {
+        this.capturing = false;
+        this.port.postMessage({
+          type: 'stopped',
+          sampleCount: this.sampleCount,
+        } satisfies ProcessorMessage);
+      }
+    };
+  }
+
+  process(inputs: Float32Array[][]): boolean {
+    if (!this.capturing) return true;
+
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    // Capture the first channel (mono recording)
+    const channelData = input[0];
+    if (!channelData || channelData.length === 0) return true;
+
+    const chunk = new Float32Array(channelData.length);
+    chunk.set(channelData);
+    this.sampleCount += chunk.length;
+
+    this.port.postMessage(
+      { type: 'chunk', data: chunk } satisfies ProcessorMessage,
+      [chunk.buffer],
+    );
+
+    return true;
+  }
+}
+
+registerProcessor('recording-processor', RecordingProcessor);

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -2,12 +2,20 @@
 //
 // State machine: idle → armed → recording → idle
 //
-// Encapsulates Tone.Recorder and MicrophoneService so the rest of the
-// app interacts with recording through signals and service methods.
+// Supports two recording backends:
+//   1. AudioWorklet-based (WorkletRecorder) — sample-accurate PCM capture on
+//      the audio thread, no MediaRecorder encoding delay.
+//   2. Tone.Recorder (MediaRecorder) — fallback when AudioWorklet is
+//      unavailable or initialization fails.
+//
+// Call initializeWorkletRecorder() once at startup to attempt the worklet
+// path. If it fails, the service silently falls back to Tone.Recorder.
 
 import * as Tone from 'tone';
 import { computed, signal, type ReadonlySignal } from '@preact/signals-react';
 import MicrophoneService from './MicrophoneService';
+import LatencyCompensation from './LatencyCompensation';
+import WorkletRecorder from './WorkletRecorder';
 
 export type RecordingState = 'idle' | 'armed' | 'recording';
 
@@ -48,8 +56,10 @@ class RecordingService {
   };
 
   private readonly microphone: MicrophoneService;
+  readonly latencyCompensation: LatencyCompensation;
 
   private recorder: Tone.Recorder;
+  private workletRecorder: WorkletRecorder | null = null;
   private transport: Transport;
   private context: Context;
   private recordingStartTime: number | null = null;
@@ -59,6 +69,10 @@ class RecordingService {
     this.context = context;
     this.microphone = new MicrophoneService();
     this.recorder = new Tone.Recorder();
+    this.latencyCompensation = new LatencyCompensation(
+      context.rawContext,
+      context.lookAhead,
+    );
     this._isRecording = computed(
       () => this._recordingState.value !== 'idle' || this._isCountingIn.value,
     );
@@ -168,20 +182,48 @@ class RecordingService {
     return this.microphone.source;
   }
 
+  // --- WorkletRecorder initialization ---
+
+  // Attempt to initialize the AudioWorklet-based recorder. Call once at
+  // startup. Falls back to Tone.Recorder silently on failure.
+  async initializeWorkletRecorder(): Promise<void> {
+    try {
+      const rawContext = this.context.rawContext as AudioContext;
+      if (!rawContext.audioWorklet) return;
+      const wr = new WorkletRecorder(rawContext);
+      await wr.initialize();
+      this.workletRecorder = wr;
+    } catch {
+      // AudioWorklet not supported or module failed to load — keep using
+      // Tone.Recorder as fallback.
+      this.workletRecorder = null;
+    }
+  }
+
+  get isWorkletRecorderAvailable(): boolean {
+    return this.workletRecorder !== null;
+  }
+
   // --- Overdub recording ---
 
   async startOverdubRecording(): Promise<void> {
     if (!this.microphone.isOpen) {
       await this.microphone.open();
     }
-    this.microphone.connect(this.recorder);
 
     // Capture transport position before starting
     this.recordingStartTime = this.transport.seconds;
 
-    // Start recorder first (has startup delay), then Transport
-    await this.recorder.start();
-    this.transport.start();
+    if (this.workletRecorder) {
+      this.microphone.connect(this.workletRecorder.input);
+      this.workletRecorder.start();
+      this.transport.start();
+    } else {
+      this.microphone.connect(this.recorder);
+      // Start recorder first (has startup delay), then Transport
+      await this.recorder.start();
+      this.transport.start();
+    }
   }
 
   async stopOverdubRecording(): Promise<OverdubResult> {
@@ -200,18 +242,33 @@ class RecordingService {
     // to the beginning during the async gap.
     this.transport.seconds = startTime;
 
+    const latencyCompensation = this.estimateRoundTripLatency();
+
+    if (this.workletRecorder) {
+      const audioBuffer = await this.workletRecorder.stop();
+      this.microphone.close();
+
+      // Encode to ArrayBuffer (WAV) for undo/redo and blob URL storage.
+      // The WorkletRecorder produces PCM directly — we encode to a raw
+      // interleaved buffer for downstream consumption.
+      const arrayBuffer = this.audioBufferToArrayBuffer(audioBuffer);
+
+      return { audioBuffer, arrayBuffer, startTime, latencyCompensation };
+    }
+
     const blob = await this.recorder.stop();
     this.microphone.close();
 
     const arrayBuffer = await blob.arrayBuffer();
     const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
 
-    const latencyCompensation = this.estimateRoundTripLatency();
-
     return { audioBuffer, arrayBuffer, startTime, latencyCompensation };
   }
 
   isOverdubRecording(): boolean {
+    if (this.workletRecorder) {
+      return this.workletRecorder.state === 'started';
+    }
     return this.recorder.state === 'started';
   }
 
@@ -220,16 +277,7 @@ class RecordingService {
   }
 
   estimateRoundTripLatency(): number {
-    const ctx = this.context.rawContext;
-    const outputLatency =
-      (ctx as AudioContext & { outputLatency?: number }).outputLatency ?? 0;
-    const baseLatency =
-      (ctx as AudioContext & { baseLatency?: number }).baseLatency ?? 0;
-    const lookAhead = this.context.lookAhead;
-    // One render quantum (~2.9ms at 44.1kHz) as a conservative input latency
-    // estimate, per research on Web Audio API latency characteristics
-    const estimatedInputLatency = 128 / ctx.sampleRate;
-    return outputLatency + baseLatency + lookAhead + estimatedInputLatency;
+    return this.latencyCompensation.getTotalCompensation();
   }
 
   // --- Reset ---
@@ -237,6 +285,24 @@ class RecordingService {
   reset(): void {
     this._recordingState.value = 'idle';
     this._isCountingIn.value = false;
+  }
+
+  // Converts an AudioBuffer to a raw ArrayBuffer containing interleaved
+  // Float32 PCM data. Used by the worklet path which produces AudioBuffer
+  // directly (no Blob encoding step).
+  private audioBufferToArrayBuffer(audioBuffer: AudioBuffer): ArrayBuffer {
+    const channels = audioBuffer.numberOfChannels;
+    const length = audioBuffer.length;
+    const interleaved = new Float32Array(length * channels);
+
+    for (let ch = 0; ch < channels; ch++) {
+      const channelData = audioBuffer.getChannelData(ch);
+      for (let i = 0; i < length; i++) {
+        interleaved[i * channels + ch] = channelData[i];
+      }
+    }
+
+    return interleaved.buffer;
   }
 }
 

--- a/src/services/WorkletAnalyser.ts
+++ b/src/services/WorkletAnalyser.ts
@@ -1,0 +1,81 @@
+// WorkletAnalyser — main-thread wrapper for the AnalysisProcessor
+// AudioWorklet.
+//
+// Drop-in replacement for Tone.Meter that runs RMS loudness calculation
+// on the audio thread instead of the main thread. Eliminates
+// AnalyserNode's main-thread contention during complex playback with
+// many tracks.
+//
+// The analyser exposes a getLoudness() method compatible with the pattern
+// used in MixerService and MicrophoneService.
+
+import { type AnalysisMessage } from './AnalysisProcessor';
+
+const PROCESSOR_NAME = 'analysis-processor';
+const DEFAULT_SMOOTHING = 0.8;
+const POWER_CURVE_EXPONENT = 0.6;
+
+class WorkletAnalyser {
+  private audioContext: AudioContext;
+  private node: AudioWorkletNode | null = null;
+  private currentRms = 0;
+  private smoothing: number;
+  private initialized = false;
+
+  constructor(audioContext: AudioContext, smoothing = DEFAULT_SMOOTHING) {
+    this.audioContext = audioContext;
+    this.smoothing = smoothing;
+  }
+
+  // Load the worklet module. Must be called once before connecting sources.
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    const moduleUrl = new URL('./AnalysisProcessor.ts', import.meta.url);
+    await this.audioContext.audioWorklet.addModule(moduleUrl);
+    this.initialized = true;
+  }
+
+  // Returns the AudioWorkletNode so the caller can connect audio sources
+  // to it (e.g., destination → analyser node).
+  get input(): AudioNode {
+    if (!this.node) {
+      this.node = new AudioWorkletNode(this.audioContext, PROCESSOR_NAME);
+      this.setupMessageHandler(this.node);
+
+      // Send initial smoothing configuration
+      this.node.port.postMessage({
+        type: 'configure',
+        smoothing: this.smoothing,
+      });
+    }
+    return this.node;
+  }
+
+  // Returns the current loudness value (0–1) with the same power curve
+  // used by MixerService for perceptual scaling.
+  getLoudness(): number {
+    return Math.pow(Math.max(0, this.currentRms), POWER_CURVE_EXPONENT);
+  }
+
+  // Returns the raw RMS value without the perceptual power curve.
+  getRawRms(): number {
+    return Math.max(0, this.currentRms);
+  }
+
+  dispose(): void {
+    this.node?.disconnect();
+    this.node = null;
+    this.currentRms = 0;
+  }
+
+  private setupMessageHandler(node: AudioWorkletNode): void {
+    node.port.onmessage = (event: MessageEvent<AnalysisMessage>) => {
+      if (event.data.type === 'loudness') {
+        this.currentRms = event.data.rms;
+      }
+    };
+  }
+}
+
+export default WorkletAnalyser;

--- a/src/services/WorkletRecorder.ts
+++ b/src/services/WorkletRecorder.ts
@@ -1,0 +1,128 @@
+// WorkletRecorder — main-thread wrapper for the RecordingProcessor
+// AudioWorklet.
+//
+// Loads the worklet module, creates the AudioWorkletNode, and accumulates
+// PCM chunks posted from the audio thread. On stop, merges chunks into a
+// single AudioBuffer — no MediaRecorder encoding delay, no variable chunk
+// timing, and sample-accurate start/stop timestamps.
+
+import { type ProcessorMessage } from './RecordingProcessor';
+
+const PROCESSOR_NAME = 'recording-processor';
+const CHANNEL_COUNT = 1;
+
+class WorkletRecorder {
+  private audioContext: AudioContext;
+  private node: AudioWorkletNode | null = null;
+  private chunks: Float32Array[] = [];
+  private recording = false;
+  private initialized = false;
+
+  constructor(audioContext: AudioContext) {
+    this.audioContext = audioContext;
+  }
+
+  // Load the worklet module. Must be called once before start(). Subsequent
+  // calls are no-ops.
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    const moduleUrl = new URL('./RecordingProcessor.ts', import.meta.url);
+    await this.audioContext.audioWorklet.addModule(moduleUrl);
+    this.initialized = true;
+  }
+
+  // Returns the AudioWorkletNode so the caller can connect a source to it
+  // (e.g., microphone → worklet node).
+  get input(): AudioNode {
+    if (!this.node) {
+      this.node = new AudioWorkletNode(this.audioContext, PROCESSOR_NAME, {
+        channelCount: CHANNEL_COUNT,
+      });
+      this.setupMessageHandler(this.node);
+    }
+    return this.node;
+  }
+
+  get state(): 'started' | 'stopped' {
+    return this.recording ? 'started' : 'stopped';
+  }
+
+  get sampleRate(): number {
+    return this.audioContext.sampleRate;
+  }
+
+  start(): void {
+    this.chunks = [];
+    this.recording = true;
+    // Lazily create the node on first access via .input
+    this.ensureNode();
+    this.node!.port.postMessage({ type: 'start' });
+  }
+
+  // Sends a stop command to the processor and resolves with the merged
+  // AudioBuffer once the processor acknowledges the stop.
+  stop(): Promise<AudioBuffer> {
+    return new Promise((resolve, reject) => {
+      if (!this.node || !this.recording) {
+        reject(new Error('WorkletRecorder is not recording'));
+        return;
+      }
+
+      const onStopped = (event: MessageEvent<ProcessorMessage>) => {
+        if (event.data.type !== 'stopped') return;
+        this.node!.port.removeEventListener('message', onStopped);
+        this.recording = false;
+        resolve(this.mergeChunks());
+      };
+
+      this.node.port.addEventListener('message', onStopped);
+      this.node.port.postMessage({ type: 'stop' });
+    });
+  }
+
+  dispose(): void {
+    this.node?.disconnect();
+    this.node = null;
+    this.chunks = [];
+    this.recording = false;
+  }
+
+  private ensureNode(): void {
+    // Accessing .input will create the node if needed
+    void this.input;
+  }
+
+  private setupMessageHandler(node: AudioWorkletNode): void {
+    node.port.onmessage = (event: MessageEvent<ProcessorMessage>) => {
+      if (event.data.type === 'chunk') {
+        this.chunks.push(event.data.data);
+      }
+    };
+  }
+
+  private mergeChunks(): AudioBuffer {
+    const totalLength = this.chunks.reduce(
+      (sum, chunk) => sum + chunk.length,
+      0,
+    );
+
+    const buffer = new AudioBuffer({
+      numberOfChannels: CHANNEL_COUNT,
+      length: Math.max(totalLength, 1),
+      sampleRate: this.sampleRate,
+    });
+
+    const channelData = buffer.getChannelData(0);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      channelData.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    this.chunks = [];
+    return buffer;
+  }
+}
+
+export default WorkletRecorder;

--- a/src/services/__tests__/LatencyCompensation.test.ts
+++ b/src/services/__tests__/LatencyCompensation.test.ts
@@ -1,0 +1,225 @@
+import LatencyCompensation from '../LatencyCompensation';
+
+const SAMPLE_RATE = 44100;
+
+function createCompensation(
+  overrides: {
+    outputLatency?: number;
+    baseLatency?: number;
+    sampleRate?: number;
+    lookAhead?: number;
+  } = {},
+) {
+  const rawContext = {
+    sampleRate: overrides.sampleRate ?? SAMPLE_RATE,
+    outputLatency: overrides.outputLatency ?? 0.01,
+    baseLatency: overrides.baseLatency ?? 0.005,
+  };
+  return new LatencyCompensation(rawContext, overrides.lookAhead ?? 0.05);
+}
+
+describe('LatencyCompensation', () => {
+  describe('getOutputLatency', () => {
+    it('returns the context outputLatency', () => {
+      const lc = createCompensation({ outputLatency: 0.012 });
+
+      expect(lc.getOutputLatency()).toBe(0.012);
+    });
+
+    it('returns 0 when outputLatency is not exposed', () => {
+      const lc = new LatencyCompensation({ sampleRate: SAMPLE_RATE }, 0.05);
+
+      expect(lc.getOutputLatency()).toBe(0);
+    });
+  });
+
+  describe('getBaseLatency', () => {
+    it('returns the context baseLatency', () => {
+      const lc = createCompensation({ baseLatency: 0.003 });
+
+      expect(lc.getBaseLatency()).toBe(0.003);
+    });
+
+    it('returns 0 when baseLatency is not exposed', () => {
+      const lc = new LatencyCompensation({ sampleRate: SAMPLE_RATE }, 0.05);
+
+      expect(lc.getBaseLatency()).toBe(0);
+    });
+  });
+
+  describe('getInputLatency', () => {
+    it('returns one render quantum at the context sample rate', () => {
+      const lc = createCompensation({ sampleRate: 44100 });
+
+      // 128 / 44100 ≈ 0.002902 seconds
+      expect(lc.getInputLatency()).toBeCloseTo(128 / 44100, 6);
+    });
+
+    it('scales with sample rate', () => {
+      const lc = createCompensation({ sampleRate: 48000 });
+
+      expect(lc.getInputLatency()).toBeCloseTo(128 / 48000, 6);
+    });
+  });
+
+  describe('getLookAhead', () => {
+    it('returns the configured look-ahead', () => {
+      const lc = createCompensation({ lookAhead: 0.05 });
+
+      expect(lc.getLookAhead()).toBe(0.05);
+    });
+  });
+
+  describe('getTotalCompensation', () => {
+    it('sums all latency components', () => {
+      const lc = createCompensation({
+        outputLatency: 0.01,
+        baseLatency: 0.005,
+        lookAhead: 0.05,
+        sampleRate: 44100,
+      });
+
+      const expected = 0.01 + 0.005 + 0.05 + 128 / 44100;
+
+      expect(lc.getTotalCompensation()).toBeCloseTo(expected, 6);
+    });
+
+    it('handles missing optional latencies gracefully', () => {
+      const lc = new LatencyCompensation({ sampleRate: SAMPLE_RATE }, 0.05);
+
+      // outputLatency=0, baseLatency=0, lookAhead=0.05, input=128/44100
+      const expected = 0.05 + 128 / 44100;
+
+      expect(lc.getTotalCompensation()).toBeCloseTo(expected, 6);
+    });
+  });
+
+  describe('compensationInSamples', () => {
+    it('converts total compensation to integer sample count', () => {
+      const lc = createCompensation({
+        outputLatency: 0.01,
+        baseLatency: 0.005,
+        lookAhead: 0.05,
+        sampleRate: 44100,
+      });
+
+      const totalSeconds = lc.getTotalCompensation();
+      const expected = Math.floor(totalSeconds * 48000);
+
+      expect(lc.compensationInSamples(48000)).toBe(expected);
+    });
+  });
+
+  describe('trimBuffer', () => {
+    function createMockBuffer(
+      length: number,
+      channels = 1,
+      sampleRate = 44100,
+    ): AudioBuffer {
+      const channelArrays: Float32Array[] = [];
+      for (let ch = 0; ch < channels; ch++) {
+        const data = new Float32Array(length);
+        for (let i = 0; i < length; i++) {
+          data[i] = i + ch * 1000;
+        }
+        channelArrays.push(data);
+      }
+
+      return {
+        numberOfChannels: channels,
+        length,
+        sampleRate,
+        duration: length / sampleRate,
+        getChannelData: (ch: number) => channelArrays[ch],
+      } as unknown as AudioBuffer;
+    }
+
+    // jsdom doesn't implement AudioBuffer constructor — provide a minimal stub
+    const OriginalAudioBuffer = globalThis.AudioBuffer;
+
+    beforeAll(() => {
+      globalThis.AudioBuffer = class MockAudioBuffer {
+        numberOfChannels: number;
+        length: number;
+        sampleRate: number;
+        duration: number;
+        private channels: Float32Array[];
+
+        constructor(options: {
+          numberOfChannels: number;
+          length: number;
+          sampleRate: number;
+        }) {
+          this.numberOfChannels = options.numberOfChannels;
+          this.length = options.length;
+          this.sampleRate = options.sampleRate;
+          this.duration = options.length / options.sampleRate;
+          this.channels = [];
+          for (let ch = 0; ch < options.numberOfChannels; ch++) {
+            this.channels.push(new Float32Array(options.length));
+          }
+        }
+
+        getChannelData(ch: number): Float32Array {
+          return this.channels[ch];
+        }
+      } as unknown as typeof AudioBuffer;
+    });
+
+    afterAll(() => {
+      globalThis.AudioBuffer = OriginalAudioBuffer;
+    });
+
+    it('trims leading samples from a mono buffer', () => {
+      const buffer = createMockBuffer(1000);
+      const lc = createCompensation();
+      const compensationSeconds = 100 / 44100;
+
+      const trimmed = lc.trimBuffer(buffer, compensationSeconds);
+
+      expect(trimmed.length).toBe(1000 - 100);
+      expect(trimmed.getChannelData(0)[0]).toBe(100);
+    });
+
+    it('trims leading samples from a stereo buffer', () => {
+      const buffer = createMockBuffer(1000, 2);
+      const lc = createCompensation();
+      const compensationSeconds = 50 / 44100;
+
+      const trimmed = lc.trimBuffer(buffer, compensationSeconds);
+
+      expect(trimmed.numberOfChannels).toBe(2);
+      expect(trimmed.length).toBe(1000 - 50);
+      expect(trimmed.getChannelData(0)[0]).toBe(50);
+      expect(trimmed.getChannelData(1)[0]).toBe(1050);
+    });
+
+    it('returns the original buffer when compensation is zero', () => {
+      const buffer = createMockBuffer(1000);
+      const lc = createCompensation();
+
+      const result = lc.trimBuffer(buffer, 0);
+
+      expect(result).toBe(buffer);
+    });
+
+    it('returns the original buffer when compensation is negative', () => {
+      const buffer = createMockBuffer(1000);
+      const lc = createCompensation();
+
+      const result = lc.trimBuffer(buffer, -0.01);
+
+      expect(result).toBe(buffer);
+    });
+
+    it('returns the original buffer when compensation exceeds buffer length', () => {
+      const buffer = createMockBuffer(100);
+      const lc = createCompensation();
+      const compensationSeconds = 200 / 44100;
+
+      const result = lc.trimBuffer(buffer, compensationSeconds);
+
+      expect(result).toBe(buffer);
+    });
+  });
+});

--- a/src/services/__tests__/WorkletAnalyser.test.ts
+++ b/src/services/__tests__/WorkletAnalyser.test.ts
@@ -1,0 +1,180 @@
+import { vi } from 'vitest';
+import WorkletAnalyser from '../WorkletAnalyser';
+
+// --- AudioWorkletNode mock ---
+
+type MessageHandler = (event: MessageEvent) => void;
+
+function createMockPort() {
+  let onmessageHandler: MessageHandler | null = null;
+  return {
+    postMessage: vi.fn(),
+    get onmessage() {
+      return onmessageHandler;
+    },
+    set onmessage(handler: MessageHandler | null) {
+      onmessageHandler = handler;
+    },
+    // Test helper: simulate a message from the processor
+    _simulateMessage(data: unknown) {
+      if (onmessageHandler) {
+        onmessageHandler({ data } as MessageEvent);
+      }
+    },
+  };
+}
+
+let mockPort: ReturnType<typeof createMockPort>;
+
+function createMockAudioContext() {
+  return {
+    sampleRate: 44100,
+    audioWorklet: {
+      addModule: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as AudioContext;
+}
+
+const OriginalAudioWorkletNode = globalThis.AudioWorkletNode;
+
+beforeEach(() => {
+  mockPort = createMockPort();
+  // Must be a regular function (not arrow) to support `new` in Vitest v4
+  globalThis.AudioWorkletNode = vi.fn().mockImplementation(function () {
+    return {
+      port: mockPort,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }) as unknown as typeof AudioWorkletNode;
+});
+
+afterEach(() => {
+  globalThis.AudioWorkletNode = OriginalAudioWorkletNode;
+});
+
+describe('WorkletAnalyser', () => {
+  describe('initialize', () => {
+    it('loads the worklet module', async () => {
+      const ctx = createMockAudioContext();
+      const analyser = new WorkletAnalyser(ctx);
+
+      await analyser.initialize();
+
+      expect(ctx.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent', async () => {
+      const ctx = createMockAudioContext();
+      const analyser = new WorkletAnalyser(ctx);
+
+      await analyser.initialize();
+      await analyser.initialize();
+
+      expect(ctx.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('input', () => {
+    it('returns an AudioWorkletNode', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+
+      const node = analyser.input;
+
+      expect(node).toBeDefined();
+      expect(AudioWorkletNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses the same node on subsequent accesses', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+
+      const first = analyser.input;
+      const second = analyser.input;
+
+      expect(first).toBe(second);
+      expect(AudioWorkletNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends initial smoothing configuration', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext(), 0.9);
+
+      void analyser.input;
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({
+        type: 'configure',
+        smoothing: 0.9,
+      });
+    });
+  });
+
+  describe('getLoudness', () => {
+    it('returns 0 before any messages', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+
+      expect(analyser.getLoudness()).toBe(0);
+    });
+
+    it('returns the power-curved RMS value after receiving a message', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input; // trigger node creation
+
+      mockPort._simulateMessage({ type: 'loudness', rms: 0.5 });
+
+      // Power curve: Math.pow(0.5, 0.6) ≈ 0.6598
+      expect(analyser.getLoudness()).toBeCloseTo(Math.pow(0.5, 0.6), 4);
+    });
+
+    it('clamps negative RMS to zero', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input;
+
+      mockPort._simulateMessage({ type: 'loudness', rms: -0.1 });
+
+      expect(analyser.getLoudness()).toBe(0);
+    });
+  });
+
+  describe('getRawRms', () => {
+    it('returns the raw RMS without power curve', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input;
+
+      mockPort._simulateMessage({ type: 'loudness', rms: 0.5 });
+
+      expect(analyser.getRawRms()).toBe(0.5);
+    });
+
+    it('clamps negative values to zero', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input;
+
+      mockPort._simulateMessage({ type: 'loudness', rms: -0.1 });
+
+      expect(analyser.getRawRms()).toBe(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('disconnects the node', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      const node = analyser.input;
+
+      analyser.dispose();
+
+      expect(
+        (node as unknown as { disconnect: ReturnType<typeof vi.fn> })
+          .disconnect,
+      ).toHaveBeenCalled();
+    });
+
+    it('resets loudness to zero', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input;
+      mockPort._simulateMessage({ type: 'loudness', rms: 0.8 });
+
+      analyser.dispose();
+
+      expect(analyser.getLoudness()).toBe(0);
+    });
+  });
+});

--- a/src/services/__tests__/WorkletRecorder.test.ts
+++ b/src/services/__tests__/WorkletRecorder.test.ts
@@ -1,0 +1,289 @@
+import { vi } from 'vitest';
+import WorkletRecorder from '../WorkletRecorder';
+
+// --- AudioBuffer stub (jsdom doesn't implement the constructor) ---
+
+const OriginalAudioBuffer = globalThis.AudioBuffer;
+
+beforeAll(() => {
+  globalThis.AudioBuffer = class MockAudioBuffer {
+    numberOfChannels: number;
+    length: number;
+    sampleRate: number;
+    duration: number;
+    private channels: Float32Array[];
+
+    constructor(options: {
+      numberOfChannels: number;
+      length: number;
+      sampleRate: number;
+    }) {
+      this.numberOfChannels = options.numberOfChannels;
+      this.length = options.length;
+      this.sampleRate = options.sampleRate;
+      this.duration = options.length / options.sampleRate;
+      this.channels = [];
+      for (let ch = 0; ch < options.numberOfChannels; ch++) {
+        this.channels.push(new Float32Array(options.length));
+      }
+    }
+
+    getChannelData(ch: number): Float32Array {
+      return this.channels[ch];
+    }
+  } as unknown as typeof AudioBuffer;
+});
+
+afterAll(() => {
+  globalThis.AudioBuffer = OriginalAudioBuffer;
+});
+
+// --- AudioWorkletNode mock ---
+
+type MessageHandler = (event: MessageEvent) => void;
+
+function createMockPort() {
+  const listeners = new Map<string, MessageHandler[]>();
+  let onmessageHandler: MessageHandler | null = null;
+  return {
+    postMessage: vi.fn(),
+    addEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      const handlers = listeners.get(type) ?? [];
+      handlers.push(handler);
+      listeners.set(type, handlers);
+    }),
+    removeEventListener: vi.fn((type: string, handler: MessageHandler) => {
+      const handlers = listeners.get(type) ?? [];
+      listeners.set(
+        type,
+        handlers.filter((h) => h !== handler),
+      );
+    }),
+    get onmessage() {
+      return onmessageHandler;
+    },
+    set onmessage(handler: MessageHandler | null) {
+      onmessageHandler = handler;
+    },
+    // Test helper: simulate a message from the processor
+    _simulateMessage(data: unknown) {
+      const event = { data } as MessageEvent;
+      if (onmessageHandler) onmessageHandler(event);
+      for (const handler of listeners.get('message') ?? []) {
+        handler(event);
+      }
+    },
+    _listeners: listeners,
+  };
+}
+
+let mockPort: ReturnType<typeof createMockPort>;
+
+function createMockAudioContext() {
+  return {
+    sampleRate: 44100,
+    audioWorklet: {
+      addModule: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as AudioContext;
+}
+
+// Mock AudioWorkletNode globally
+const OriginalAudioWorkletNode = globalThis.AudioWorkletNode;
+
+beforeEach(() => {
+  mockPort = createMockPort();
+  // Must be a regular function (not arrow) to support `new` in Vitest v4
+  globalThis.AudioWorkletNode = vi.fn().mockImplementation(function () {
+    return {
+      port: mockPort,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }) as unknown as typeof AudioWorkletNode;
+});
+
+afterEach(() => {
+  globalThis.AudioWorkletNode = OriginalAudioWorkletNode;
+});
+
+describe('WorkletRecorder', () => {
+  describe('initialize', () => {
+    it('loads the worklet module via audioWorklet.addModule', async () => {
+      const ctx = createMockAudioContext();
+      const recorder = new WorkletRecorder(ctx);
+
+      await recorder.initialize();
+
+      expect(ctx.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+    });
+
+    it('is idempotent — subsequent calls are no-ops', async () => {
+      const ctx = createMockAudioContext();
+      const recorder = new WorkletRecorder(ctx);
+
+      await recorder.initialize();
+      await recorder.initialize();
+
+      expect(ctx.audioWorklet.addModule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('input', () => {
+    it('returns an AudioWorkletNode', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      const node = recorder.input;
+
+      expect(node).toBeDefined();
+      expect(AudioWorkletNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses the same node on subsequent accesses', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      const first = recorder.input;
+      const second = recorder.input;
+
+      expect(first).toBe(second);
+      expect(AudioWorkletNode).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('state', () => {
+    it('starts as stopped', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      expect(recorder.state).toBe('stopped');
+    });
+
+    it('transitions to started after start()', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      recorder.start();
+
+      expect(recorder.state).toBe('started');
+    });
+
+    it('transitions back to stopped after stop()', async () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      recorder.start();
+
+      const stopPromise = recorder.stop();
+      // Simulate the processor acknowledging the stop
+      mockPort._simulateMessage({ type: 'stopped', sampleCount: 0 });
+      await stopPromise;
+
+      expect(recorder.state).toBe('stopped');
+    });
+  });
+
+  describe('start', () => {
+    it('sends a start command to the processor port', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      recorder.start();
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({
+        type: 'start',
+      });
+    });
+  });
+
+  describe('stop', () => {
+    it('sends a stop command to the processor port', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      recorder.start();
+
+      recorder.stop();
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({
+        type: 'stop',
+      });
+    });
+
+    it('resolves with an AudioBuffer', async () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      recorder.start();
+
+      // Simulate receiving a chunk
+      mockPort._simulateMessage({
+        type: 'chunk',
+        data: new Float32Array([0.1, 0.2, 0.3]),
+      });
+
+      const stopPromise = recorder.stop();
+      mockPort._simulateMessage({ type: 'stopped', sampleCount: 3 });
+      const result = await stopPromise;
+
+      expect(result).toBeInstanceOf(AudioBuffer);
+      expect(result.length).toBe(3);
+      expect(result.sampleRate).toBe(44100);
+    });
+
+    it('merges multiple chunks into a single buffer', async () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      recorder.start();
+
+      mockPort._simulateMessage({
+        type: 'chunk',
+        data: new Float32Array([0.1, 0.2]),
+      });
+      mockPort._simulateMessage({
+        type: 'chunk',
+        data: new Float32Array([0.3, 0.4, 0.5]),
+      });
+
+      const stopPromise = recorder.stop();
+      mockPort._simulateMessage({ type: 'stopped', sampleCount: 5 });
+      const result = await stopPromise;
+
+      expect(result.length).toBe(5);
+      const channelData = result.getChannelData(0);
+      expect(channelData[0]).toBeCloseTo(0.1);
+      expect(channelData[1]).toBeCloseTo(0.2);
+      expect(channelData[2]).toBeCloseTo(0.3);
+      expect(channelData[3]).toBeCloseTo(0.4);
+      expect(channelData[4]).toBeCloseTo(0.5);
+    });
+
+    it('rejects when not recording', async () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      await expect(recorder.stop()).rejects.toThrow(
+        'WorkletRecorder is not recording',
+      );
+    });
+  });
+
+  describe('dispose', () => {
+    it('disconnects the node', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      const node = recorder.input;
+
+      recorder.dispose();
+
+      expect(
+        (node as unknown as { disconnect: ReturnType<typeof vi.fn> })
+          .disconnect,
+      ).toHaveBeenCalled();
+    });
+
+    it('resets recording state', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+      recorder.start();
+
+      recorder.dispose();
+
+      expect(recorder.state).toBe('stopped');
+    });
+  });
+
+  describe('sampleRate', () => {
+    it('returns the audio context sample rate', () => {
+      const recorder = new WorkletRecorder(createMockAudioContext());
+
+      expect(recorder.sampleRate).toBe(44100);
+    });
+  });
+});

--- a/src/services/audioWorkletTypes.d.ts
+++ b/src/services/audioWorkletTypes.d.ts
@@ -1,0 +1,19 @@
+// Type declarations for AudioWorklet scope APIs that TypeScript's DOM lib
+// does not expose to the main-thread scope. These types are used by
+// RecordingProcessor.ts and AnalysisProcessor.ts which run inside an
+// AudioWorklet.
+
+declare class AudioWorkletProcessor {
+  readonly port: MessagePort;
+  constructor();
+  process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>,
+  ): boolean;
+}
+
+declare function registerProcessor(
+  name: string,
+  processorCtor: new () => AudioWorkletProcessor,
+): void;


### PR DESCRIPTION
Issue #170: Extract latency estimation from RecordingService into a
dedicated LatencyCompensation service with explicit getters for each
latency component (output, base, input, look-ahead) and a trimBuffer
utility for trimming leading latency samples from recorded audio.

Issue #169: Add AudioWorklet-based recording pipeline as an alternative
to Tone.Recorder (MediaRecorder). RecordingProcessor captures raw PCM
Float32Array chunks on the audio thread, WorkletRecorder accumulates
them on the main thread and merges into an AudioBuffer on stop.
RecordingService tries the worklet path at startup and falls back to
Tone.Recorder silently. MicrophoneService gains low-latency
getUserMedia constraint constants and a widened connect() signature
for native AudioNode.

Issue #178: Add AnalysisProcessor AudioWorklet that computes RMS
loudness on the audio thread with exponential smoothing, and
WorkletAnalyser as a drop-in wrapper with the same getLoudness()
pattern used by MixerService.

https://claude.ai/code/session_015qrK6DdTFJfqFGDMwUp8SY