### PR TITLE
Integrate classification into track creation flow and add bridge hook (#176)

### DIFF
--- a/src/hooks/useClassificationService.ts
+++ b/src/hooks/useClassificationService.ts
@@ -1,0 +1,36 @@
+// useClassificationService — React hook that bridges
+// InstrumentClassificationService signals to components.
+//
+// Provides reactive classification state and lookup functions
+// for instrument labels detected on each track.
+
+import { useSignals } from '@preact/signals-react/runtime';
+import { useContext } from 'react';
+import { AudioServiceContext } from './useAudioService';
+import type { ClassificationState } from '../services/InstrumentClassificationService';
+import type { TrackId } from '../types/track';
+
+export function useClassificationService() {
+  useSignals();
+  const service = useContext(AudioServiceContext).classificationService;
+
+  return {
+    // --- Reactive state (getter → lazy signal subscription via signals accessor) ---
+
+    get classifications() {
+      return service.signals.classifications.value;
+    },
+
+    // --- Lookups ---
+
+    getClassification: (trackId: TrackId) => service.getClassification(trackId),
+    getClassificationState: (trackId: TrackId): ClassificationState =>
+      service.getClassificationState(trackId),
+
+    // --- Cleanup ---
+
+    removeClassification: (trackId: TrackId) =>
+      service.removeClassification(trackId),
+    reset: () => service.reset(),
+  };
+}

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -9,6 +9,7 @@ import * as Tone from 'tone';
 import PlaybackService from './PlaybackService';
 import RecordingService from './RecordingService';
 import TrackService from './TrackService';
+import InstrumentClassificationService from './InstrumentClassificationService';
 import SpectrogramCache from './SpectrogramCache';
 import WorkletAnalyser from './WorkletAnalyser';
 
@@ -31,6 +32,7 @@ class AudioService {
   readonly playbackService: PlaybackService;
   readonly recordingService: RecordingService;
   readonly trackService: TrackService;
+  readonly classificationService: InstrumentClassificationService;
   readonly spectrogramCache: SpectrogramCache;
 
   private static instance: AudioService;
@@ -42,7 +44,15 @@ class AudioService {
     this.playbackService = new PlaybackService(transport);
     this.recordingService = new RecordingService(transport, context);
     this.trackService = new TrackService(context);
+    this.classificationService = new InstrumentClassificationService();
     this.spectrogramCache = new SpectrogramCache();
+
+    // Fire-and-forget classification when a track is created
+    this.trackService.setOnTrackCreated((trackId, audioBuffer) => {
+      this.classificationService.classify(trackId, audioBuffer).catch(() => {
+        // Classification failure is non-critical — silently ignored
+      });
+    });
 
     // Attempt to initialize the AudioWorklet-based recorder for
     // sample-accurate capture. Falls back to Tone.Recorder silently.

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -42,6 +42,8 @@ type Context = {
   decodeAudioData: (arrayBuffer: ArrayBuffer) => Promise<AudioBuffer>;
 };
 
+type TrackCreatedCallback = (trackId: string, audioBuffer: AudioBuffer) => void;
+
 const DEFAULT_VOLUME = 100;
 
 class TrackService {
@@ -61,6 +63,7 @@ class TrackService {
   private audioSourceRepository: AudioSourceRepository;
   private signalStore = new Map<TrackId, TrackSignals>();
   private effectDisposers = new Map<TrackId, Array<() => void>>();
+  private onTrackCreated: TrackCreatedCallback | null = null;
 
   // Bumped on every store mutation so computed signals that depend on the
   // store's membership (e.g. mutedTracks) know to re-evaluate.
@@ -92,6 +95,12 @@ class TrackService {
     return this._mutedTracks.value;
   }
 
+  // --- Lifecycle hooks ---
+
+  setOnTrackCreated(callback: TrackCreatedCallback): void {
+    this.onTrackCreated = callback;
+  }
+
   // --- Track creation ---
 
   async createTrack(arrayBuffer: ArrayBuffer): Promise<TrackCreationResult> {
@@ -115,6 +124,7 @@ class TrackService {
     });
 
     this.createSignals(trackId, initialVolume);
+    this.onTrackCreated?.(trackId, audioBuffer);
 
     return { trackId, initialVolume };
   }
@@ -148,6 +158,7 @@ class TrackService {
     });
 
     this.createSignals(trackId, initialVolume);
+    this.onTrackCreated?.(trackId, audioBuffer);
 
     return { trackId, initialVolume };
   }

--- a/src/services/__tests__/AudioService.test.ts
+++ b/src/services/__tests__/AudioService.test.ts
@@ -49,6 +49,11 @@ describe('sub-services', () => {
     expect(audioService.trackService.mutedTracks).toEqual([]);
   });
 
+  it('creates an InstrumentClassificationService', () => {
+    expect(audioService.classificationService).toBeDefined();
+    expect(audioService.classificationService.classifications.size).toBe(0);
+  });
+
   it('creates a SpectrogramCache', () => {
     expect(audioService.spectrogramCache).toBeDefined();
   });

--- a/src/services/__tests__/TrackService.classification.test.ts
+++ b/src/services/__tests__/TrackService.classification.test.ts
@@ -1,0 +1,73 @@
+import { vi } from 'vitest';
+import * as Tone from 'tone';
+import TrackService from '../TrackService';
+
+// jsdom doesn't implement URL.createObjectURL
+if (typeof URL.createObjectURL === 'undefined') {
+  URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+}
+
+function mockAudioBuffer(overrides: Partial<AudioBuffer> = {}): AudioBuffer {
+  const channelData = new Float32Array(100).fill(0.2);
+  return {
+    numberOfChannels: 1,
+    length: 100,
+    sampleRate: 44100,
+    duration: 100 / 44100,
+    getChannelData: vi.fn().mockReturnValue(channelData),
+    ...overrides,
+  } as unknown as AudioBuffer;
+}
+
+let service: TrackService;
+
+beforeEach(() => {
+  vi.mocked(Tone.context.decodeAudioData).mockResolvedValue(mockAudioBuffer());
+  service = new TrackService(Tone.context);
+});
+
+describe('TrackService track creation callback', () => {
+  it('calls onTrackCreated after createTrack', async () => {
+    const callback = vi.fn();
+    service.setOnTrackCreated(callback);
+
+    const { trackId } = await service.createTrack(new ArrayBuffer(16));
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(trackId, expect.any(Object));
+  });
+
+  it('calls onTrackCreated after createRecordedTrack', () => {
+    const callback = vi.fn();
+    service.setOnTrackCreated(callback);
+    const audioBuffer = mockAudioBuffer({ duration: 5.0 });
+
+    const { trackId } = service.createRecordedTrack(
+      audioBuffer,
+      new ArrayBuffer(16),
+      3.0,
+    );
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(trackId, audioBuffer);
+  });
+
+  it('does not throw when no callback is registered', async () => {
+    await expect(
+      service.createTrack(new ArrayBuffer(16)),
+    ).resolves.toBeDefined();
+  });
+
+  it('passes the decoded audio buffer to the callback', async () => {
+    const decodedBuffer = mockAudioBuffer({ duration: 2.0 });
+    vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+      decodedBuffer,
+    );
+    const callback = vi.fn();
+    service.setOnTrackCreated(callback);
+
+    await service.createTrack(new ArrayBuffer(16));
+
+    expect(callback.mock.calls[0][1]).toBe(decodedBuffer);
+  });
+});


### PR DESCRIPTION
## Summary
- Wired `InstrumentClassificationService` into `AudioService` as a sub-service, created alongside other sub-services
- Added a `setOnTrackCreated` callback hook on `TrackService` that fires after both `createTrack()` and `createRecordedTrack()` complete, triggering fire-and-forget classification
- Created `useClassificationService` bridge hook following the existing pattern (`useSignals()`, lazy getters, action callbacks) for reactive access to classification state from React components
- Added tests: AudioService sub-service creation, TrackService callback invocation for both uploaded and recorded tracks

## Test plan
- [x] Existing tests pass (630 tests, 50 files)
- [x] ESLint passes
- [x] New `TrackService.classification.test.ts` verifies callback fires for `createTrack()` and `createRecordedTrack()`
- [x] `AudioService.test.ts` verifies `classificationService` is created
- [ ] Manual: upload a file and verify classification runs (pending Steps 5–6 for UI)

https://claude.ai/code/session_01TZ2sYcGHLF28SrboBmGXAd