### PR TITLE
Add InstrumentClassificationService for instrument detection (#176)

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -1,0 +1,220 @@
+// InstrumentClassificationService — owns instrument classification state.
+//
+// Wraps Transformers.js zero-shot audio classification to detect the
+// instrument in an audio track. Results are cached by TrackId and
+// exposed as a signal for reactive consumers.
+
+import { signal, type ReadonlySignal } from '@preact/signals-react';
+import type { TrackId } from '../types/track';
+
+export type ClassificationState = 'idle' | 'classifying' | 'done' | 'error';
+
+export type ClassificationResult = {
+  label: string;
+  score: number;
+};
+
+type ClassificationEntry = {
+  state: ClassificationState;
+  result?: ClassificationResult;
+};
+
+const CANDIDATE_LABELS = [
+  'vocals',
+  'guitar',
+  'bass',
+  'drums',
+  'keyboard',
+  'strings',
+  'brass',
+  'woodwind',
+  'synth',
+  'percussion',
+] as const;
+
+export type InstrumentLabel = (typeof CANDIDATE_LABELS)[number];
+
+// Sample rate expected by the CLAP model
+const MODEL_SAMPLE_RATE = 48_000;
+
+type Pipeline = (
+  audio: Float32Array,
+  labels: string[],
+) => Promise<Array<{ label: string; score: number }>>;
+
+class InstrumentClassificationService {
+  // --- Private signals (only the service writes these) ---
+
+  private readonly _classifications = signal<
+    ReadonlyMap<TrackId, ClassificationEntry>
+  >(new Map());
+
+  // --- Narrow channel for reactive consumers (hooks) ---
+
+  readonly signals: {
+    readonly classifications: ReadonlySignal<
+      ReadonlyMap<TrackId, ClassificationEntry>
+    >;
+  };
+
+  private pipeline: Pipeline | null = null;
+  private pipelinePromise: Promise<Pipeline> | null = null;
+  private cache = new Map<TrackId, ClassificationEntry>();
+
+  constructor() {
+    this.signals = {
+      classifications: this._classifications,
+    };
+  }
+
+  // --- Plain getters for non-reactive consumers (tests, workflows) ---
+
+  get classifications(): ReadonlyMap<TrackId, ClassificationEntry> {
+    return this._classifications.value;
+  }
+
+  getClassification(trackId: TrackId): ClassificationResult | undefined {
+    return this.cache.get(trackId)?.result;
+  }
+
+  getClassificationState(trackId: TrackId): ClassificationState {
+    return this.cache.get(trackId)?.state ?? 'idle';
+  }
+
+  // --- Classification ---
+
+  async classify(trackId: TrackId, audioBuffer: AudioBuffer): Promise<string> {
+    if (this.cache.has(trackId)) {
+      const cached = this.cache.get(trackId)!;
+      if (cached.state === 'done' && cached.result) {
+        return cached.result.label;
+      }
+    }
+
+    this.setEntry(trackId, { state: 'classifying' });
+
+    try {
+      const classifierPipeline = await this.loadPipeline();
+      const monoSamples = downmixToMono(audioBuffer, MODEL_SAMPLE_RATE);
+      const results = await classifierPipeline(monoSamples, [
+        ...CANDIDATE_LABELS,
+      ]);
+
+      const top = results.reduce((best, current) =>
+        current.score > best.score ? current : best,
+      );
+
+      const result: ClassificationResult = {
+        label: top.label,
+        score: top.score,
+      };
+      this.setEntry(trackId, { state: 'done', result });
+      return top.label;
+    } catch {
+      this.setEntry(trackId, { state: 'error' });
+      throw new Error(`Classification failed for track ${trackId}`);
+    }
+  }
+
+  // --- Pipeline management ---
+
+  private async loadPipeline(): Promise<Pipeline> {
+    if (this.pipeline) return this.pipeline;
+    if (this.pipelinePromise) return this.pipelinePromise;
+
+    this.pipelinePromise = this.initializePipeline();
+    this.pipeline = await this.pipelinePromise;
+    this.pipelinePromise = null;
+    return this.pipeline;
+  }
+
+  private async initializePipeline(): Promise<Pipeline> {
+    const { pipeline } = await import('@huggingface/transformers');
+
+    const classifier = await pipeline(
+      'zero-shot-audio-classification',
+      'Xenova/clap-large',
+      { device: 'wasm' },
+    );
+
+    return async (audio: Float32Array, labels: string[]) => {
+      const output = await classifier(audio, labels);
+
+      return output as Array<{ label: string; score: number }>;
+    };
+  }
+
+  // --- Cleanup ---
+
+  removeClassification(trackId: TrackId): void {
+    this.cache.delete(trackId);
+    this.publishCache();
+  }
+
+  reset(): void {
+    this.cache.clear();
+    this.publishCache();
+  }
+
+  // --- Internal state management ---
+
+  private setEntry(trackId: TrackId, entry: ClassificationEntry): void {
+    this.cache.set(trackId, entry);
+    this.publishCache();
+  }
+
+  private publishCache(): void {
+    this._classifications.value = new Map(this.cache);
+  }
+}
+
+// --- Audio utilities ---
+
+function downmixToMono(
+  audioBuffer: AudioBuffer,
+  targetSampleRate: number,
+): Float32Array {
+  const numberOfChannels = audioBuffer.numberOfChannels;
+  const sourceSampleRate = audioBuffer.sampleRate;
+  const sourceLength = audioBuffer.length;
+
+  // Downmix to mono by averaging all channels
+  const mono = new Float32Array(sourceLength);
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    const channelData = audioBuffer.getChannelData(ch);
+    for (let i = 0; i < sourceLength; i++) {
+      mono[i] += channelData[i] / numberOfChannels;
+    }
+  }
+
+  // Resample if needed
+  if (sourceSampleRate === targetSampleRate) {
+    return mono;
+  }
+
+  return resample(mono, sourceSampleRate, targetSampleRate);
+}
+
+function resample(
+  samples: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
+  const ratio = fromRate / toRate;
+  const outputLength = Math.round(samples.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const srcIndexFloor = Math.floor(srcIndex);
+    const fraction = srcIndex - srcIndexFloor;
+
+    const sample0 = samples[srcIndexFloor] ?? 0;
+    const sample1 = samples[srcIndexFloor + 1] ?? 0;
+    output[i] = sample0 + fraction * (sample1 - sample0);
+  }
+
+  return output;
+}
+
+export default InstrumentClassificationService;

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -1,0 +1,226 @@
+import { vi } from 'vitest';
+import InstrumentClassificationService from '../InstrumentClassificationService';
+
+const mockClassifier = vi.fn();
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: vi.fn().mockResolvedValue(mockClassifier),
+}));
+
+function createAudioBuffer(
+  numberOfChannels = 1,
+  length = 48000,
+  sampleRate = 48000,
+): AudioBuffer {
+  const channelData: Float32Array[] = [];
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    channelData.push(new Float32Array(length));
+  }
+  return {
+    numberOfChannels,
+    length,
+    sampleRate,
+    duration: length / sampleRate,
+    getChannelData: (ch: number) => channelData[ch],
+  } as unknown as AudioBuffer;
+}
+
+let service: InstrumentClassificationService;
+
+beforeEach(() => {
+  service = new InstrumentClassificationService();
+  mockClassifier.mockReset();
+  mockClassifier.mockResolvedValue([
+    { label: 'guitar', score: 0.85 },
+    { label: 'vocals', score: 0.1 },
+    { label: 'drums', score: 0.05 },
+  ]);
+});
+
+describe('InstrumentClassificationService', () => {
+  describe('initial state', () => {
+    it('starts with empty classifications', () => {
+      expect(service.classifications.size).toBe(0);
+    });
+
+    it('returns undefined for unknown track', () => {
+      expect(service.getClassification('unknown')).toBeUndefined();
+    });
+
+    it('returns idle state for unknown track', () => {
+      expect(service.getClassificationState('unknown')).toBe('idle');
+    });
+  });
+
+  describe('classify', () => {
+    it('returns the top-scoring label', async () => {
+      const buffer = createAudioBuffer();
+
+      const label = await service.classify('track-1', buffer);
+
+      expect(label).toBe('guitar');
+    });
+
+    it('stores the result in the classifications signal', async () => {
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+
+      const result = service.getClassification('track-1');
+      expect(result).toEqual({ label: 'guitar', score: 0.85 });
+    });
+
+    it('sets state to done after classification', async () => {
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+
+      expect(service.getClassificationState('track-1')).toBe('done');
+    });
+
+    it('returns cached result without re-running inference', async () => {
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+      const label = await service.classify('track-1', buffer);
+
+      expect(label).toBe('guitar');
+      expect(mockClassifier).toHaveBeenCalledTimes(1);
+    });
+
+    it('classifies multiple tracks independently', async () => {
+      const buffer1 = createAudioBuffer();
+      const buffer2 = createAudioBuffer();
+
+      mockClassifier
+        .mockResolvedValueOnce([
+          { label: 'guitar', score: 0.9 },
+          { label: 'bass', score: 0.1 },
+        ])
+        .mockResolvedValueOnce([
+          { label: 'drums', score: 0.8 },
+          { label: 'percussion', score: 0.2 },
+        ]);
+
+      await service.classify('track-1', buffer1);
+      await service.classify('track-2', buffer2);
+
+      expect(service.getClassification('track-1')?.label).toBe('guitar');
+      expect(service.getClassification('track-2')?.label).toBe('drums');
+      expect(service.classifications.size).toBe(2);
+    });
+
+    it('sets state to error when classification fails', async () => {
+      mockClassifier.mockRejectedValue(new Error('model error'));
+      const buffer = createAudioBuffer();
+
+      await expect(service.classify('track-1', buffer)).rejects.toThrow(
+        'Classification failed for track track-1',
+      );
+
+      expect(service.getClassificationState('track-1')).toBe('error');
+    });
+
+    it('passes candidate labels to the pipeline', async () => {
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+
+      expect(mockClassifier).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        expect.arrayContaining([
+          'vocals',
+          'guitar',
+          'bass',
+          'drums',
+          'keyboard',
+          'strings',
+          'brass',
+          'woodwind',
+          'synth',
+          'percussion',
+        ]),
+      );
+    });
+  });
+
+  describe('audio preprocessing', () => {
+    it('downmixes stereo to mono', async () => {
+      const buffer = createAudioBuffer(2, 48000, 48000);
+
+      await service.classify('track-1', buffer);
+
+      const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
+      expect(passedAudio.length).toBe(48000);
+    });
+
+    it('resamples from 44100 to 48000', async () => {
+      const buffer = createAudioBuffer(1, 44100, 44100);
+
+      await service.classify('track-1', buffer);
+
+      const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
+      expect(passedAudio.length).toBe(48000);
+    });
+
+    it('does not resample when already at target rate', async () => {
+      const buffer = createAudioBuffer(1, 48000, 48000);
+
+      await service.classify('track-1', buffer);
+
+      const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
+      expect(passedAudio.length).toBe(48000);
+    });
+  });
+
+  describe('pipeline loading', () => {
+    it('loads the pipeline lazily on first classify call', async () => {
+      const { pipeline } = await import('@huggingface/transformers');
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+
+      expect(pipeline).toHaveBeenCalledWith(
+        'zero-shot-audio-classification',
+        'Xenova/clap-large',
+        { device: 'wasm' },
+      );
+    });
+
+    it('reuses the pipeline across multiple calls', async () => {
+      const { pipeline } = await import('@huggingface/transformers');
+      const buffer = createAudioBuffer();
+
+      await service.classify('track-1', buffer);
+      mockClassifier.mockResolvedValueOnce([{ label: 'bass', score: 0.9 }]);
+      await service.classify('track-2', buffer);
+
+      expect(pipeline).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('removeClassification', () => {
+    it('removes a classification entry', async () => {
+      const buffer = createAudioBuffer();
+      await service.classify('track-1', buffer);
+
+      service.removeClassification('track-1');
+
+      expect(service.getClassification('track-1')).toBeUndefined();
+      expect(service.getClassificationState('track-1')).toBe('idle');
+      expect(service.classifications.size).toBe(0);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all classifications', async () => {
+      const buffer = createAudioBuffer();
+      await service.classify('track-1', buffer);
+      await service.classify('track-2', buffer);
+
+      service.reset();
+
+      expect(service.classifications.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Created `InstrumentClassificationService` in `src/services/` that wraps Transformers.js zero-shot audio classification to detect instruments in audio tracks
- Follows the established service pattern: private signals, plain getters, and a `signals` accessor for reactive consumers (hooks)
- Lazy-loads the classification pipeline via dynamic `import()` on first use to avoid increasing initial bundle size
- Downmixes audio to mono and resamples to 48kHz before running classification against 10 candidate labels (vocals, guitar, bass, drums, keyboard, strings, brass, woodwind, synth, percussion)
- Caches results by `TrackId` to avoid redundant inference on the same track
- Exposes a `classifications` signal (`Map<TrackId, ClassificationEntry>`) with per-track state tracking (idle, classifying, done, error)
- Added 17 unit tests covering classification, caching, audio preprocessing, pipeline loading, cleanup, and error handling

Implements step 2 of #176.

## Test plan
- [x] All 17 new unit tests pass
- [x] Full test suite (625 tests across 49 files) passes
- [x] ESLint passes
- [x] Production build succeeds

https://claude.ai/code/session_018H8DKt4Z3c6Xy8w16ZMVrV