### PR TITLE
Fix frequency spacing between spectrogram and scrubber

### DIFF
--- a/src/services/__tests__/logFrequencyMapping.test.ts
+++ b/src/services/__tests__/logFrequencyMapping.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyLogFrequencyMapping,
+  createDualBandLogMapping,
+  createLogFrequencyMapping,
+} from '../logFrequencyMapping';
+import { fft, magnitudeToBytes } from '../fft';
+
+/**
+ * 12-TET semitone frequencies covering the musically relevant range.
+ * Each semitone is a factor of 2^(1/12) apart, so on a true log-frequency
+ * scale the output bin positions must be equally spaced.
+ */
+const SEMITONE_RATIO = Math.pow(2, 1 / 12);
+const BASE_FREQUENCY = 27.5; // A0
+
+function generateSemitoneFrequencies(minHz: number, maxHz: number): number[] {
+  const frequencies: number[] = [];
+  let freq = BASE_FREQUENCY;
+  while (freq < minHz) freq *= SEMITONE_RATIO;
+  while (freq <= maxHz) {
+    frequencies.push(freq);
+    freq *= SEMITONE_RATIO;
+  }
+  return frequencies;
+}
+
+/**
+ * Generates synthetic FFT byte data with peaks at the given frequencies.
+ *
+ * Creates a time-domain signal as a sum of cosines, applies the FFT, then
+ * converts to the 0–255 byte convention used by AnalyserNode.
+ */
+function generateFftByteData(
+  frequencies: number[],
+  fftSize: number,
+  sampleRate: number,
+): Uint8Array {
+  const N = fftSize;
+  const real = new Float32Array(N);
+  const imag = new Float32Array(N);
+
+  for (let n = 0; n < N; n++) {
+    for (const freq of frequencies) {
+      real[n] += Math.cos((2 * Math.PI * freq * n) / sampleRate);
+    }
+  }
+
+  fft(real, imag);
+
+  const output = new Uint8Array(N / 2);
+  magnitudeToBytes(real, imag, N, -80, -30, output);
+  return output;
+}
+
+/**
+ * Finds the output bin with the highest value within a neighbourhood.
+ */
+function findPeakBin(
+  data: Uint8Array | Float32Array,
+  searchCenter: number,
+  searchRadius: number,
+): number {
+  const start = Math.max(0, Math.floor(searchCenter - searchRadius));
+  const end = Math.min(data.length - 1, Math.ceil(searchCenter + searchRadius));
+  let peakBin = start;
+  for (let i = start + 1; i <= end; i++) {
+    if (data[i] > data[peakBin]) peakBin = i;
+  }
+  return peakBin;
+}
+
+/**
+ * Measures how evenly spaced a set of positions are by computing the
+ * coefficient of variation (stddev / mean) of consecutive spacings.
+ * A perfect equal spacing gives CV = 0.
+ */
+function spacingCoefficientOfVariation(positions: number[]): number {
+  if (positions.length < 3) return 0;
+  const spacings: number[] = [];
+  for (let i = 1; i < positions.length; i++) {
+    spacings.push(positions[i] - positions[i - 1]);
+  }
+  const mean = spacings.reduce((a, b) => a + b, 0) / spacings.length;
+  const variance =
+    spacings.reduce((sum, s) => sum + (s - mean) ** 2, 0) / spacings.length;
+  return Math.sqrt(variance) / mean;
+}
+
+/**
+ * Builds a reverse map: input bin → first output bin that references it.
+ */
+function buildReverseMap(mapping: number[][]): Map<number, number> {
+  const rev = new Map<number, number>();
+  for (let i = 0; i < mapping.length; i++) {
+    for (const inputBin of mapping[i]) {
+      if (!rev.has(inputBin)) rev.set(inputBin, i);
+    }
+  }
+  return rev;
+}
+
+describe('logFrequencyMapping', () => {
+  describe('12-TET equal spacing', () => {
+    const SAMPLE_RATE = 44100;
+    const FFT_SIZE = 2048;
+    const INPUT_BIN_COUNT = FFT_SIZE / 2; // 1024
+    const OUTPUT_BIN_COUNT = 512;
+    const BIN_WIDTH = SAMPLE_RATE / FFT_SIZE; // ~21.53 Hz
+
+    // Semitones in a range where individual FFT bins can resolve them.
+    // Start at ~200 Hz (well above bin width) and go to ~8 kHz.
+    // Take every 4th semitone (minor thirds) for clean peak separation.
+    const semitones = generateSemitoneFrequencies(200, 8000);
+    const testFrequencies = semitones.filter((_, i) => i % 4 === 0);
+
+    it('createDualBandLogMapping spaces 12-TET tones equally', () => {
+      const mapping = createDualBandLogMapping(
+        INPUT_BIN_COUNT,
+        INPUT_BIN_COUNT,
+        BIN_WIDTH,
+        0,
+        BIN_WIDTH,
+        OUTPUT_BIN_COUNT,
+      );
+
+      const fftData = generateFftByteData(
+        testFrequencies,
+        FFT_SIZE,
+        SAMPLE_RATE,
+      );
+
+      const output = new Uint8Array(OUTPUT_BIN_COUNT);
+      applyLogFrequencyMapping(fftData, mapping, output);
+
+      const peakPositions: number[] = [];
+      for (const freq of testFrequencies) {
+        const minFreq = BIN_WIDTH;
+        const maxFreq = (INPUT_BIN_COUNT - 1) * BIN_WIDTH;
+        const t =
+          (Math.log(freq) - Math.log(minFreq)) /
+          (Math.log(maxFreq) - Math.log(minFreq));
+        const expectedBin = t * (OUTPUT_BIN_COUNT - 1);
+        const peak = findPeakBin(output, expectedBin, OUTPUT_BIN_COUNT * 0.05);
+        if (output[peak] > 0) {
+          peakPositions.push(peak);
+        }
+      }
+
+      expect(peakPositions.length).toBeGreaterThanOrEqual(5);
+
+      const cv = spacingCoefficientOfVariation(peakPositions);
+      expect(cv).toBeLessThan(0.15);
+    });
+
+    it('createLogFrequencyMapping spaces 12-TET tones equally', () => {
+      const mapping = createLogFrequencyMapping(
+        INPUT_BIN_COUNT,
+        OUTPUT_BIN_COUNT,
+      );
+
+      const fftData = generateFftByteData(
+        testFrequencies,
+        FFT_SIZE,
+        SAMPLE_RATE,
+      );
+
+      const output = new Uint8Array(OUTPUT_BIN_COUNT);
+      applyLogFrequencyMapping(fftData, mapping, output);
+
+      const peakPositions: number[] = [];
+      for (const freq of testFrequencies) {
+        const minFreq = BIN_WIDTH;
+        const maxFreq = (INPUT_BIN_COUNT - 1) * BIN_WIDTH;
+        const t =
+          (Math.log(freq) - Math.log(minFreq)) /
+          (Math.log(maxFreq) - Math.log(minFreq));
+        const expectedBin = t * (OUTPUT_BIN_COUNT - 1);
+        const peak = findPeakBin(output, expectedBin, OUTPUT_BIN_COUNT * 0.08);
+        if (output[peak] > 0) {
+          peakPositions.push(peak);
+        }
+      }
+
+      expect(peakPositions.length).toBeGreaterThanOrEqual(5);
+
+      const cv = spacingCoefficientOfVariation(peakPositions);
+      expect(cv).toBeLessThan(0.15);
+    });
+
+    it('both mappings place the same tone at the same output bin', () => {
+      const uniformMapping = createLogFrequencyMapping(
+        INPUT_BIN_COUNT,
+        OUTPUT_BIN_COUNT,
+      );
+      const dualBandMapping = createDualBandLogMapping(
+        INPUT_BIN_COUNT,
+        INPUT_BIN_COUNT,
+        BIN_WIDTH,
+        0,
+        BIN_WIDTH,
+        OUTPUT_BIN_COUNT,
+      );
+
+      const rev1 = buildReverseMap(uniformMapping);
+      const rev2 = buildReverseMap(dualBandMapping);
+
+      // Check that semitone frequencies map to the same output bin in both.
+      // Use frequencies across a wide range to catch low-frequency divergence.
+      const checkFrequencies = [110, 220, 440, 880, 1760, 3520, 7040];
+      for (const freq of checkFrequencies) {
+        const inputBin = Math.round(freq / BIN_WIDTH);
+        const out1 = rev1.get(inputBin)!;
+        const out2 = rev2.get(inputBin)!;
+        expect(
+          Math.abs(out1 - out2),
+          `${freq} Hz (bin ${inputBin}): uniform=${out1} vs dual-band=${out2}`,
+        ).toBeLessThanOrEqual(2);
+      }
+    });
+  });
+
+  describe('basic properties', () => {
+    it('createLogFrequencyMapping produces correct output length', () => {
+      const mapping = createLogFrequencyMapping(1024, 512);
+      expect(mapping.length).toBe(512);
+    });
+
+    it('createLogFrequencyMapping entries reference valid input indices', () => {
+      const inputBinCount = 1024;
+      const mapping = createLogFrequencyMapping(inputBinCount, 512);
+      for (const pool of mapping) {
+        for (const idx of pool) {
+          expect(idx).toBeGreaterThanOrEqual(0);
+          expect(idx).toBeLessThan(inputBinCount);
+        }
+      }
+    });
+
+    it('createDualBandLogMapping produces correct output length', () => {
+      const mapping = createDualBandLogMapping(800, 300, 2.5, 18, 43.07, 512);
+      expect(mapping.length).toBe(512);
+    });
+
+    it('createLogFrequencyMapping output bins are monotonically non-decreasing', () => {
+      const mapping = createLogFrequencyMapping(1024, 512);
+      for (let i = 1; i < mapping.length; i++) {
+        expect(mapping[i][0]).toBeGreaterThanOrEqual(mapping[i - 1][0]);
+      }
+    });
+
+    it('createDualBandLogMapping output bins are monotonically non-decreasing', () => {
+      const mapping = createDualBandLogMapping(800, 300, 2.5, 18, 43.07, 512);
+      for (let i = 1; i < mapping.length; i++) {
+        expect(mapping[i][0]).toBeGreaterThanOrEqual(mapping[i - 1][0]);
+      }
+    });
+  });
+});

--- a/src/services/logFrequencyMapping.ts
+++ b/src/services/logFrequencyMapping.ts
@@ -14,26 +14,39 @@
  * (expanding the low range); high-frequency output bins pool multiple
  * input bins (compressing the high range).
  *
- * When `outputBinCount` differs from `inputBinCount`, the log curve is
- * scaled so the output spans the full input range at the requested
- * resolution.
+ * Uses the same true logarithmic frequency scale as
+ * `createDualBandLogMapping`: output bins are spaced so that equal visual
+ * distances correspond to equal musical intervals. Bin 0 (DC) is skipped;
+ * the mapping spans from input bin 1 to input bin `inputBinCount - 1`.
  */
 export function createLogFrequencyMapping(
   inputBinCount: number,
   outputBinCount: number = inputBinCount,
 ): number[][] {
+  const logMin = 0; // ln(1) — first non-DC bin
+  const logMax = Math.log(inputBinCount - 1);
+
   const mapping: number[][] = new Array(outputBinCount);
-  const lower = 1;
-  const upper = inputBinCount + 1;
-  const b = Math.log(lower / upper) / (lower - upper);
-  const scale = inputBinCount / outputBinCount;
+
   for (let i = 0; i < outputBinCount; i++) {
-    const logIdx = Math.min(
-      Math.trunc(Math.exp(b * i * scale)) - 1,
-      inputBinCount - 1,
-    );
-    mapping[i] = [logIdx];
+    const t = i / (outputBinCount - 1);
+    const targetIdx = Math.exp(logMin + t * (logMax - logMin));
+
+    let lo = 0;
+    let hi = inputBinCount - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (mid < targetIdx) lo = mid + 1;
+      else hi = mid;
+    }
+    let closest = lo;
+    if (lo > 0 && Math.abs(targetIdx - (lo - 1)) < Math.abs(lo - targetIdx)) {
+      closest = lo - 1;
+    }
+
+    mapping[i] = [Math.min(closest, inputBinCount - 1)];
   }
+
   for (let i = 0; i < outputBinCount - 1; i++) {
     const df = mapping[i + 1][0] - mapping[i][0];
     if (df <= 1) {


### PR DESCRIPTION
## Summary
- Fix `createLogFrequencyMapping` to use the same true logarithmic frequency scale as `createDualBandLogMapping`, so that the scrubber (single-band path) and spectrogram (dual-band path) place the same frequencies at the same visual positions
- The old formula `exp(b*i*scale) - 1` deviated from true log spacing, particularly at low frequencies (e.g. 110 Hz was placed at output bin 133 vs 111, a 22-bin discrepancy)
- Add `logFrequencyMapping.test.ts` with 12-TET semitone tests that verify both mapping functions produce equal spacing and agree on bin positions

## Test plan
- [x] New test: `createLogFrequencyMapping spaces 12-TET tones equally` — verifies coefficient of variation of semitone spacings < 15%
- [x] New test: `createDualBandLogMapping spaces 12-TET tones equally` — same check for reference mapping
- [x] New test: `both mappings place the same tone at the same output bin` — verifies 110–7040 Hz map within ±2 bins across both functions
- [x] All 600 existing tests pass
- [x] Lint and build pass

https://claude.ai/code/session_01NZ2eSDAuvLDvy1qDgpySHg