### PR TITLE
Fix live spectrogram not rendering on first recording

### DIFF
--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -147,9 +147,17 @@ function drawRecordingFrame(
 ): void {
   if (!buffer || !visualizer) return;
 
-  const isRecActive = recordingHook.isRecording;
+  const isRecActive = recordingHook.isOverdubRecording();
   const recordingStartTime = recordingHook.getRecordingStartTime();
-  const elapsed = Math.max(0, playbackHook.transportTime - recordingStartTime);
+  // Read engine time directly instead of the transportTime signal.
+  // The signal is updated by the Scrubber animation loop which only runs
+  // when playbackState is 'playing'. During the first recording from
+  // position 0, playback.play() is never called (no count-in lead-in),
+  // so the signal stays at 0 even though the transport is running.
+  const elapsed = Math.max(
+    0,
+    playbackHook.getEngineTime() - recordingStartTime,
+  );
   const contentWidth = elapsed * pixelsPerSecond;
 
   // Update container width and offset directly to avoid React re-renders

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -109,6 +109,7 @@ vi.mock('../../../../hooks/useRecordingService', () => ({
     startRecording: () => recordingService.startRecording(),
     stopRecording: () => recordingService.stopRecording(),
     getRecordingStartTime: () => recordingService.getRecordingStartTime(),
+    isOverdubRecording: () => recordingService.isOverdubRecording(),
     getMicrophoneSource: () => recordingService.getMicrophoneSource(),
     reset: () => recordingService.reset(),
   }),
@@ -402,10 +403,11 @@ describe('recording mode', () => {
     expect(spectrogram).toHaveStyle({ width: '0px' });
   });
 
-  it('reads visualization data from FrequencyVisualizer during recording', () => {
+  it('reads visualization data from FrequencyVisualizer during overdub recording', () => {
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.setTransportTime(1.5);
+    vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.5);
+    vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {
@@ -436,7 +438,8 @@ describe('recording mode', () => {
   it('offsets container by recording start time during overdub', () => {
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.setTransportTime(5.0);
+    vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(5.0);
+    vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {
@@ -453,7 +456,6 @@ describe('recording mode', () => {
       mockCtx as unknown as CanvasRenderingContext2D,
     );
 
-    // Spy on getRecordingStartTime to return 3.0
     vi.spyOn(recordingService, 'getRecordingStartTime').mockReturnValue(3.0);
 
     const { container } = render(<Spectrogram {...recordingProps} />);
@@ -469,10 +471,19 @@ describe('recording mode', () => {
     vi.restoreAllMocks();
   });
 
-  it('updates container width based on elapsed recording time', () => {
+  it('renders live spectrogram using engine time even when transport signal is stale', () => {
+    // Simulates the first-recording bug: the Scrubber animation loop only
+    // runs when playbackState is 'playing', but during the first recording
+    // from position 0 playback.play() is never called (no count-in lead-in).
+    // The transportTime signal stays at 0 while the transport engine is
+    // actually advancing.  The spectrogram must read the engine time
+    // directly so it renders regardless of the signal state.
+
     recordingService.arm();
     recordingService.startRecording();
-    playbackService.setTransportTime(2.0);
+    // Do NOT call playbackService.setTransportTime() — signal stays at 0
+    vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(2.0);
+    vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
     mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
 
     const mockCtx = {
@@ -489,7 +500,42 @@ describe('recording mode', () => {
       mockCtx as unknown as CanvasRenderingContext2D,
     );
 
-    // Recording started at 0
+    vi.spyOn(recordingService, 'getRecordingStartTime').mockReturnValue(0);
+
+    const { container } = render(<Spectrogram {...recordingProps} />);
+
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    const spectrogram = container.querySelector('.spectrogram');
+    // elapsed = getEngineTime() - 0 = 2.0, width = 2.0 * 200 = 400
+    expect(spectrogram).toHaveStyle({ width: '400px' });
+
+    vi.restoreAllMocks();
+  });
+
+  it('updates container width based on elapsed recording time', () => {
+    recordingService.arm();
+    recordingService.startRecording();
+    vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(2.0);
+    vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
+    mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: 800, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
     vi.spyOn(recordingService, 'getRecordingStartTime').mockReturnValue(0);
 
     const { container } = render(<Spectrogram {...recordingProps} />);


### PR DESCRIPTION
The live spectrogram used playbackHook.transportTime (a signal) to
compute elapsed recording time. This signal is updated by the Scrubber
animation loop, which only runs when playbackState is 'playing'. During
the first recording from position 0, playback.play() is never called
(no count-in lead-in available), so the signal stays at 0 and
contentWidth stays at 0 — nothing renders.

Fix: read engine time directly via playbackHook.getEngineTime(), which
always reflects the real transport position regardless of the Scrubber
loop. Also tighten the frame accumulation guard from isRecording (true
during armed/count-in) to isOverdubRecording() (true only when the
recorder is actively capturing), preventing premature frame buildup.

https://claude.ai/code/session_01V9rAM7D87B7Fg3yZVAMxoS