### PR TITLE
Wire WorkletAnalyser into MixerService as primary loudness meter (#178)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,3 +324,10 @@ Tests read service state through plain getters (`service.playbackState`, `getFoc
 
 After all tasks are done — code changes committed and pushed — create a pull request using `gh pr create --repo vsandvold/mawimbi`. Target the `master` branch. Include a summary of what changed and a test plan in the PR body.
 
+## Issue Updates
+
+When working on a GitHub issue, comment on the issue after completing work. Use `gh issue comment <number> --repo vsandvold/mawimbi`. The comment should include:
+
+1. **What was done** — summarize the changes made (files modified, new APIs, patterns followed)
+2. **Recommended next steps** — list concrete follow-up tasks that remain, numbered to show suggested order
+

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -10,6 +10,7 @@ import PlaybackService from './PlaybackService';
 import RecordingService from './RecordingService';
 import TrackService from './TrackService';
 import SpectrogramCache from './SpectrogramCache';
+import WorkletAnalyser from './WorkletAnalyser';
 
 // Reduce scheduling lookahead from the default 0.1s to 0.05s for lower
 // recording latency while keeping enough headroom to avoid scheduling glitches
@@ -46,6 +47,27 @@ class AudioService {
     // Attempt to initialize the AudioWorklet-based recorder for
     // sample-accurate capture. Falls back to Tone.Recorder silently.
     this.recordingService.initializeWorkletRecorder();
+
+    // Attempt to initialize the AudioWorklet-based loudness analyser.
+    // Replaces Tone.Meter on the destination for lower-latency metering.
+    // Falls back to Tone.Meter silently if AudioWorklet is unavailable.
+    this.initializeWorkletAnalyser();
+  }
+
+  private async initializeWorkletAnalyser(): Promise<void> {
+    try {
+      const rawContext = Tone.context.rawContext as AudioContext;
+      if (!rawContext.audioWorklet) return;
+      const nativeCtx =
+        (rawContext as unknown as { _nativeContext?: AudioContext })
+          ._nativeContext ?? rawContext;
+      const analyser = new WorkletAnalyser(nativeCtx);
+      await analyser.initialize();
+      this.trackService.useWorkletAnalyser(analyser);
+    } catch {
+      // AudioWorklet not supported or module failed to load — keep using
+      // Tone.Meter as fallback.
+    }
   }
 
   static getInstance(): AudioService {

--- a/src/services/MixerService.ts
+++ b/src/services/MixerService.ts
@@ -1,4 +1,5 @@
 import * as Tone from 'tone';
+import type WorkletAnalyser from './WorkletAnalyser';
 
 const SMOOTHING = 0.8;
 const POWER_CURVE_EXPONENT = 0.6;
@@ -6,6 +7,7 @@ const POWER_CURVE_EXPONENT = 0.6;
 class MixerService {
   private audioChannelRepository: AudioChannelRepository;
   private meter: Tone.Meter;
+  private workletAnalyser: WorkletAnalyser | null = null;
 
   constructor() {
     this.audioChannelRepository = new AudioChannelRepository();
@@ -13,7 +15,19 @@ class MixerService {
     Tone.getDestination().connect(this.meter);
   }
 
+  // Replace Tone.Meter with a WorkletAnalyser for loudness metering.
+  // Call after the analyser has been initialized (module loaded).
+  // Re-routes the destination connection from Tone.Meter to the worklet.
+  useWorkletAnalyser(analyser: WorkletAnalyser): void {
+    Tone.getDestination().disconnect(this.meter);
+    this.workletAnalyser = analyser;
+    Tone.getDestination().connect(analyser.input);
+  }
+
   getLoudness(): number {
+    if (this.workletAnalyser) {
+      return this.workletAnalyser.getLoudness();
+    }
     const value = this.meter.getValue();
     const clamped = typeof value === 'number' ? Math.max(0, value) : 0;
     return Math.pow(clamped, POWER_CURVE_EXPONENT);

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -15,6 +15,7 @@ import {
 } from '@preact/signals-react';
 import { LoudnessNormalizer } from './LoudnessNormalizer';
 import MixerService, { type AudioChannel } from './MixerService';
+import type WorkletAnalyser from './WorkletAnalyser';
 import { type TrackId } from '../types/track';
 
 export type TrackSignals = {
@@ -219,6 +220,10 @@ class TrackService {
   }
 
   // --- Mixer delegates ---
+
+  useWorkletAnalyser(analyser: WorkletAnalyser): void {
+    this.mixer.useWorkletAnalyser(analyser);
+  }
 
   getLoudness(): number {
     return this.mixer.getLoudness();

--- a/src/services/__tests__/MixerService.test.ts
+++ b/src/services/__tests__/MixerService.test.ts
@@ -1,6 +1,17 @@
 import { vi } from 'vitest';
 import * as Tone from 'tone';
 import MixerService, { AudioChannel } from '../MixerService';
+import type WorkletAnalyser from '../WorkletAnalyser';
+
+function createMockWorkletAnalyser(loudness = 0): WorkletAnalyser {
+  return {
+    input: { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode,
+    getLoudness: vi.fn().mockReturnValue(loudness),
+    getRawRms: vi.fn().mockReturnValue(0),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+  } as unknown as WorkletAnalyser;
+}
 
 let mixer: MixerService;
 
@@ -57,6 +68,38 @@ describe('getLoudness', () => {
     meterInstance.getValue.mockReturnValue([0.5, 0.6] as unknown as number);
 
     expect(mixer.getLoudness()).toBe(0);
+  });
+});
+
+describe('useWorkletAnalyser', () => {
+  it('disconnects Tone.Meter and connects WorkletAnalyser to destination', () => {
+    const analyser = createMockWorkletAnalyser();
+    const destination = vi.mocked(Tone.getDestination).mock.results[0].value;
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+
+    mixer.useWorkletAnalyser(analyser);
+
+    expect(destination.disconnect).toHaveBeenCalledWith(meterInstance);
+    expect(destination.connect).toHaveBeenCalledWith(analyser.input);
+  });
+
+  it('delegates getLoudness to WorkletAnalyser after upgrade', () => {
+    const analyser = createMockWorkletAnalyser(0.75);
+
+    mixer.useWorkletAnalyser(analyser);
+
+    expect(mixer.getLoudness()).toBe(0.75);
+    expect(analyser.getLoudness).toHaveBeenCalled();
+  });
+
+  it('does not call Tone.Meter after upgrade', () => {
+    const analyser = createMockWorkletAnalyser(0.5);
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+
+    mixer.useWorkletAnalyser(analyser);
+    mixer.getLoudness();
+
+    expect(meterInstance.getValue).not.toHaveBeenCalled();
   });
 });
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -26,6 +26,7 @@ vi.mock('tone', () => {
   function makeNode() {
     return {
       connect: vi.fn().mockReturnThis(),
+      disconnect: vi.fn().mockReturnThis(),
       chain: vi.fn().mockReturnThis(),
       sync: vi.fn().mockReturnThis(),
       start: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary

- **MixerService** gains a `useWorkletAnalyser()` method that swaps `Tone.Meter` for `WorkletAnalyser` at runtime, disconnecting the meter and routing the destination through the worklet node instead
- **TrackService** exposes a passthrough `useWorkletAnalyser()` delegate to MixerService
- **AudioService** initializes `WorkletAnalyser` asynchronously (extracting the native `AudioContext` via the same `_nativeContext` pattern used by `initializeWorkletRecorder`) and wires it into `TrackService` on success; falls back to `Tone.Meter` silently on failure
- Added `disconnect` to the Tone.js mock in `setupTests.ts` to support the new destination disconnect call

This is the next step for issue #178 (AudioWorklet migration for real-time analysis), implementing recommended step 1 from the progress comment: wiring WorkletAnalyser into MixerService as the primary meter.

## Test plan

- [x] 3 new tests in `MixerService.test.ts` verify: destination disconnect/reconnect, loudness delegation to WorkletAnalyser, and Tone.Meter bypass after upgrade
- [x] All 515 existing tests pass
- [x] ESLint passes
- [x] Production build succeeds

https://claude.ai/code/session_01MNe3k47zY3S8S4eNLsbisN