### PR TITLE
Move audio classification inference to a Web Worker

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -1,11 +1,15 @@
 // InstrumentClassificationService — owns instrument classification state.
 //
-// Wraps Transformers.js zero-shot audio classification to detect the
-// instrument in an audio track. Results are cached by TrackId and
-// exposed as a signal for reactive consumers.
+// Delegates inference to a Web Worker to keep the main thread responsive.
+// The worker handles pipeline loading (with stale-while-revalidate model
+// caching via the Cache API) and audio preprocessing. If the worker fails,
+// the service falls back to main-thread inference.
+//
+// Signal ownership and per-track caching remain on the main thread.
 
 import { signal, type ReadonlySignal } from '@preact/signals-react';
 import type { TrackId } from '../types/track';
+import { type ClassifyResponse } from './classification.worker';
 
 export type ClassificationState = 'idle' | 'classifying' | 'done' | 'error';
 
@@ -18,6 +22,8 @@ type ClassificationEntry = {
   state: ClassificationState;
   result?: ClassificationResult;
 };
+
+export type InstrumentLabel = (typeof CANDIDATE_LABELS)[number];
 
 const CANDIDATE_LABELS = [
   'vocals',
@@ -32,8 +38,6 @@ const CANDIDATE_LABELS = [
   'percussion',
 ] as const;
 
-export type InstrumentLabel = (typeof CANDIDATE_LABELS)[number];
-
 // Sample rate expected by the CLAP model
 const MODEL_SAMPLE_RATE = 48_000;
 
@@ -41,6 +45,11 @@ type Pipeline = (
   audio: Float32Array,
   labels: string[],
 ) => Promise<Array<{ label: string; score: number }>>;
+
+type PendingRequest = {
+  resolve: (result: ClassificationResult) => void;
+  reject: (error: Error) => void;
+};
 
 class InstrumentClassificationService {
   // --- Private signals (only the service writes these) ---
@@ -57,9 +66,15 @@ class InstrumentClassificationService {
     >;
   };
 
+  private cache = new Map<TrackId, ClassificationEntry>();
+  private worker: Worker | null = null;
+  private workerFailed = false;
+  private nextMessageId = 0;
+  private pendingRequests = new Map<number, PendingRequest>();
+
+  // Main-thread fallback state
   private pipeline: Pipeline | null = null;
   private pipelinePromise: Promise<Pipeline> | null = null;
-  private cache = new Map<TrackId, ClassificationEntry>();
 
   constructor() {
     this.signals = {
@@ -94,29 +109,117 @@ class InstrumentClassificationService {
     this.setEntry(trackId, { state: 'classifying' });
 
     try {
-      const classifierPipeline = await this.loadPipeline();
-      const monoSamples = downmixToMono(audioBuffer, MODEL_SAMPLE_RATE);
-      const results = await classifierPipeline(monoSamples, [
-        ...CANDIDATE_LABELS,
-      ]);
+      const result = this.workerFailed
+        ? await this.classifyOnMainThread(audioBuffer)
+        : await this.classifyInWorker(audioBuffer);
 
-      const top = results.reduce((best, current) =>
-        current.score > best.score ? current : best,
-      );
-
-      const result: ClassificationResult = {
-        label: top.label,
-        score: top.score,
-      };
       this.setEntry(trackId, { state: 'done', result });
-      return top.label;
+      return result.label;
     } catch {
+      // If the worker failed for the first time, try the main-thread fallback
+      if (!this.workerFailed) {
+        this.workerFailed = true;
+        try {
+          const result = await this.classifyOnMainThread(audioBuffer);
+          this.setEntry(trackId, { state: 'done', result });
+          return result.label;
+        } catch {
+          // Main thread also failed — fall through to error
+        }
+      }
       this.setEntry(trackId, { state: 'error' });
       throw new Error(`Classification failed for track ${trackId}`);
     }
   }
 
-  // --- Pipeline management ---
+  // --- Worker-based inference ---
+
+  private classifyInWorker(
+    audioBuffer: AudioBuffer,
+  ): Promise<ClassificationResult> {
+    const worker = this.getWorker();
+    const id = this.nextMessageId++;
+
+    const channelData: Float32Array[] = [];
+    const transferables: Transferable[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      const copy = new Float32Array(audioBuffer.getChannelData(ch));
+      channelData.push(copy);
+      transferables.push(copy.buffer);
+    }
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      worker.postMessage(
+        {
+          id,
+          type: 'classify',
+          channelData,
+          sampleRate: audioBuffer.sampleRate,
+          length: audioBuffer.length,
+        },
+        transferables,
+      );
+    });
+  }
+
+  private getWorker(): Worker {
+    if (!this.worker) {
+      this.worker = new Worker(
+        new URL('./classification.worker.ts', import.meta.url),
+        { type: 'module' },
+      );
+      this.worker.onmessage = (event: MessageEvent<ClassifyResponse>) => {
+        const { id, type } = event.data;
+        const pending = this.pendingRequests.get(id);
+        if (!pending) return;
+        this.pendingRequests.delete(id);
+
+        if (type === 'error') {
+          pending.reject(new Error(event.data.message));
+        } else {
+          pending.resolve({
+            label: event.data.label,
+            score: event.data.score,
+          });
+        }
+      };
+      this.worker.onerror = () => {
+        this.workerFailed = true;
+        this.rejectAllPending(
+          new Error(
+            'Classification worker failed; falling back to main thread',
+          ),
+        );
+      };
+    }
+    return this.worker;
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  // --- Main-thread fallback ---
+
+  private async classifyOnMainThread(
+    audioBuffer: AudioBuffer,
+  ): Promise<ClassificationResult> {
+    const classifierPipeline = await this.loadPipeline();
+    const monoSamples = downmixToMono(audioBuffer, MODEL_SAMPLE_RATE);
+    const results = await classifierPipeline(monoSamples, [
+      ...CANDIDATE_LABELS,
+    ]);
+
+    const top = results.reduce((best, current) =>
+      current.score > best.score ? current : best,
+    );
+
+    return { label: top.label, score: top.score };
+  }
 
   private async loadPipeline(): Promise<Pipeline> {
     if (this.pipeline) return this.pipeline;
@@ -168,7 +271,7 @@ class InstrumentClassificationService {
   }
 }
 
-// --- Audio utilities ---
+// --- Audio utilities (main-thread fallback) ---
 
 function downmixToMono(
   audioBuffer: AudioBuffer,
@@ -178,7 +281,6 @@ function downmixToMono(
   const sourceSampleRate = audioBuffer.sampleRate;
   const sourceLength = audioBuffer.length;
 
-  // Downmix to mono by averaging all channels
   const mono = new Float32Array(sourceLength);
   for (let ch = 0; ch < numberOfChannels; ch++) {
     const channelData = audioBuffer.getChannelData(ch);
@@ -187,7 +289,6 @@ function downmixToMono(
     }
   }
 
-  // Resample if needed
   if (sourceSampleRate === targetSampleRate) {
     return mono;
   }

--- a/src/services/ModelCache.ts
+++ b/src/services/ModelCache.ts
@@ -1,0 +1,72 @@
+// ModelCache — Cache API utility implementing stale-while-revalidate
+// for Transformers.js model files.
+//
+// Transformers.js stores downloaded model files in a Cache API cache
+// named 'transformers-cache'. This module provides two capabilities:
+//
+// 1. Check whether model files are already cached (to decide between
+//    a fast cache-only load vs. a network-first load).
+//
+// 2. Revalidate cached files in the background using conditional
+//    requests (ETag / If-None-Match). Only files that have actually
+//    changed on the server are re-downloaded — unchanged files return
+//    304 Not Modified and the existing cache entry is kept.
+//
+// Together these enable stale-while-revalidate: the pipeline loads
+// instantly from cache, while a background pass ensures the cache
+// stays fresh for the next session.
+
+const CACHE_NAME = 'transformers-cache';
+
+/**
+ * Returns true if the Cache API contains at least one entry whose URL
+ * includes the given model ID (e.g. 'Xenova/clap-large').
+ */
+export async function isModelCached(modelId: string): Promise<boolean> {
+  if (typeof caches === 'undefined') return false;
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const keys = await cache.keys();
+    return keys.some((request) => request.url.includes(modelId));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-fetches all cached files for the given model using conditional
+ * requests. Files that are unchanged on the server (304) are skipped.
+ * Updated files (200) replace the stale cache entry.
+ *
+ * Failures are silently ignored — revalidation is best-effort.
+ */
+export async function revalidateCache(modelId: string): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const keys = await cache.keys();
+    const modelRequests = keys.filter((request) =>
+      request.url.includes(modelId),
+    );
+
+    await Promise.allSettled(
+      modelRequests.map(async (request) => {
+        const cached = await cache.match(request);
+        const headers: Record<string, string> = {};
+
+        const etag = cached?.headers.get('etag');
+        if (etag) headers['If-None-Match'] = etag;
+
+        const lastModified = cached?.headers.get('last-modified');
+        if (lastModified) headers['If-Modified-Since'] = lastModified;
+
+        const response = await fetch(request.url, { headers });
+        if (response.ok && response.status === 200) {
+          await cache.put(request, response);
+        }
+      }),
+    );
+  } catch {
+    // Revalidation failure is non-critical
+  }
+}

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -25,6 +25,41 @@ function createAudioBuffer(
   } as unknown as AudioBuffer;
 }
 
+type MockWorker = {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+let mockWorker: MockWorker;
+
+// Must be a regular function (not arrow) to support `new` in Vitest v4
+vi.stubGlobal(
+  'Worker',
+  vi.fn().mockImplementation(function () {
+    mockWorker = {
+      postMessage: vi.fn(),
+      onmessage: null,
+      onerror: null,
+      terminate: vi.fn(),
+    };
+    return mockWorker;
+  }),
+);
+
+function simulateWorkerResult(label: string, score: number, id = 0): void {
+  mockWorker.onmessage!({
+    data: { id, type: 'result', label, score },
+  } as MessageEvent);
+}
+
+function simulateWorkerError(message: string, id = 0): void {
+  mockWorker.onmessage!({
+    data: { id, type: 'error', message },
+  } as MessageEvent);
+}
+
 let service: InstrumentClassificationService;
 
 beforeEach(() => {
@@ -52,19 +87,115 @@ describe('InstrumentClassificationService', () => {
     });
   });
 
-  describe('classify', () => {
-    it('returns the top-scoring label', async () => {
+  describe('worker-based classification', () => {
+    it('creates a Worker on first classify call', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
+
+      expect(Worker).toHaveBeenCalledWith(expect.any(URL), {
+        type: 'module',
+      });
+    });
+
+    it('reuses the same Worker across multiple classify calls', async () => {
       const buffer = createAudioBuffer();
 
-      const label = await service.classify('track-1', buffer);
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85, 0);
+      await promise1;
+
+      const promise2 = service.classify('track-2', buffer);
+      simulateWorkerResult('drums', 0.8, 1);
+      await promise2;
+
+      expect(Worker).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts channel data, sampleRate, and length to the worker', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
+
+      expect(mockWorker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 0,
+          type: 'classify',
+          sampleRate: 48000,
+          length: 48000,
+        }),
+        expect.any(Array),
+      );
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.channelData).toHaveLength(1);
+      expect(postedMessage.channelData[0]).toBeInstanceOf(Float32Array);
+    });
+
+    it('transfers channel data ArrayBuffers to avoid copying', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
+
+      const transferables = mockWorker.postMessage.mock.calls[0][1];
+      expect(transferables).toHaveLength(1);
+      expect(transferables[0]).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it('copies channel data before transfer to preserve the original AudioBuffer', async () => {
+      const originalData = new Float32Array([0.1, 0.2, 0.3]);
+      const buffer = {
+        numberOfChannels: 1,
+        length: 3,
+        sampleRate: 48000,
+        duration: 3 / 48000,
+        getChannelData: vi.fn().mockReturnValue(originalData),
+      } as unknown as AudioBuffer;
+
+      const promise = service.classify('track-1', buffer);
+
+      const postedChannelData =
+        mockWorker.postMessage.mock.calls[0][0].channelData[0];
+      expect(postedChannelData).not.toBe(originalData);
+      expect(Array.from(postedChannelData)).toEqual(Array.from(originalData));
+
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
+    });
+
+    it('extracts all channels for multi-channel audio', async () => {
+      const buffer = createAudioBuffer(2, 48000, 48000);
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.channelData).toHaveLength(2);
+    });
+
+    it('returns the label from the worker response', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerResult('guitar', 0.85);
+      const label = await promise;
 
       expect(label).toBe('guitar');
     });
 
     it('stores the result in the classifications signal', async () => {
       const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
 
-      await service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
 
       const result = service.getClassification('track-1');
       expect(result).toEqual({ label: 'guitar', score: 0.85 });
@@ -72,8 +203,10 @@ describe('InstrumentClassificationService', () => {
 
     it('sets state to done after classification', async () => {
       const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
 
-      await service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
 
       expect(service.getClassificationState('track-1')).toBe('done');
     });
@@ -81,50 +214,102 @@ describe('InstrumentClassificationService', () => {
     it('returns cached result without re-running inference', async () => {
       const buffer = createAudioBuffer();
 
-      await service.classify('track-1', buffer);
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85);
+      await promise1;
+
       const label = await service.classify('track-1', buffer);
 
       expect(label).toBe('guitar');
-      expect(mockClassifier).toHaveBeenCalledTimes(1);
+      expect(mockWorker.postMessage).toHaveBeenCalledTimes(1);
     });
 
     it('classifies multiple tracks independently', async () => {
       const buffer1 = createAudioBuffer();
       const buffer2 = createAudioBuffer();
 
-      mockClassifier
-        .mockResolvedValueOnce([
-          { label: 'guitar', score: 0.9 },
-          { label: 'bass', score: 0.1 },
-        ])
-        .mockResolvedValueOnce([
-          { label: 'drums', score: 0.8 },
-          { label: 'percussion', score: 0.2 },
-        ]);
+      const promise1 = service.classify('track-1', buffer1);
+      simulateWorkerResult('guitar', 0.9, 0);
+      await promise1;
 
-      await service.classify('track-1', buffer1);
-      await service.classify('track-2', buffer2);
+      const promise2 = service.classify('track-2', buffer2);
+      simulateWorkerResult('drums', 0.8, 1);
+      await promise2;
 
       expect(service.getClassification('track-1')?.label).toBe('guitar');
       expect(service.getClassification('track-2')?.label).toBe('drums');
       expect(service.classifications.size).toBe(2);
     });
 
-    it('sets state to error when classification fails', async () => {
-      mockClassifier.mockRejectedValue(new Error('model error'));
+    it('assigns sequential message IDs', async () => {
       const buffer = createAudioBuffer();
 
-      await expect(service.classify('track-1', buffer)).rejects.toThrow(
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85, 0);
+      await promise1;
+
+      const promise2 = service.classify('track-2', buffer);
+      simulateWorkerResult('drums', 0.8, 1);
+      await promise2;
+
+      expect(mockWorker.postMessage.mock.calls[0][0].id).toBe(0);
+      expect(mockWorker.postMessage.mock.calls[1][0].id).toBe(1);
+    });
+  });
+
+  describe('worker error handling', () => {
+    it('falls back to main thread when the worker responds with an error', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerError('Pipeline initialization failed');
+      await promise;
+
+      // Should have fallen back to main-thread pipeline
+      const { pipeline } = await import('@huggingface/transformers');
+      expect(pipeline).toHaveBeenCalled();
+      expect(service.getClassification('track-1')?.label).toBe('guitar');
+    });
+
+    it('sets state to error when both worker and main thread fail', async () => {
+      mockClassifier.mockRejectedValue(new Error('model error'));
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      simulateWorkerError('Worker failed');
+
+      await expect(promise).rejects.toThrow(
         'Classification failed for track track-1',
       );
-
       expect(service.getClassificationState('track-1')).toBe('error');
     });
 
+    it('uses main thread directly after worker has failed once', async () => {
+      const buffer = createAudioBuffer();
+
+      // First call — worker error triggers fallback
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise1;
+
+      // Second call — should go directly to main thread (no worker message)
+      const postMessageCallCount = mockWorker.postMessage.mock.calls.length;
+      await service.classify('track-2', buffer);
+
+      expect(mockWorker.postMessage.mock.calls.length).toBe(
+        postMessageCallCount,
+      );
+    });
+  });
+
+  describe('main-thread fallback', () => {
     it('passes candidate labels to the pipeline', async () => {
       const buffer = createAudioBuffer();
 
-      await service.classify('track-1', buffer);
+      // Force fallback by triggering worker error
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
 
       expect(mockClassifier).toHaveBeenCalledWith(
         expect.any(Float32Array),
@@ -142,13 +327,14 @@ describe('InstrumentClassificationService', () => {
         ]),
       );
     });
-  });
 
-  describe('audio preprocessing', () => {
     it('downmixes stereo to mono', async () => {
       const buffer = createAudioBuffer(2, 48000, 48000);
 
-      await service.classify('track-1', buffer);
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
 
       const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
       expect(passedAudio.length).toBe(48000);
@@ -157,7 +343,10 @@ describe('InstrumentClassificationService', () => {
     it('resamples from 44100 to 48000', async () => {
       const buffer = createAudioBuffer(1, 44100, 44100);
 
-      await service.classify('track-1', buffer);
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
 
       const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
       expect(passedAudio.length).toBe(48000);
@@ -166,19 +355,23 @@ describe('InstrumentClassificationService', () => {
     it('does not resample when already at target rate', async () => {
       const buffer = createAudioBuffer(1, 48000, 48000);
 
-      await service.classify('track-1', buffer);
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
 
       const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
       expect(passedAudio.length).toBe(48000);
     });
-  });
 
-  describe('pipeline loading', () => {
     it('loads the pipeline lazily on first classify call', async () => {
       const { pipeline } = await import('@huggingface/transformers');
       const buffer = createAudioBuffer();
 
-      await service.classify('track-1', buffer);
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
 
       expect(pipeline).toHaveBeenCalledWith(
         'zero-shot-audio-classification',
@@ -191,7 +384,11 @@ describe('InstrumentClassificationService', () => {
       const { pipeline } = await import('@huggingface/transformers');
       const buffer = createAudioBuffer();
 
-      await service.classify('track-1', buffer);
+      // Force fallback
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise1;
+
       mockClassifier.mockResolvedValueOnce([{ label: 'bass', score: 0.9 }]);
       await service.classify('track-2', buffer);
 
@@ -202,7 +399,9 @@ describe('InstrumentClassificationService', () => {
   describe('removeClassification', () => {
     it('removes a classification entry', async () => {
       const buffer = createAudioBuffer();
-      await service.classify('track-1', buffer);
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85);
+      await promise;
 
       service.removeClassification('track-1');
 
@@ -215,8 +414,14 @@ describe('InstrumentClassificationService', () => {
   describe('reset', () => {
     it('clears all classifications', async () => {
       const buffer = createAudioBuffer();
-      await service.classify('track-1', buffer);
-      await service.classify('track-2', buffer);
+
+      const promise1 = service.classify('track-1', buffer);
+      simulateWorkerResult('guitar', 0.85, 0);
+      await promise1;
+
+      const promise2 = service.classify('track-2', buffer);
+      simulateWorkerResult('drums', 0.8, 1);
+      await promise2;
 
       service.reset();
 

--- a/src/services/__tests__/ModelCache.test.ts
+++ b/src/services/__tests__/ModelCache.test.ts
@@ -1,0 +1,197 @@
+import { vi } from 'vitest';
+import { isModelCached, revalidateCache } from '../ModelCache';
+
+const mockMatch = vi.fn();
+const mockPut = vi.fn();
+const mockKeys = vi.fn();
+
+const mockCache = {
+  match: mockMatch,
+  put: mockPut,
+  keys: mockKeys,
+};
+
+const mockCachesOpen = vi.fn().mockResolvedValue(mockCache);
+
+vi.stubGlobal('caches', {
+  open: mockCachesOpen,
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockKeys.mockReset();
+  mockMatch.mockReset();
+  mockPut.mockReset();
+  mockCachesOpen.mockClear();
+  mockFetch.mockReset();
+});
+
+describe('isModelCached', () => {
+  it('returns true when cache contains entries for the model', async () => {
+    mockKeys.mockResolvedValue([
+      { url: 'https://huggingface.co/Xenova/clap-large/config.json' },
+      { url: 'https://huggingface.co/Xenova/clap-large/model.onnx' },
+    ]);
+
+    const result = await isModelCached('Xenova/clap-large');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when cache has no entries for the model', async () => {
+    mockKeys.mockResolvedValue([
+      { url: 'https://huggingface.co/other-model/config.json' },
+    ]);
+
+    const result = await isModelCached('Xenova/clap-large');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when cache is empty', async () => {
+    mockKeys.mockResolvedValue([]);
+
+    const result = await isModelCached('Xenova/clap-large');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when caches API is unavailable', async () => {
+    const originalCaches = globalThis.caches;
+    // @ts-expect-error — simulating missing API
+    delete globalThis.caches;
+
+    const result = await isModelCached('Xenova/clap-large');
+
+    expect(result).toBe(false);
+
+    globalThis.caches = originalCaches;
+  });
+
+  it('returns false when cache.keys() throws', async () => {
+    mockKeys.mockRejectedValue(new Error('Storage error'));
+
+    const result = await isModelCached('Xenova/clap-large');
+
+    expect(result).toBe(false);
+  });
+
+  it('opens the transformers-cache cache store', async () => {
+    mockKeys.mockResolvedValue([]);
+
+    await isModelCached('Xenova/clap-large');
+
+    expect(mockCachesOpen).toHaveBeenCalledWith('transformers-cache');
+  });
+});
+
+describe('revalidateCache', () => {
+  it('fetches model files with conditional request headers', async () => {
+    const modelUrl =
+      'https://huggingface.co/Xenova/clap-large/resolve/main/config.json';
+    mockKeys.mockResolvedValue([{ url: modelUrl }]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({
+        etag: '"abc123"',
+        'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT',
+      }),
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await revalidateCache('Xenova/clap-large');
+
+    expect(mockFetch).toHaveBeenCalledWith(modelUrl, {
+      headers: {
+        'If-None-Match': '"abc123"',
+        'If-Modified-Since': 'Wed, 01 Jan 2025 00:00:00 GMT',
+      },
+    });
+  });
+
+  it('updates the cache when server returns 200', async () => {
+    const modelUrl =
+      'https://huggingface.co/Xenova/clap-large/resolve/main/config.json';
+    const request = { url: modelUrl };
+    mockKeys.mockResolvedValue([request]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({ etag: '"abc123"' }),
+    });
+    const freshResponse = { ok: true, status: 200 };
+    mockFetch.mockResolvedValue(freshResponse);
+
+    await revalidateCache('Xenova/clap-large');
+
+    expect(mockPut).toHaveBeenCalledWith(request, freshResponse);
+  });
+
+  it('does not update cache when server returns 304', async () => {
+    const modelUrl =
+      'https://huggingface.co/Xenova/clap-large/resolve/main/config.json';
+    mockKeys.mockResolvedValue([{ url: modelUrl }]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({ etag: '"abc123"' }),
+    });
+    mockFetch.mockResolvedValue({ ok: false, status: 304 });
+
+    await revalidateCache('Xenova/clap-large');
+
+    expect(mockPut).not.toHaveBeenCalled();
+  });
+
+  it('only revalidates files matching the model ID', async () => {
+    const modelUrl =
+      'https://huggingface.co/Xenova/clap-large/resolve/main/config.json';
+    const otherUrl =
+      'https://huggingface.co/other-model/resolve/main/config.json';
+    mockKeys.mockResolvedValue([{ url: modelUrl }, { url: otherUrl }]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({}),
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await revalidateCache('Xenova/clap-large');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(modelUrl, expect.any(Object));
+  });
+
+  it('does not throw when fetch fails', async () => {
+    mockKeys.mockResolvedValue([
+      {
+        url: 'https://huggingface.co/Xenova/clap-large/resolve/main/config.json',
+      },
+    ]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({}),
+    });
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    await expect(revalidateCache('Xenova/clap-large')).resolves.not.toThrow();
+  });
+
+  it('does not throw when caches API is unavailable', async () => {
+    const originalCaches = globalThis.caches;
+    // @ts-expect-error — simulating missing API
+    delete globalThis.caches;
+
+    await expect(revalidateCache('Xenova/clap-large')).resolves.not.toThrow();
+
+    globalThis.caches = originalCaches;
+  });
+
+  it('sends no conditional headers when cached response has none', async () => {
+    const modelUrl =
+      'https://huggingface.co/Xenova/clap-large/resolve/main/config.json';
+    mockKeys.mockResolvedValue([{ url: modelUrl }]);
+    mockMatch.mockResolvedValue({
+      headers: new Headers({}),
+    });
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+    await revalidateCache('Xenova/clap-large');
+
+    expect(mockFetch).toHaveBeenCalledWith(modelUrl, { headers: {} });
+  });
+});

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -1,0 +1,172 @@
+// Classification worker — runs Transformers.js pipeline loading and
+// inference off the main thread to keep the UI responsive.
+//
+// Implements stale-while-revalidate model caching:
+// 1. If model files exist in Cache API, load from cache only (fast path)
+// 2. After cache hit, revalidate cached files in the background
+// 3. On cache miss, download from network (slow first load)
+//
+// Audio preprocessing (downmix + resample) also runs here to avoid
+// blocking the main thread with CPU-intensive sample manipulation.
+
+import { isModelCached, revalidateCache } from './ModelCache';
+
+const MODEL_ID = 'Xenova/clap-large';
+const TASK = 'zero-shot-audio-classification';
+const MODEL_SAMPLE_RATE = 48_000;
+
+const CANDIDATE_LABELS = [
+  'vocals',
+  'guitar',
+  'bass',
+  'drums',
+  'keyboard',
+  'strings',
+  'brass',
+  'woodwind',
+  'synth',
+  'percussion',
+] as const;
+
+export type ClassifyRequest = {
+  id: number;
+  type: 'classify';
+  channelData: Float32Array[];
+  sampleRate: number;
+  length: number;
+};
+
+export type ClassifyResponse =
+  | { id: number; type: 'result'; label: string; score: number }
+  | { id: number; type: 'error'; message: string };
+
+type Classifier = (
+  audio: Float32Array,
+  labels: string[],
+) => Promise<Array<{ label: string; score: number }>>;
+
+let classifier: Classifier | null = null;
+let pipelinePromise: Promise<Classifier> | null = null;
+
+async function loadPipeline(): Promise<Classifier> {
+  if (classifier) return classifier;
+  if (pipelinePromise) return pipelinePromise;
+
+  pipelinePromise = initializePipeline();
+  classifier = await pipelinePromise;
+  pipelinePromise = null;
+  return classifier;
+}
+
+async function initializePipeline(): Promise<Classifier> {
+  const { pipeline, env } = await import('@huggingface/transformers');
+  env.useBrowserCache = true;
+
+  // Stale-while-revalidate: try cache-only first for fast startup
+  const cached = await isModelCached(MODEL_ID);
+  if (cached) {
+    try {
+      env.allowRemoteModels = false;
+      const pipe = await pipeline(TASK, MODEL_ID, { device: 'wasm' });
+
+      // Cache hit — revalidate in background for next session
+      env.allowRemoteModels = true;
+      revalidateCache(MODEL_ID);
+
+      return createClassifier(pipe);
+    } catch {
+      // Cache was stale or corrupt — fall through to network
+      env.allowRemoteModels = true;
+    }
+  }
+
+  // Network path (first load or cache miss)
+  env.allowRemoteModels = true;
+  const pipe = await pipeline(TASK, MODEL_ID, { device: 'wasm' });
+  return createClassifier(pipe);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createClassifier(pipe: any): Classifier {
+  return async (audio: Float32Array, labels: string[]) => {
+    const output = await pipe(audio, labels);
+    return output as Array<{ label: string; score: number }>;
+  };
+}
+
+// --- Audio preprocessing ---
+
+function downmixToMono(
+  channelData: Float32Array[],
+  sampleRate: number,
+  length: number,
+): Float32Array {
+  const numberOfChannels = channelData.length;
+
+  const mono = new Float32Array(length);
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    for (let i = 0; i < length; i++) {
+      mono[i] += channelData[ch][i] / numberOfChannels;
+    }
+  }
+
+  if (sampleRate === MODEL_SAMPLE_RATE) return mono;
+  return resample(mono, sampleRate, MODEL_SAMPLE_RATE);
+}
+
+function resample(
+  samples: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
+  const ratio = fromRate / toRate;
+  const outputLength = Math.round(samples.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const srcIndexFloor = Math.floor(srcIndex);
+    const fraction = srcIndex - srcIndexFloor;
+
+    const sample0 = samples[srcIndexFloor] ?? 0;
+    const sample1 = samples[srcIndexFloor + 1] ?? 0;
+    output[i] = sample0 + fraction * (sample1 - sample0);
+  }
+
+  return output;
+}
+
+// --- Worker message handler ---
+
+type WorkerSelf = {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: unknown): void;
+};
+
+const workerSelf = self as unknown as WorkerSelf;
+
+workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
+  const { id, channelData, sampleRate, length } = event.data;
+
+  try {
+    const pipe = await loadPipeline();
+    const monoSamples = downmixToMono(channelData, sampleRate, length);
+    const results = await pipe(monoSamples, [...CANDIDATE_LABELS]);
+
+    const top = results.reduce((best, current) =>
+      current.score > best.score ? current : best,
+    );
+
+    const response: ClassifyResponse = {
+      id,
+      type: 'result',
+      label: top.label,
+      score: top.score,
+    };
+    workerSelf.postMessage(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const response: ClassifyResponse = { id, type: 'error', message };
+    workerSelf.postMessage(response);
+  }
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
     },
   },
+  worker: {
+    format: 'es',
+  },
   optimizeDeps: {
     exclude: ['@huggingface/transformers'],
   },


### PR DESCRIPTION
## Summary

Closes #227

- **Classification worker** (`classification.worker.ts`): Moves Transformers.js pipeline loading and inference off the main thread into a dedicated Web Worker, following the existing `SpectrogramCache` worker pattern
- **Model caching** (`ModelCache.ts`): Implements stale-while-revalidate for model files using the native Cache API — loads from cache first for fast startup, then revalidates in the background using conditional requests (ETag / If-None-Match) so only changed files are re-downloaded
- **Service update** (`InstrumentClassificationService.ts`): Delegates classification to the worker via `postMessage` / `onmessage`, with automatic main-thread fallback if the worker fails (mirrors `SpectrogramCache`'s fallback pattern)
- **Vite config**: Sets `worker.format` to `'es'` to support code-splitting in the classification worker bundle

### Architecture

```
InstrumentClassificationService (main thread)
  ├── Signal ownership + per-track cache
  ├── Worker communication (postMessage / onmessage)
  └── Main-thread fallback (if worker fails)

classification.worker.ts (worker thread)
  ├── Pipeline loading with stale-while-revalidate caching
  ├── Audio preprocessing (downmix + resample)
  └── Inference (Transformers.js zero-shot classification)

ModelCache.ts (shared utility)
  ├── isModelCached() — check Cache API for cached model files
  └── revalidateCache() — conditional re-fetch to update stale entries
```

## Test plan

- [x] All 670 existing tests pass (no regressions)
- [x] 26 new/updated tests for worker-based classification in `InstrumentClassificationService.test.ts`
- [x] 13 new tests for `ModelCache.test.ts` covering cache detection, conditional revalidation, and edge cases
- [x] ESLint passes
- [x] Production build succeeds with worker properly bundled as separate chunk
- [ ] Manual test: upload an audio file and verify classification completes without UI blocking
- [ ] Manual test: verify model loads from Cache API on second page load (fast path)

https://claude.ai/code/session_019CsuH8H3UYib42LbuzrYS8