### PR TITLE
Fix AudioWorklet recording by bypassing standardized-audio-context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Services own state as private signals, expose plain getters for non-reactive rea
 - Signals owned (private): `recordingState`, `isCountingIn`, `isRecording`
 - Plain getters: `recordingState`, `isCountingIn`, `isRecording`
 - Encapsulates `MicrophoneService` (private) — Tone.UserMedia wrapper for microphone input
+- Encapsulates `WorkletRecorder` (private) — AudioWorklet-based PCM capture; falls back to `Tone.Recorder` if unavailable
 - Public API: `arm()`, `disarm()`, `startRecording()`, `stopRecording()`, `toggleArm()`, `startCountIn()`, `stopCountIn()`, `isTransportLocked()`, `prepareMicrophone()`, `closeMicrophone()`, `getLoudness()`, `getMicrophoneSource()`
 - The `armed` state models the GarageBand workflow: arm, position, then play to record
 
@@ -169,6 +170,9 @@ src/
 │   │                                  #   encapsulates MixerService
 │   ├── MixerService.ts                # Tone.Player + Tone.Channel chain per track (private to TrackService)
 │   ├── MicrophoneService.ts           # Tone.UserMedia wrapper + meter (private to RecordingService)
+│   ├── WorkletRecorder.ts             # Main-thread wrapper for AudioWorklet PCM capture
+│   ├── RecordingProcessor.ts          # AudioWorkletProcessor: captures PCM chunks on audio thread
+│   ├── LatencyCompensation.ts         # Round-trip latency estimation for recording alignment
 │   └── OfflineAnalyser.ts             # OfflineAudioContext + AnalyserNode for spectrogram data
 │
 ├── signals/
@@ -262,6 +266,15 @@ Channel volume (slider 0–100) is converted to decibels: `20 * Math.log((value 
 
 ### @dnd-kit is PointerSensor only
 `Mixer.tsx` registers only `PointerSensor` (not `MouseSensor` or `TouchSensor`). This is intentional to unify pointer events across devices.
+
+### Tone.js context is not the native AudioContext
+Tone.js v14+ uses `standardized-audio-context`, which wraps the native browser `AudioContext` in a proxy that maintains an internal node registry. `Tone.getContext().rawContext` returns this **wrapper**, not the native `AudioContext`. The wrapper's `instanceof AudioContext` check returns `false`.
+
+This wrapper breaks `AudioWorkletNode` connections — calling `.connect()` between a wrapper-created node and a native node triggers a "value with the given key could not be found" error from the internal registry ([Tone.js #712](https://github.com/Tonejs/Tone.js/issues/712)).
+
+The worklet recording path (`WorkletRecorder`, `RecordingProcessor`) bypasses this entirely by extracting the actual native `AudioContext` via `rawContext._nativeContext` (a private field on the standardized-audio-context wrapper). All nodes in the worklet chain — `MediaStreamSourceNode`, `AudioWorkletNode`, and `destination` — are created on the native context. This avoids the registry and keeps the recording path fully native. The `_nativeContext` extraction happens once in `RecordingService.initializeWorkletRecorder()` and is stored for reuse during recording.
+
+If `_nativeContext` is unavailable (e.g., the context is already native), the code falls back to using `rawContext` directly. If worklet initialization fails entirely, `RecordingService` silently falls back to `Tone.Recorder` (MediaRecorder-based).
 
 ### Signal access pattern
 Every signal owner (service or signal module) provides three tiers of access:

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -31,6 +31,7 @@ type Context = {
   decodeAudioData: (arrayBuffer: ArrayBuffer) => Promise<AudioBuffer>;
   lookAhead: number;
   rawContext: AudioContext | OfflineAudioContext;
+  sampleRate: number;
 };
 
 export type OverdubResult = {
@@ -60,6 +61,17 @@ class RecordingService {
 
   private recorder: Tone.Recorder;
   private workletRecorder: WorkletRecorder | null = null;
+  // Native MediaStreamSourceNode used to bridge the microphone stream to the
+  // AudioWorklet recorder. Created on the native AudioContext (bypassing
+  // standardized-audio-context) so the worklet node can be connected without
+  // triggering node registry errors. Cleaned up when recording stops.
+  private nativeSourceNode: MediaStreamAudioSourceNode | null = null;
+  // The actual native browser AudioContext, extracted from Tone.js's
+  // standardized-audio-context wrapper. Needed to create native audio nodes
+  // that can connect to the native AudioWorkletNode without triggering
+  // standardized-audio-context's node registry errors.
+  // See https://github.com/Tonejs/Tone.js/issues/712.
+  private nativeAudioContext: AudioContext | null = null;
   private transport: Transport;
   private context: Context;
   private recordingStartTime: number | null = null;
@@ -190,13 +202,24 @@ class RecordingService {
     try {
       const rawContext = this.context.rawContext as AudioContext;
       if (!rawContext.audioWorklet) return;
-      const wr = new WorkletRecorder(rawContext);
+      // Tone.js v14+ uses standardized-audio-context, whose rawContext is a
+      // wrapper — not the native browser AudioContext. The wrapper's internal
+      // node registry breaks when connecting AudioWorkletNode instances.
+      // Extract the actual native AudioContext via the private _nativeContext
+      // field so all worklet-path nodes are native and bypass the registry.
+      // See https://github.com/Tonejs/Tone.js/issues/712.
+      const nativeCtx =
+        (rawContext as unknown as { _nativeContext?: AudioContext })
+          ._nativeContext ?? rawContext;
+      this.nativeAudioContext = nativeCtx;
+      const wr = new WorkletRecorder(nativeCtx);
       await wr.initialize();
       this.workletRecorder = wr;
     } catch {
       // AudioWorklet not supported or module failed to load — keep using
       // Tone.Recorder as fallback.
       this.workletRecorder = null;
+      this.nativeAudioContext = null;
     }
   }
 
@@ -214,8 +237,18 @@ class RecordingService {
     // Capture transport position before starting
     this.recordingStartTime = this.transport.seconds;
 
-    if (this.workletRecorder) {
-      this.microphone.connect(this.workletRecorder.input);
+    if (this.workletRecorder && this.nativeAudioContext) {
+      // Connect microphone to worklet via a native MediaStreamSourceNode.
+      // Tone.UserMedia exposes its MediaStream as _stream (private). We
+      // create a native source node on the native AudioContext and connect it
+      // to the native AudioWorkletNode, bypassing standardized-audio-context
+      // entirely for the recording path.
+      const stream = (
+        this.microphone.source as unknown as { _stream: MediaStream }
+      )._stream;
+      this.nativeSourceNode =
+        this.nativeAudioContext.createMediaStreamSource(stream);
+      this.nativeSourceNode.connect(this.workletRecorder.input);
       this.workletRecorder.start();
       this.transport.start();
     } else {
@@ -246,6 +279,11 @@ class RecordingService {
 
     if (this.workletRecorder) {
       const audioBuffer = await this.workletRecorder.stop();
+      // Clean up native source node before closing the microphone
+      if (this.nativeSourceNode) {
+        this.nativeSourceNode.disconnect();
+        this.nativeSourceNode = null;
+      }
       this.microphone.close();
 
       // Encode to ArrayBuffer (WAV) for undo/redo and blob URL storage.

--- a/src/services/WorkletRecorder.ts
+++ b/src/services/WorkletRecorder.ts
@@ -5,6 +5,11 @@
 // PCM chunks posted from the audio thread. On stop, merges chunks into a
 // single AudioBuffer — no MediaRecorder encoding delay, no variable chunk
 // timing, and sample-accurate start/stop timestamps.
+//
+// Uses the native browser AudioContext directly (not the standardized-audio-
+// context wrapper used by Tone.js). This avoids the node registry lookup
+// error that occurs when connecting standardized-audio-context AudioWorklet
+// nodes. See https://github.com/Tonejs/Tone.js/issues/712.
 
 import { type ProcessorMessage } from './RecordingProcessor';
 
@@ -17,6 +22,7 @@ class WorkletRecorder {
   private chunks: Float32Array[] = [];
   private recording = false;
   private initialized = false;
+  private onStopped: ((buffer: AudioBuffer) => void) | null = null;
 
   constructor(audioContext: AudioContext) {
     this.audioContext = audioContext;
@@ -34,12 +40,16 @@ class WorkletRecorder {
 
   // Returns the AudioWorkletNode so the caller can connect a source to it
   // (e.g., microphone → worklet node).
-  get input(): AudioNode {
+  get input(): AudioWorkletNode {
     if (!this.node) {
       this.node = new AudioWorkletNode(this.audioContext, PROCESSOR_NAME, {
         channelCount: CHANNEL_COUNT,
       });
       this.setupMessageHandler(this.node);
+      // Connect to destination so process() is called on the audio thread.
+      // The processor captures input only and outputs silence, so this is
+      // inaudible.
+      this.node.connect(this.audioContext.destination);
     }
     return this.node;
   }
@@ -69,14 +79,7 @@ class WorkletRecorder {
         return;
       }
 
-      const onStopped = (event: MessageEvent<ProcessorMessage>) => {
-        if (event.data.type !== 'stopped') return;
-        this.node!.port.removeEventListener('message', onStopped);
-        this.recording = false;
-        resolve(this.mergeChunks());
-      };
-
-      this.node.port.addEventListener('message', onStopped);
+      this.onStopped = (buffer: AudioBuffer) => resolve(buffer);
       this.node.port.postMessage({ type: 'stop' });
     });
   }
@@ -86,6 +89,7 @@ class WorkletRecorder {
     this.node = null;
     this.chunks = [];
     this.recording = false;
+    this.onStopped = null;
   }
 
   private ensureNode(): void {
@@ -97,6 +101,13 @@ class WorkletRecorder {
     node.port.onmessage = (event: MessageEvent<ProcessorMessage>) => {
       if (event.data.type === 'chunk') {
         this.chunks.push(event.data.data);
+      } else if (event.data.type === 'stopped') {
+        this.recording = false;
+        const buffer = this.mergeChunks();
+        if (this.onStopped) {
+          this.onStopped(buffer);
+          this.onStopped = null;
+        }
       }
     };
   }

--- a/src/services/__tests__/WorkletRecorder.test.ts
+++ b/src/services/__tests__/WorkletRecorder.test.ts
@@ -43,45 +43,32 @@ afterAll(() => {
 type MessageHandler = (event: MessageEvent) => void;
 
 function createMockPort() {
-  const listeners = new Map<string, MessageHandler[]>();
   let onmessageHandler: MessageHandler | null = null;
   return {
     postMessage: vi.fn(),
-    addEventListener: vi.fn((type: string, handler: MessageHandler) => {
-      const handlers = listeners.get(type) ?? [];
-      handlers.push(handler);
-      listeners.set(type, handlers);
-    }),
-    removeEventListener: vi.fn((type: string, handler: MessageHandler) => {
-      const handlers = listeners.get(type) ?? [];
-      listeners.set(
-        type,
-        handlers.filter((h) => h !== handler),
-      );
-    }),
     get onmessage() {
       return onmessageHandler;
     },
     set onmessage(handler: MessageHandler | null) {
       onmessageHandler = handler;
     },
-    // Test helper: simulate a message from the processor
+    // Test helper: simulate a message from the processor.
+    // Only calls the onmessage handler, matching real browser behavior
+    // where setting .onmessage takes precedence over addEventListener.
     _simulateMessage(data: unknown) {
       const event = { data } as MessageEvent;
       if (onmessageHandler) onmessageHandler(event);
-      for (const handler of listeners.get('message') ?? []) {
-        handler(event);
-      }
     },
-    _listeners: listeners,
   };
 }
 
 let mockPort: ReturnType<typeof createMockPort>;
 
 function createMockAudioContext() {
+  mockPort = createMockPort();
   return {
     sampleRate: 44100,
+    destination: {},
     audioWorklet: {
       addModule: vi.fn().mockResolvedValue(undefined),
     },
@@ -92,7 +79,6 @@ function createMockAudioContext() {
 const OriginalAudioWorkletNode = globalThis.AudioWorkletNode;
 
 beforeEach(() => {
-  mockPort = createMockPort();
   // Must be a regular function (not arrow) to support `new` in Vitest v4
   globalThis.AudioWorkletNode = vi.fn().mockImplementation(function () {
     return {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -56,6 +56,13 @@ vi.mock('tone', () => {
     decodeAudioData: vi.fn().mockResolvedValue({}),
     lookAhead: 0.05,
     sampleRate: 44100,
+    destination: {},
+    addAudioWorkletModule: vi.fn().mockResolvedValue(undefined),
+    createAudioWorkletNode: vi.fn().mockReturnValue({
+      port: { postMessage: vi.fn(), onmessage: null },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }),
     rawContext: {
       outputLatency: 0.01,
       baseLatency: 0.005,


### PR DESCRIPTION
## Summary

- Extract the native browser `AudioContext` from Tone.js's `standardized-audio-context` wrapper (`rawContext._nativeContext`) so the entire worklet recording chain uses native nodes — fixing the node registry error that broke `AudioWorkletNode` connections ([Tone.js #712](https://github.com/Tonejs/Tone.js/issues/712))
- Fix `MessagePort` handler conflict in `WorkletRecorder` where `.onmessage` prevented `addEventListener('message', ...)` from firing, causing `stop()` to never resolve
- Connect `AudioWorkletNode` to `destination` so the worklet processor's `process()` is actually called on the audio thread
- Document the Tone.js context wrapper issue and worklet recording architecture in CLAUDE.md

## Test plan

- [x] All 6 recording e2e tests pass (previously 5 were failing with width=0 spectrograms)
- [x] All 83 e2e tests pass
- [x] All 508 unit tests pass
- [x] WorkletRecorder unit tests updated to match real browser `onmessage` behavior

https://claude.ai/code/session_01NLqX6usvBM31MEY6gkT3J3