### PR TITLE
Wire WorkletAnalyser into MicrophoneService for mic loudness (#178)

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -61,9 +61,14 @@ class AudioService {
       const nativeCtx =
         (rawContext as unknown as { _nativeContext?: AudioContext })
           ._nativeContext ?? rawContext;
-      const analyser = new WorkletAnalyser(nativeCtx);
-      await analyser.initialize();
-      this.trackService.useWorkletAnalyser(analyser);
+
+      const mixerAnalyser = new WorkletAnalyser(nativeCtx);
+      await mixerAnalyser.initialize();
+      this.trackService.useWorkletAnalyser(mixerAnalyser);
+
+      const micAnalyser = new WorkletAnalyser(nativeCtx);
+      await micAnalyser.initialize();
+      this.recordingService.useWorkletAnalyser(micAnalyser);
     } catch {
       // AudioWorklet not supported or module failed to load — keep using
       // Tone.Meter as fallback.

--- a/src/services/MicrophoneService.ts
+++ b/src/services/MicrophoneService.ts
@@ -1,4 +1,5 @@
 import * as Tone from 'tone';
+import type WorkletAnalyser from './WorkletAnalyser';
 
 // Low-latency getUserMedia constraints for recording. Disables browser
 // processing (echo cancellation, noise suppression, AGC) that adds latency
@@ -13,6 +14,7 @@ export const LOW_LATENCY_CONSTRAINTS: MediaTrackConstraints = {
 class MicrophoneService {
   private microphone: Tone.UserMedia;
   private meter: Tone.Meter;
+  private workletAnalyser: WorkletAnalyser | null = null;
 
   constructor() {
     this.meter = new Tone.Meter();
@@ -39,7 +41,19 @@ class MicrophoneService {
     this.microphone.connect(destination as Tone.ToneAudioNode);
   }
 
+  // Replace Tone.Meter with a WorkletAnalyser for loudness metering.
+  // Call after the analyser has been initialized (module loaded).
+  // Re-routes the microphone connection from Tone.Meter to the worklet.
+  useWorkletAnalyser(analyser: WorkletAnalyser): void {
+    this.microphone.disconnect(this.meter);
+    this.workletAnalyser = analyser;
+    this.microphone.connect(analyser.input as unknown as Tone.ToneAudioNode);
+  }
+
   getLoudness(): number {
+    if (this.workletAnalyser) {
+      return this.workletAnalyser.getRawRms();
+    }
     const value = this.meter.getValue();
     return typeof value === 'number' ? Math.max(0, value) : 0;
   }

--- a/src/services/RecordingService.ts
+++ b/src/services/RecordingService.ts
@@ -16,6 +16,7 @@ import { computed, signal, type ReadonlySignal } from '@preact/signals-react';
 import MicrophoneService from './MicrophoneService';
 import LatencyCompensation from './LatencyCompensation';
 import WorkletRecorder from './WorkletRecorder';
+import type WorkletAnalyser from './WorkletAnalyser';
 
 export type RecordingState = 'idle' | 'armed' | 'recording';
 
@@ -183,6 +184,10 @@ class RecordingService {
     if (this.microphone.isOpen) {
       this.microphone.close();
     }
+  }
+
+  useWorkletAnalyser(analyser: WorkletAnalyser): void {
+    this.microphone.useWorkletAnalyser(analyser);
   }
 
   getLoudness(): number {

--- a/src/services/__tests__/MicrophoneService.test.ts
+++ b/src/services/__tests__/MicrophoneService.test.ts
@@ -1,6 +1,17 @@
 import { vi } from 'vitest';
 import * as Tone from 'tone';
 import MicrophoneService from '../MicrophoneService';
+import type WorkletAnalyser from '../WorkletAnalyser';
+
+function createMockWorkletAnalyser(rawRms = 0): WorkletAnalyser {
+  return {
+    input: { connect: vi.fn(), disconnect: vi.fn() } as unknown as AudioNode,
+    getLoudness: vi.fn().mockReturnValue(rawRms),
+    getRawRms: vi.fn().mockReturnValue(rawRms),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+  } as unknown as WorkletAnalyser;
+}
 
 let mic: MicrophoneService;
 
@@ -27,5 +38,37 @@ describe('source', () => {
   it('exposes the Tone.UserMedia as a source node', () => {
     const userMediaInstance = vi.mocked(Tone.UserMedia).mock.results[0].value;
     expect(mic.source).toBe(userMediaInstance);
+  });
+});
+
+describe('useWorkletAnalyser', () => {
+  it('disconnects Tone.Meter and connects WorkletAnalyser to microphone', () => {
+    const analyser = createMockWorkletAnalyser();
+    const userMediaInstance = vi.mocked(Tone.UserMedia).mock.results[0].value;
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+
+    mic.useWorkletAnalyser(analyser);
+
+    expect(userMediaInstance.disconnect).toHaveBeenCalledWith(meterInstance);
+    expect(userMediaInstance.connect).toHaveBeenCalledWith(analyser.input);
+  });
+
+  it('delegates getLoudness to WorkletAnalyser.getRawRms after upgrade', () => {
+    const analyser = createMockWorkletAnalyser(0.42);
+
+    mic.useWorkletAnalyser(analyser);
+
+    expect(mic.getLoudness()).toBe(0.42);
+    expect(analyser.getRawRms).toHaveBeenCalled();
+  });
+
+  it('does not call Tone.Meter after upgrade', () => {
+    const analyser = createMockWorkletAnalyser(0.5);
+    const meterInstance = vi.mocked(Tone.Meter).mock.results[0].value;
+
+    mic.useWorkletAnalyser(analyser);
+    mic.getLoudness();
+
+    expect(meterInstance.getValue).not.toHaveBeenCalled();
   });
 });

--- a/src/services/__tests__/RecordingService.test.ts
+++ b/src/services/__tests__/RecordingService.test.ts
@@ -1,5 +1,6 @@
 import * as Tone from 'tone';
 import RecordingService from '../RecordingService';
+import type WorkletAnalyser from '../WorkletAnalyser';
 
 let service: RecordingService;
 
@@ -287,6 +288,26 @@ describe('RecordingService', () => {
 
       expect(service.recordingState).toBe('idle');
       expect(service.isCountingIn).toBe(false);
+    });
+  });
+
+  describe('useWorkletAnalyser', () => {
+    it('delegates getLoudness to WorkletAnalyser after upgrade', () => {
+      const analyser = {
+        input: {
+          connect: vi.fn(),
+          disconnect: vi.fn(),
+        } as unknown as AudioNode,
+        getLoudness: vi.fn().mockReturnValue(0.75),
+        getRawRms: vi.fn().mockReturnValue(0.6),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        dispose: vi.fn(),
+      } as unknown as WorkletAnalyser;
+
+      service.useWorkletAnalyser(analyser);
+
+      expect(service.getLoudness()).toBe(0.6);
+      expect(analyser.getRawRms).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- Added `useWorkletAnalyser()` to `MicrophoneService` — disconnects `Tone.Meter`, connects mic to `WorkletAnalyser`, delegates `getLoudness()` to `getRawRms()`
- Added `useWorkletAnalyser()` passthrough on `RecordingService` (MicrophoneService is encapsulated)
- `AudioService.initializeWorkletAnalyser()` now creates a second `WorkletAnalyser` instance for the mic path and wires it through `RecordingService` into `MicrophoneService`

## Test plan

- [x] 3 new tests in `MicrophoneService.test.ts`: verifies disconnect/reconnect, getLoudness delegation, Tone.Meter no longer called
- [x] 1 new test in `RecordingService.test.ts`: verifies getLoudness delegates through to WorkletAnalyser after upgrade
- [x] All 519 tests pass
- [x] Lint clean
- [x] Production build succeeds

https://claude.ai/code/session_01GrQRoQDQSDGET5aYbPecP2