### PR TITLE
Add frequency-domain FFT analysis to AudioWorklet (#178)

### DIFF
--- a/src/services/AnalysisProcessor.ts
+++ b/src/services/AnalysisProcessor.ts
@@ -1,17 +1,34 @@
 // AnalysisProcessor — AudioWorkletProcessor that computes RMS loudness
-// on the audio thread, replacing Tone.Analyser (AnalyserNode) for
-// lowest-latency real-time metering.
+// and optional FFT frequency analysis on the audio thread.
 //
 // Runs inside an AudioWorklet scope on a dedicated thread, eliminating
 // main-thread contention during complex playback with many tracks.
 //
+// Frequency analysis is opt-in: send a 'configure' command with
+// frequencyAnalysis: true to enable it. When enabled, the processor
+// accumulates samples into a ring buffer, applies a Hann window, runs
+// a Cooley-Tukey radix-2 FFT, and posts byte-scaled magnitude bins
+// (0–255, matching AnalyserNode.getByteFrequencyData conventions).
+//
 // Message protocol:
 //   Processor → Main:  { type: 'loudness', rms: number }
-//   Main → Processor:  { type: 'configure', smoothing: number }
+//   Processor → Main:  { type: 'frequencyData', bins: Uint8Array }
+//   Main → Processor:  { type: 'configure', ... }
 
-export type AnalysisMessage = { type: 'loudness'; rms: number };
+import { createHannWindow, fft, magnitudeToBytes } from './fft';
 
-export type AnalysisCommand = { type: 'configure'; smoothing: number };
+export type AnalysisMessage =
+  | { type: 'loudness'; rms: number }
+  | { type: 'frequencyData'; bins: Uint8Array };
+
+export type AnalysisCommand = {
+  type: 'configure';
+  smoothing?: number;
+  frequencyAnalysis?: boolean;
+  fftSize?: number;
+  minDecibels?: number;
+  maxDecibels?: number;
+};
 
 // Exponential moving average coefficient. Higher values = smoother but
 // more latent meter response.
@@ -22,16 +39,31 @@ const DEFAULT_SMOOTHING = 0.8;
 // update rate — sufficient for smooth meter animation.
 const REPORT_INTERVAL = 8;
 
+const DEFAULT_FFT_SIZE = 2048;
+const DEFAULT_MIN_DECIBELS = -100;
+const DEFAULT_MAX_DECIBELS = -30;
+
 class AnalysisProcessor extends AudioWorkletProcessor {
   private smoothing = DEFAULT_SMOOTHING;
   private smoothedRms = 0;
   private callCount = 0;
 
+  // Frequency analysis state (lazily allocated on enable)
+  private frequencyEnabled = false;
+  private fftSize = DEFAULT_FFT_SIZE;
+  private minDecibels = DEFAULT_MIN_DECIBELS;
+  private maxDecibels = DEFAULT_MAX_DECIBELS;
+  private ringBuffer: Float32Array | null = null;
+  private ringWritePos = 0;
+  private hannWindow: Float32Array | null = null;
+  private samplesUntilFft = 0;
+  private hopSize = 0;
+
   constructor() {
     super();
     this.port.onmessage = (event: MessageEvent<AnalysisCommand>) => {
       if (event.data.type === 'configure') {
-        this.smoothing = event.data.smoothing;
+        this.handleConfigure(event.data);
       }
     };
   }
@@ -63,7 +95,95 @@ class AnalysisProcessor extends AudioWorkletProcessor {
       } satisfies AnalysisMessage);
     }
 
+    // Frequency analysis: accumulate samples and run FFT when ready
+    if (this.frequencyEnabled && this.ringBuffer) {
+      this.accumulateAndAnalyse(channelData);
+    }
+
     return true;
+  }
+
+  private handleConfigure(cmd: AnalysisCommand): void {
+    if (cmd.smoothing !== undefined) {
+      this.smoothing = cmd.smoothing;
+    }
+    if (cmd.minDecibels !== undefined) {
+      this.minDecibels = cmd.minDecibels;
+    }
+    if (cmd.maxDecibels !== undefined) {
+      this.maxDecibels = cmd.maxDecibels;
+    }
+
+    const fftSizeChanged =
+      cmd.fftSize !== undefined && cmd.fftSize !== this.fftSize;
+    if (fftSizeChanged) {
+      this.fftSize = cmd.fftSize!;
+    }
+
+    if (cmd.frequencyAnalysis !== undefined) {
+      this.frequencyEnabled = cmd.frequencyAnalysis;
+    }
+
+    // (Re-)allocate buffers when enabling or changing FFT size
+    if (this.frequencyEnabled && (!this.ringBuffer || fftSizeChanged)) {
+      this.initFrequencyBuffers();
+    }
+  }
+
+  private initFrequencyBuffers(): void {
+    this.ringBuffer = new Float32Array(this.fftSize);
+    this.hannWindow = createHannWindow(this.fftSize);
+    this.ringWritePos = 0;
+    // Hop size = fftSize / 4 gives 75% overlap.
+    // At 44.1 kHz with fftSize=2048: hop=512 → ~86 Hz update rate.
+    this.hopSize = this.fftSize / 4;
+    this.samplesUntilFft = this.fftSize;
+  }
+
+  private accumulateAndAnalyse(channelData: Float32Array): void {
+    const ring = this.ringBuffer!;
+    const fftSize = this.fftSize;
+
+    // Write incoming samples into the ring buffer
+    for (let i = 0; i < channelData.length; i++) {
+      ring[this.ringWritePos] = channelData[i];
+      this.ringWritePos = (this.ringWritePos + 1) % fftSize;
+    }
+
+    this.samplesUntilFft -= channelData.length;
+    if (this.samplesUntilFft > 0) return;
+
+    // Reset countdown for next FFT
+    this.samplesUntilFft += this.hopSize;
+
+    // Copy ring buffer into FFT input with Hann window applied.
+    // ringWritePos points to the oldest sample, so we read from there
+    // wrapping around to get the most recent fftSize samples in order.
+    const real = new Float32Array(fftSize);
+    const imag = new Float32Array(fftSize);
+    const window = this.hannWindow!;
+
+    for (let i = 0; i < fftSize; i++) {
+      const idx = (this.ringWritePos + i) % fftSize;
+      real[i] = ring[idx] * window[i];
+    }
+
+    fft(real, imag);
+
+    const bins = new Uint8Array(fftSize / 2);
+    magnitudeToBytes(
+      real,
+      imag,
+      fftSize,
+      this.minDecibels,
+      this.maxDecibels,
+      bins,
+    );
+
+    this.port.postMessage(
+      { type: 'frequencyData', bins } satisfies AnalysisMessage,
+      [bins.buffer],
+    );
   }
 }
 

--- a/src/services/WorkletAnalyser.ts
+++ b/src/services/WorkletAnalyser.ts
@@ -6,14 +6,21 @@
 // AnalyserNode's main-thread contention during complex playback with
 // many tracks.
 //
-// The analyser exposes a getLoudness() method compatible with the pattern
-// used in MixerService and MicrophoneService.
+// Optionally provides frequency-domain analysis (FFT on the audio
+// thread), replacing AnalyserNode.getByteFrequencyData(). Enable with
+// enableFrequencyAnalysis() after initialization.
 
-import { type AnalysisMessage } from './AnalysisProcessor';
+import {
+  type AnalysisCommand,
+  type AnalysisMessage,
+} from './AnalysisProcessor';
 
 const PROCESSOR_NAME = 'analysis-processor';
 const DEFAULT_SMOOTHING = 0.8;
 const POWER_CURVE_EXPONENT = 0.6;
+const DEFAULT_FFT_SIZE = 2048;
+const DEFAULT_MIN_DECIBELS = -100;
+const DEFAULT_MAX_DECIBELS = -30;
 
 class WorkletAnalyser {
   private audioContext: AudioContext;
@@ -22,9 +29,18 @@ class WorkletAnalyser {
   private smoothing: number;
   private initialized = false;
 
+  // Frequency analysis state
+  private _fftSize: number;
+  private _minDecibels: number;
+  private _maxDecibels: number;
+  private currentBins: Uint8Array | null = null;
+
   constructor(audioContext: AudioContext, smoothing = DEFAULT_SMOOTHING) {
     this.audioContext = audioContext;
     this.smoothing = smoothing;
+    this._fftSize = DEFAULT_FFT_SIZE;
+    this._minDecibels = DEFAULT_MIN_DECIBELS;
+    this._maxDecibels = DEFAULT_MAX_DECIBELS;
   }
 
   // Load the worklet module. Must be called once before connecting sources.
@@ -47,7 +63,7 @@ class WorkletAnalyser {
       this.node.port.postMessage({
         type: 'configure',
         smoothing: this.smoothing,
-      });
+      } satisfies AnalysisCommand);
     }
     return this.node;
   }
@@ -63,16 +79,107 @@ class WorkletAnalyser {
     return Math.max(0, this.currentRms);
   }
 
+  /**
+   * Number of frequency bins (fftSize / 2). Only meaningful after
+   * enableFrequencyAnalysis() has been called.
+   */
+  get frequencyBinCount(): number {
+    return this._fftSize / 2;
+  }
+
+  get fftSize(): number {
+    return this._fftSize;
+  }
+
+  get minDecibels(): number {
+    return this._minDecibels;
+  }
+
+  get maxDecibels(): number {
+    return this._maxDecibels;
+  }
+
+  /**
+   * Enables frequency-domain analysis on the audio thread.
+   *
+   * Must be called after `initialize()` and after accessing `.input`
+   * at least once (so the node exists). Sends a configure command to
+   * the processor to start accumulating samples and running FFT.
+   */
+  enableFrequencyAnalysis(options?: {
+    fftSize?: number;
+    minDecibels?: number;
+    maxDecibels?: number;
+  }): void {
+    if (options?.fftSize !== undefined) this._fftSize = options.fftSize;
+    if (options?.minDecibels !== undefined)
+      this._minDecibels = options.minDecibels;
+    if (options?.maxDecibels !== undefined)
+      this._maxDecibels = options.maxDecibels;
+
+    this.currentBins = new Uint8Array(this._fftSize / 2);
+
+    this.sendFrequencyConfig();
+  }
+
+  /**
+   * Disables frequency-domain analysis. The processor stops computing
+   * FFT, freeing audio-thread resources.
+   */
+  disableFrequencyAnalysis(): void {
+    this.currentBins = null;
+
+    if (this.node) {
+      this.node.port.postMessage({
+        type: 'configure',
+        frequencyAnalysis: false,
+      } satisfies AnalysisCommand);
+    }
+  }
+
+  /**
+   * Copies the latest frequency magnitude data into the provided array.
+   *
+   * Follows the same convention as `AnalyserNode.getByteFrequencyData()`:
+   * values are 0–255 representing dB magnitude scaled between
+   * `minDecibels` and `maxDecibels`.
+   *
+   * Returns false if frequency analysis is not enabled or no data is
+   * available yet.
+   */
+  getByteFrequencyData(output: Uint8Array): boolean {
+    if (!this.currentBins) return false;
+    output.set(this.currentBins.subarray(0, output.length));
+    return true;
+  }
+
   dispose(): void {
     this.node?.disconnect();
     this.node = null;
     this.currentRms = 0;
+    this.currentBins = null;
+  }
+
+  private sendFrequencyConfig(): void {
+    if (!this.node) return;
+
+    this.node.port.postMessage({
+      type: 'configure',
+      frequencyAnalysis: true,
+      fftSize: this._fftSize,
+      minDecibels: this._minDecibels,
+      maxDecibels: this._maxDecibels,
+    } satisfies AnalysisCommand);
   }
 
   private setupMessageHandler(node: AudioWorkletNode): void {
     node.port.onmessage = (event: MessageEvent<AnalysisMessage>) => {
       if (event.data.type === 'loudness') {
         this.currentRms = event.data.rms;
+      } else if (event.data.type === 'frequencyData' && this.currentBins) {
+        this.currentBins.set(
+          event.data.bins.subarray(0, this.currentBins.length),
+        );
       }
     };
   }

--- a/src/services/__tests__/WorkletAnalyser.test.ts
+++ b/src/services/__tests__/WorkletAnalyser.test.ts
@@ -154,6 +154,144 @@ describe('WorkletAnalyser', () => {
     });
   });
 
+  describe('frequency analysis', () => {
+    it('has default frequencyBinCount of fftSize/2', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+
+      expect(analyser.frequencyBinCount).toBe(1024);
+      expect(analyser.fftSize).toBe(2048);
+    });
+
+    it('has default dB range', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+
+      expect(analyser.minDecibels).toBe(-100);
+      expect(analyser.maxDecibels).toBe(-30);
+    });
+
+    describe('enableFrequencyAnalysis', () => {
+      it('sends configure command to processor', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+
+        analyser.enableFrequencyAnalysis();
+
+        expect(mockPort.postMessage).toHaveBeenCalledWith({
+          type: 'configure',
+          frequencyAnalysis: true,
+          fftSize: 2048,
+          minDecibels: -100,
+          maxDecibels: -30,
+        });
+      });
+
+      it('accepts custom fftSize', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+
+        analyser.enableFrequencyAnalysis({ fftSize: 1024 });
+
+        expect(analyser.fftSize).toBe(1024);
+        expect(analyser.frequencyBinCount).toBe(512);
+        expect(mockPort.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ fftSize: 1024 }),
+        );
+      });
+
+      it('accepts custom dB range', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+
+        analyser.enableFrequencyAnalysis({
+          minDecibels: -80,
+          maxDecibels: -20,
+        });
+
+        expect(analyser.minDecibels).toBe(-80);
+        expect(analyser.maxDecibels).toBe(-20);
+      });
+    });
+
+    describe('disableFrequencyAnalysis', () => {
+      it('sends disable command to processor', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+        analyser.enableFrequencyAnalysis();
+        mockPort.postMessage.mockClear();
+
+        analyser.disableFrequencyAnalysis();
+
+        expect(mockPort.postMessage).toHaveBeenCalledWith({
+          type: 'configure',
+          frequencyAnalysis: false,
+        });
+      });
+    });
+
+    describe('getByteFrequencyData', () => {
+      it('returns false when frequency analysis is not enabled', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        const output = new Uint8Array(1024);
+
+        expect(analyser.getByteFrequencyData(output)).toBe(false);
+      });
+
+      it('returns true after enabling and receiving data', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+        analyser.enableFrequencyAnalysis();
+
+        const bins = new Uint8Array(1024);
+        bins[0] = 200;
+        bins[1] = 150;
+        mockPort._simulateMessage({ type: 'frequencyData', bins });
+
+        const output = new Uint8Array(1024);
+        expect(analyser.getByteFrequencyData(output)).toBe(true);
+        expect(output[0]).toBe(200);
+        expect(output[1]).toBe(150);
+      });
+
+      it('returns zeros before any frequency data arrives', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+        analyser.enableFrequencyAnalysis();
+
+        const output = new Uint8Array(1024);
+        expect(analyser.getByteFrequencyData(output)).toBe(true);
+        expect(output[0]).toBe(0);
+      });
+
+      it('copies only as many bins as the output array can hold', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+        analyser.enableFrequencyAnalysis();
+
+        const bins = new Uint8Array(1024);
+        bins[0] = 100;
+        bins[511] = 50;
+        mockPort._simulateMessage({ type: 'frequencyData', bins });
+
+        const smallOutput = new Uint8Array(256);
+        analyser.getByteFrequencyData(smallOutput);
+
+        expect(smallOutput[0]).toBe(100);
+        // Bin 511 is beyond the output size, so it shouldn't appear
+        expect(smallOutput[255]).toBe(0);
+      });
+
+      it('returns false after disabling frequency analysis', () => {
+        const analyser = new WorkletAnalyser(createMockAudioContext());
+        void analyser.input;
+        analyser.enableFrequencyAnalysis();
+        analyser.disableFrequencyAnalysis();
+
+        const output = new Uint8Array(1024);
+        expect(analyser.getByteFrequencyData(output)).toBe(false);
+      });
+    });
+  });
+
   describe('dispose', () => {
     it('disconnects the node', () => {
       const analyser = new WorkletAnalyser(createMockAudioContext());
@@ -175,6 +313,17 @@ describe('WorkletAnalyser', () => {
       analyser.dispose();
 
       expect(analyser.getLoudness()).toBe(0);
+    });
+
+    it('clears frequency data', () => {
+      const analyser = new WorkletAnalyser(createMockAudioContext());
+      void analyser.input;
+      analyser.enableFrequencyAnalysis();
+
+      analyser.dispose();
+
+      const output = new Uint8Array(1024);
+      expect(analyser.getByteFrequencyData(output)).toBe(false);
     });
   });
 });

--- a/src/services/__tests__/fft.test.ts
+++ b/src/services/__tests__/fft.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { createHannWindow, fft, magnitudeToBytes } from '../fft';
+
+describe('fft', () => {
+  describe('DC signal', () => {
+    it('concentrates energy in bin 0', () => {
+      const N = 8;
+      const real = new Float32Array(N).fill(1);
+      const imag = new Float32Array(N);
+
+      fft(real, imag);
+
+      // Bin 0 should equal N (sum of all samples)
+      expect(real[0]).toBeCloseTo(N, 5);
+      expect(imag[0]).toBeCloseTo(0, 5);
+
+      // All other bins should be ~0
+      for (let i = 1; i < N; i++) {
+        expect(real[i]).toBeCloseTo(0, 5);
+        expect(imag[i]).toBeCloseTo(0, 5);
+      }
+    });
+  });
+
+  describe('single cosine', () => {
+    it('produces peaks in the correct bin', () => {
+      const N = 256;
+      const k = 10; // frequency bin
+      const real = new Float32Array(N);
+      const imag = new Float32Array(N);
+
+      for (let i = 0; i < N; i++) {
+        real[i] = Math.cos((2 * Math.PI * k * i) / N);
+      }
+
+      fft(real, imag);
+
+      // A pure cosine at bin k should produce N/2 magnitude at bins k and N-k
+      const magK = Math.sqrt(real[k] * real[k] + imag[k] * imag[k]);
+      const magNK = Math.sqrt(
+        real[N - k] * real[N - k] + imag[N - k] * imag[N - k],
+      );
+
+      expect(magK).toBeCloseTo(N / 2, 1);
+      expect(magNK).toBeCloseTo(N / 2, 1);
+
+      // Other bins should be ~0
+      for (let i = 1; i < N; i++) {
+        if (i === k || i === N - k) continue;
+        const mag = Math.sqrt(real[i] * real[i] + imag[i] * imag[i]);
+        expect(mag).toBeCloseTo(0, 3);
+      }
+    });
+  });
+
+  describe('single sine', () => {
+    it('produces imaginary peaks in the correct bin', () => {
+      const N = 64;
+      const k = 5;
+      const real = new Float32Array(N);
+      const imag = new Float32Array(N);
+
+      for (let i = 0; i < N; i++) {
+        real[i] = Math.sin((2 * Math.PI * k * i) / N);
+      }
+
+      fft(real, imag);
+
+      // sin produces energy in imag parts: -N/2 at bin k, +N/2 at bin N-k
+      expect(imag[k]).toBeCloseTo(-N / 2, 1);
+      expect(imag[N - k]).toBeCloseTo(N / 2, 1);
+    });
+  });
+
+  describe('Parseval relation', () => {
+    it('preserves total energy between time and frequency domains', () => {
+      const N = 512;
+      const real = new Float32Array(N);
+      const imag = new Float32Array(N);
+
+      // Random signal
+      for (let i = 0; i < N; i++) {
+        real[i] = Math.sin(i * 0.1) + 0.5 * Math.cos(i * 0.37);
+      }
+
+      // Time-domain energy
+      let timeEnergy = 0;
+      for (let i = 0; i < N; i++) {
+        timeEnergy += real[i] * real[i];
+      }
+
+      fft(real, imag);
+
+      // Frequency-domain energy
+      let freqEnergy = 0;
+      for (let i = 0; i < N; i++) {
+        freqEnergy += real[i] * real[i] + imag[i] * imag[i];
+      }
+      freqEnergy /= N;
+
+      expect(freqEnergy).toBeCloseTo(timeEnergy, 3);
+    });
+  });
+
+  describe('power of 2 sizes', () => {
+    it.each([4, 8, 16, 32, 1024, 2048])('handles N=%d', (N) => {
+      const real = new Float32Array(N);
+      const imag = new Float32Array(N);
+
+      // DC signal for easy verification
+      real.fill(1);
+
+      fft(real, imag);
+
+      expect(real[0]).toBeCloseTo(N, 3);
+      for (let i = 1; i < N; i++) {
+        expect(Math.abs(real[i])).toBeLessThan(1e-3);
+      }
+    });
+  });
+});
+
+describe('createHannWindow', () => {
+  it('returns the correct length', () => {
+    const window = createHannWindow(256);
+    expect(window.length).toBe(256);
+  });
+
+  it('is zero at the endpoints', () => {
+    const window = createHannWindow(128);
+    expect(window[0]).toBeCloseTo(0, 5);
+    expect(window[127]).toBeCloseTo(0, 5);
+  });
+
+  it('peaks at 1.0 in the center', () => {
+    const N = 256;
+    const window = createHannWindow(N);
+    // For even N, the peak is at index (N-1)/2 ≈ 127.5, so indices 127 and 128
+    // should both be very close to 1
+    const center = (N - 1) / 2;
+    const idx = Math.round(center);
+    expect(window[idx]).toBeCloseTo(1, 2);
+  });
+
+  it('is symmetric', () => {
+    const N = 64;
+    const window = createHannWindow(N);
+    for (let i = 0; i < N / 2; i++) {
+      expect(window[i]).toBeCloseTo(window[N - 1 - i], 5);
+    }
+  });
+});
+
+describe('magnitudeToBytes', () => {
+  it('maps a DC signal correctly', () => {
+    const N = 8;
+    const real = new Float32Array(N);
+    const imag = new Float32Array(N);
+
+    // Pure DC of amplitude 1: after FFT, bin 0 has magnitude N
+    real.fill(1);
+    fft(real, imag);
+
+    const output = new Uint8Array(N / 2);
+    magnitudeToBytes(real, imag, N, -100, -30, output);
+
+    // Bin 0: magnitude = N = 8, dB = 20*log10(8/8) = 0 dB
+    // Scaled: (0 - (-100)) / ((-30) - (-100)) * 255 = 100/70 * 255 ≈ 364 → clamped to 255
+    expect(output[0]).toBe(255);
+
+    // Other bins: magnitude ~0 → -Infinity dB → clamped to 0
+    for (let i = 1; i < N / 2; i++) {
+      expect(output[i]).toBe(0);
+    }
+  });
+
+  it('maps silence to all zeros', () => {
+    const N = 16;
+    const real = new Float32Array(N);
+    const imag = new Float32Array(N);
+    const output = new Uint8Array(N / 2);
+
+    magnitudeToBytes(real, imag, N, -100, -30, output);
+
+    for (let i = 0; i < N / 2; i++) {
+      expect(output[i]).toBe(0);
+    }
+  });
+
+  it('clamps values within 0-255 range', () => {
+    const N = 8;
+    const real = new Float32Array(N);
+    const imag = new Float32Array(N);
+    real[0] = N * 10; // Very large magnitude → dB > maxDecibels
+    const output = new Uint8Array(N / 2);
+
+    magnitudeToBytes(real, imag, N, -100, -30, output);
+
+    expect(output[0]).toBe(255);
+  });
+
+  it('scales a mid-range value proportionally', () => {
+    const N = 8;
+    const real = new Float32Array(N);
+    const imag = new Float32Array(N);
+
+    // Set bin 0 so dB lands in the middle of the range
+    // Want dB = -65 (midpoint of -100 to -30)
+    // dB = 20 * log10(mag / N), so mag = N * 10^(dB/20)
+    const targetDb = -65;
+    real[0] = N * Math.pow(10, targetDb / 20);
+
+    const output = new Uint8Array(N / 2);
+    magnitudeToBytes(real, imag, N, -100, -30, output);
+
+    // Expected: 255 * ((-65) - (-100)) / ((-30) - (-100)) = 255 * 35/70 = 127.5
+    // Math.round(127.5) is implementation-defined; accept 127 or 128
+    expect(output[0]).toBeGreaterThanOrEqual(127);
+    expect(output[0]).toBeLessThanOrEqual(128);
+  });
+});

--- a/src/services/fft.ts
+++ b/src/services/fft.ts
@@ -1,0 +1,112 @@
+/**
+ * Cooley-Tukey radix-2 decimation-in-time FFT.
+ *
+ * In-place transform of interleaved real and imaginary arrays.
+ * Input length must be a power of 2.
+ *
+ * Runs inside AudioWorklet scope (no DOM or Node dependencies), so it
+ * must be a self-contained pure function with no external imports.
+ */
+
+/**
+ * Computes the in-place forward FFT of the given real and imaginary arrays.
+ *
+ * After the call, `real[k]` and `imag[k]` hold the real and imaginary
+ * parts of the k-th frequency bin (0 ≤ k < N).
+ */
+export function fft(real: Float32Array, imag: Float32Array): void {
+  const N = real.length;
+
+  // Bit-reversal permutation
+  for (let i = 1, j = 0; i < N; i++) {
+    let bit = N >> 1;
+    while (j & bit) {
+      j ^= bit;
+      bit >>= 1;
+    }
+    j ^= bit;
+
+    if (i < j) {
+      const tmpR = real[i];
+      real[i] = real[j];
+      real[j] = tmpR;
+
+      const tmpI = imag[i];
+      imag[i] = imag[j];
+      imag[j] = tmpI;
+    }
+  }
+
+  // Butterfly stages
+  for (let size = 2; size <= N; size *= 2) {
+    const halfSize = size / 2;
+    const angle = (-2 * Math.PI) / size;
+    const wReal = Math.cos(angle);
+    const wImag = Math.sin(angle);
+
+    for (let i = 0; i < N; i += size) {
+      let tReal = 1;
+      let tImag = 0;
+
+      for (let j = 0; j < halfSize; j++) {
+        const a = i + j;
+        const b = a + halfSize;
+
+        const bReal = real[b] * tReal - imag[b] * tImag;
+        const bImag = real[b] * tImag + imag[b] * tReal;
+
+        real[b] = real[a] - bReal;
+        imag[b] = imag[a] - bImag;
+        real[a] += bReal;
+        imag[a] += bImag;
+
+        const nextTReal = tReal * wReal - tImag * wImag;
+        tImag = tReal * wImag + tImag * wReal;
+        tReal = nextTReal;
+      }
+    }
+  }
+}
+
+/**
+ * Creates a Hann window of the given length.
+ *
+ * w(n) = 0.5 * (1 - cos(2πn / (N-1)))
+ */
+export function createHannWindow(length: number): Float32Array {
+  const window = new Float32Array(length);
+  const factor = (2 * Math.PI) / (length - 1);
+  for (let i = 0; i < length; i++) {
+    window[i] = 0.5 * (1 - Math.cos(factor * i));
+  }
+  return window;
+}
+
+/**
+ * Computes magnitude spectrum in dB from FFT output, mapped to 0–255 bytes.
+ *
+ * Matches the AnalyserNode byte-frequency-data convention:
+ *   dB = 20 * log10(magnitude / fftSize)
+ *   byte = 255 * (dB - minDecibels) / (maxDecibels - minDecibels)
+ *   clamped to [0, 255]
+ *
+ * Only the first N/2 bins (positive frequencies) are written.
+ */
+export function magnitudeToBytes(
+  real: Float32Array,
+  imag: Float32Array,
+  fftSize: number,
+  minDecibels: number,
+  maxDecibels: number,
+  output: Uint8Array,
+): void {
+  const binCount = fftSize / 2;
+  const rangeInv = 255 / (maxDecibels - minDecibels);
+
+  for (let i = 0; i < binCount; i++) {
+    const magnitude = Math.sqrt(real[i] * real[i] + imag[i] * imag[i]);
+    const dB = magnitude > 0 ? 20 * Math.log10(magnitude / fftSize) : -Infinity;
+    const scaled = (dB - minDecibels) * rangeInv;
+    output[i] = Math.max(0, Math.min(255, Math.round(scaled)));
+  }
+}


### PR DESCRIPTION
## Summary

- Add opt-in frequency-domain analysis to `AnalysisProcessor` AudioWorklet, implementing step 4 of #178
- Implement Cooley-Tukey radix-2 FFT that runs entirely on the audio thread, eliminating `AnalyserNode` main-thread contention
- Add `enableFrequencyAnalysis()` / `getByteFrequencyData()` API to `WorkletAnalyser`, matching `AnalyserNode` conventions
- Frequency analysis is disabled by default — existing RMS loudness behavior is unchanged

### New files
- **`fft.ts`** — Pure FFT implementation (Cooley-Tukey radix-2), Hann window, and dB-scaled magnitude-to-byte mapping
- **`fft.test.ts`** — 18 tests: DC signal, cosine/sine peaks, Parseval energy conservation, power-of-2 sizes, Hann window properties, magnitude byte mapping

### Modified files
- **`AnalysisProcessor.ts`** — Ring buffer sample accumulation, configurable FFT with 75% overlap (hop = fftSize/4), Hann windowing, posts `frequencyData` messages with byte-scaled bins (0–255)
- **`WorkletAnalyser.ts`** — `enableFrequencyAnalysis(options?)`, `disableFrequencyAnalysis()`, `getByteFrequencyData(output)`, `frequencyBinCount`/`fftSize`/`minDecibels`/`maxDecibels` getters
- **`WorkletAnalyser.test.ts`** — 12 new tests for frequency analysis enable/disable, configuration, data retrieval, and disposal

## Test plan

- [x] All 549 tests pass
- [x] ESLint clean
- [x] Production build succeeds
- [ ] Verify FFT output matches `AnalyserNode.getByteFrequencyData()` for known signals in a browser environment
- [ ] Profile audio-thread CPU usage with frequency analysis enabled vs disabled

https://claude.ai/code/session_01VMduiqd4M5pUkjZoXwSqwj