### PR TITLE
Fix playback end-of-timeline behavior

### DIFF
--- a/src/services/PlaybackService.ts
+++ b/src/services/PlaybackService.ts
@@ -77,6 +77,9 @@ class PlaybackService {
 
   setTransportTime(time: number): void {
     this._transportTime.value = time;
+    if (this._playbackState.value === 'playing' && this.isAtEndOfTimeline()) {
+      this.stopAtEndOfTimeline();
+    }
   }
 
   setTotalTime(time: number): void {
@@ -168,6 +171,14 @@ class PlaybackService {
     this._transportTime.value = 0;
     this._totalTime.value = 0;
     this._loudness.value = 0;
+  }
+
+  // Stops playback at the end of the timeline without rewinding.
+  // Uses transport.pause() instead of transport.stop() to preserve
+  // the current position, so the scrubber stays at the end.
+  private stopAtEndOfTimeline(): void {
+    this._playbackState.value = 'stopped';
+    this.transport.pause();
   }
 
   private isAtEndOfTimeline(): boolean {

--- a/src/services/__tests__/PlaybackService.test.ts
+++ b/src/services/__tests__/PlaybackService.test.ts
@@ -150,6 +150,57 @@ describe('PlaybackService', () => {
     });
   });
 
+  describe('auto-stop at end of timeline', () => {
+    it('stops playback when transport time reaches the end', () => {
+      service.setTotalTime(10.0);
+      service.play();
+
+      service.setTransportTime(10.0);
+
+      expect(service.playbackState).toBe('stopped');
+      expect(service.isPlaying).toBe(false);
+    });
+
+    it('preserves transport time at the end position', () => {
+      service.setTotalTime(10.0);
+      service.play();
+
+      service.setTransportTime(10.0);
+
+      expect(service.transportTime).toBe(10.0);
+    });
+
+    it('pauses the transport engine to preserve position', () => {
+      service.setTotalTime(10.0);
+      service.play();
+      vi.mocked(Tone.getTransport().pause).mockClear();
+
+      service.setTransportTime(10.0);
+
+      expect(Tone.getTransport().pause).toHaveBeenCalledTimes(1);
+      expect(Tone.getTransport().stop).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-stop when not playing', () => {
+      service.setTotalTime(10.0);
+
+      service.setTransportTime(10.0);
+
+      expect(service.playbackState).toBe('stopped');
+      expect(Tone.getTransport().pause).not.toHaveBeenCalled();
+    });
+
+    it('handles toFixed(1) rounding at end of timeline', () => {
+      service.setTotalTime(10.0);
+      service.play();
+
+      service.setTransportTime(10.04);
+
+      expect(service.playbackState).toBe('stopped');
+      expect(service.transportTime).toBe(10.04);
+    });
+  });
+
   describe('stop', () => {
     it('transitions from playing to stopped', () => {
       service.play();


### PR DESCRIPTION
## Summary
- Playback now automatically stops when the transport time reaches the end of the timeline
- The playback position is preserved at the end (no rewind to start on auto-stop)
- Starting playback from the end of the timeline still rewinds to the beginning (existing behavior)

## Changes
- **PlaybackService.ts**: Added auto-stop detection in `setTransportTime()` — when the transport reaches the end during playback, a new `stopAtEndOfTimeline()` method transitions state to `stopped` while using `transport.pause()` (instead of `transport.stop()`) to preserve the scrubber position
- **PlaybackService.test.ts**: Added 5 tests covering auto-stop at end of timeline, position preservation, transport engine behavior, no-op when not playing, and toFixed(1) rounding

## Test plan
- [x] Failing tests written before the fix to confirm they capture the bug
- [x] All 5 new tests pass after the fix
- [x] Full test suite passes (605 tests)

https://claude.ai/code/session_01MHwhWUnTfQekEU6fP5E5fb