### PR TITLE
Apply trimBuffer in recording pipeline to fix overdub timeshift (#170)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,3 +320,7 @@ Vitest + React Testing Library. Test setup (`setupTests.ts`) globally mocks:
 
 Tests read service state through plain getters (`service.playbackState`, `getFocusedTracks()`, `getPixelsPerSecond()`), not through `.signals.*.value`. This keeps tests decoupled from signal internals and makes assertions more readable.
 
+## Pull Requests
+
+After all tasks are done — code changes committed and pushed — create a pull request using `gh pr create --repo vsandvold/mawimbi`. Target the `master` branch. Include a summary of what changed and a test plan in the PR body.
+

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -68,7 +68,6 @@ describe('useMicrophone', () => {
       audioBuffer: {} as AudioBuffer,
       arrayBuffer: new ArrayBuffer(16),
       startTime: 0,
-      latencyCompensation: 0.05,
     });
     vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
 
@@ -103,7 +102,6 @@ describe('useMicrophone', () => {
       expect.anything(),
       expect.anything(),
       0,
-      0.05,
     );
     expect(mockProjectDispatch).toHaveBeenCalledWith([
       'ADD_TRACK',

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -171,13 +171,12 @@ export const useMicrophone = (isRecording: boolean) => {
         return;
       }
       try {
-        const { audioBuffer, arrayBuffer, startTime, latencyCompensation } =
+        const { audioBuffer, arrayBuffer, startTime } =
           await recording.stopOverdubRecording();
         const { trackId } = trackHook.createRecordedTrack(
           audioBuffer,
           arrayBuffer,
           startTime,
-          latencyCompensation,
         );
         projectDispatch([
           ADD_TRACK,

--- a/src/hooks/useTrackService.ts
+++ b/src/hooks/useTrackService.ts
@@ -39,14 +39,7 @@ export function useTrackService() {
       audioBuffer: AudioBuffer,
       arrayBuffer: ArrayBuffer,
       startTime: number,
-      latencyCompensation: number,
-    ) =>
-      service.createRecordedTrack(
-        audioBuffer,
-        arrayBuffer,
-        startTime,
-        latencyCompensation,
-      ),
+    ) => service.createRecordedTrack(audioBuffer, arrayBuffer, startTime),
 
     // --- Signal management ---
 

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -38,7 +38,6 @@ export type OverdubResult = {
   audioBuffer: AudioBuffer;
   arrayBuffer: ArrayBuffer;
   startTime: number;
-  latencyCompensation: number;
 };
 
 class RecordingService {
@@ -275,10 +274,10 @@ class RecordingService {
     // to the beginning during the async gap.
     this.transport.seconds = startTime;
 
-    const latencyCompensation = this.estimateRoundTripLatency();
+    const compensation = this.latencyCompensation.getTotalCompensation();
 
     if (this.workletRecorder) {
-      const audioBuffer = await this.workletRecorder.stop();
+      const rawBuffer = await this.workletRecorder.stop();
       // Clean up native source node before closing the microphone
       if (this.nativeSourceNode) {
         this.nativeSourceNode.disconnect();
@@ -286,21 +285,38 @@ class RecordingService {
       }
       this.microphone.close();
 
-      // Encode to ArrayBuffer (WAV) for undo/redo and blob URL storage.
-      // The WorkletRecorder produces PCM directly — we encode to a raw
-      // interleaved buffer for downstream consumption.
+      // Trim leading latency samples so the recording aligns with the
+      // transport timeline. Without this, the overdub is shifted forward
+      // by the round-trip latency (output + base + look-ahead + input).
+      const audioBuffer = this.latencyCompensation.trimBuffer(
+        rawBuffer,
+        compensation,
+      );
       const arrayBuffer = this.audioBufferToArrayBuffer(audioBuffer);
 
-      return { audioBuffer, arrayBuffer, startTime, latencyCompensation };
+      return { audioBuffer, arrayBuffer, startTime };
     }
 
     const blob = await this.recorder.stop();
     this.microphone.close();
 
-    const arrayBuffer = await blob.arrayBuffer();
-    const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
+    const rawArrayBuffer = await blob.arrayBuffer();
+    const rawBuffer = await this.context.decodeAudioData(rawArrayBuffer);
 
-    return { audioBuffer, arrayBuffer, startTime, latencyCompensation };
+    // Trim leading latency samples so the recording aligns with the
+    // transport timeline.
+    const audioBuffer = this.latencyCompensation.trimBuffer(
+      rawBuffer,
+      compensation,
+    );
+    // Re-encode from the trimmed buffer when trimming occurred, otherwise
+    // keep the original encoded bytes.
+    const arrayBuffer =
+      audioBuffer !== rawBuffer
+        ? this.audioBufferToArrayBuffer(audioBuffer)
+        : rawArrayBuffer;
+
+    return { audioBuffer, arrayBuffer, startTime };
   }
 
   isOverdubRecording(): boolean {

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -122,7 +122,6 @@ class TrackService {
     audioBuffer: AudioBuffer,
     arrayBuffer: ArrayBuffer,
     startTime: number,
-    latencyCompensation: number,
   ): TrackCreationResult {
     const trackId = uuidv4();
     const blob = new Blob([arrayBuffer], { type: 'audio/*' });
@@ -132,14 +131,11 @@ class TrackService {
     const initialVolume =
       LoudnessNormalizer.gainToInitialVolume(normalizationGainDb);
 
-    // The audioOffset trims latency from the beginning of the recording.
-    // The startTime positions the track at the correct transport position.
     this.mixer.createChannel(
       trackId,
       audioBuffer,
       normalizationGainDb,
       startTime,
-      latencyCompensation,
     );
     this.audioSourceRepository.add({
       id: trackId,

--- a/src/services/__tests__/RecordingService.test.ts
+++ b/src/services/__tests__/RecordingService.test.ts
@@ -12,6 +12,57 @@ beforeEach(() => {
   service = new RecordingService(transport, Tone.context);
 });
 
+// jsdom doesn't implement AudioBuffer constructor — provide a minimal stub
+// so LatencyCompensation.trimBuffer() can create trimmed buffers.
+const OriginalAudioBuffer = globalThis.AudioBuffer;
+
+beforeAll(() => {
+  globalThis.AudioBuffer = class MockAudioBuffer {
+    numberOfChannels: number;
+    length: number;
+    sampleRate: number;
+    duration: number;
+    private channels: Float32Array[];
+
+    constructor(options: {
+      numberOfChannels: number;
+      length: number;
+      sampleRate: number;
+    }) {
+      this.numberOfChannels = options.numberOfChannels;
+      this.length = options.length;
+      this.sampleRate = options.sampleRate;
+      this.duration = options.length / options.sampleRate;
+      this.channels = [];
+      for (let ch = 0; ch < options.numberOfChannels; ch++) {
+        this.channels.push(new Float32Array(options.length));
+      }
+    }
+
+    getChannelData(ch: number): Float32Array {
+      return this.channels[ch];
+    }
+  } as unknown as typeof AudioBuffer;
+});
+
+afterAll(() => {
+  globalThis.AudioBuffer = OriginalAudioBuffer;
+});
+
+function createMockBuffer(length: number, sampleRate = 44100): AudioBuffer {
+  const data = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    data[i] = i / length;
+  }
+  return {
+    numberOfChannels: 1,
+    length,
+    sampleRate,
+    duration: length / sampleRate,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer;
+}
+
 describe('RecordingService', () => {
   describe('initial state', () => {
     it('starts in idle state', () => {
@@ -236,6 +287,48 @@ describe('RecordingService', () => {
 
       expect(service.recordingState).toBe('idle');
       expect(service.isCountingIn).toBe(false);
+    });
+  });
+
+  describe('stopOverdubRecording', () => {
+    it('trims the recorded buffer by the latency compensation', async () => {
+      const sampleRate = 44100;
+      const rawLength = sampleRate; // 1 second of audio
+      const rawBuffer = createMockBuffer(rawLength, sampleRate);
+      vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(rawBuffer);
+
+      await service.startOverdubRecording();
+      const result = await service.stopOverdubRecording();
+
+      const compensation = service.estimateRoundTripLatency();
+      const expectedTrim = Math.floor(compensation * sampleRate);
+      expect(result.audioBuffer.length).toBe(rawLength - expectedTrim);
+    });
+
+    it('returns an arrayBuffer that matches the trimmed audioBuffer', async () => {
+      const sampleRate = 44100;
+      const rawBuffer = createMockBuffer(sampleRate, sampleRate);
+      vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(rawBuffer);
+
+      await service.startOverdubRecording();
+      const result = await service.stopOverdubRecording();
+
+      // Mono Float32: 4 bytes per sample
+      const expectedBytes = result.audioBuffer.length * 1 * 4;
+      expect(result.arrayBuffer.byteLength).toBe(expectedBytes);
+    });
+
+    it('preserves the original startTime from when recording began', async () => {
+      const transport = Tone.getTransport();
+      transport.seconds = 5.0;
+      service = new RecordingService(transport, Tone.context);
+      const rawBuffer = createMockBuffer(44100);
+      vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(rawBuffer);
+
+      await service.startOverdubRecording();
+      const result = await service.stopOverdubRecording();
+
+      expect(result.startTime).toBe(5.0);
     });
   });
 });

--- a/src/services/__tests__/TrackService.test.ts
+++ b/src/services/__tests__/TrackService.test.ts
@@ -331,14 +331,13 @@ describe('TrackService', () => {
   });
 
   describe('createRecordedTrack', () => {
-    it('creates a track with start time and latency compensation', () => {
+    it('creates a track with the given start time', () => {
       const audioBuffer = mockAudioBuffer({ duration: 5.0 });
 
       const { trackId, initialVolume } = service.createRecordedTrack(
         audioBuffer,
         new ArrayBuffer(16),
         3.0,
-        0.05,
       );
 
       expect(trackId).toBeDefined();
@@ -353,7 +352,6 @@ describe('TrackService', () => {
         audioBuffer,
         new ArrayBuffer(16),
         0,
-        0.05,
       );
 
       expect(service.getSignals(trackId)).toBeDefined();
@@ -362,7 +360,7 @@ describe('TrackService', () => {
     it('includes recorded track in total time calculation', () => {
       const audioBuffer = mockAudioBuffer({ duration: 5.0 });
 
-      service.createRecordedTrack(audioBuffer, new ArrayBuffer(16), 8.0, 0.05);
+      service.createRecordedTrack(audioBuffer, new ArrayBuffer(16), 8.0);
 
       // Total = startTime (8) + duration (5) = 13
       expect(service.getTotalTime()).toBe(13.0);


### PR DESCRIPTION
## Summary

- Apply `LatencyCompensation.trimBuffer()` in `RecordingService.stopOverdubRecording()` so recorded buffers have leading latency samples removed before being stored — fixes the overdub timeshift where new recordings were shifted forward by the round-trip latency
- Remove the `latencyCompensation` pass-through from `OverdubResult`, `TrackService.createRecordedTrack()`, and `useTrackService` bridge hook, since the compensation is now baked into the trimmed buffer
- Also fixes a secondary bug where `recreateChannel()` (undo/redo) silently lost the audio offset because it never received the `latencyCompensation` parameter

## Test plan

- [x] New tests in `RecordingService.test.ts` verify trimmed buffer length, matching arrayBuffer size, and preserved startTime
- [x] Updated `TrackService.test.ts` to match new 3-parameter `createRecordedTrack` signature
- [x] Updated `workstationEffects.test.ts` mock and assertion to match simplified `OverdubResult`
- [x] All 512 tests pass
- [x] ESLint clean
- [x] Production build succeeds

https://claude.ai/code/session_014m8UUHcAWk3We8NzDs2QRK