### PR TITLE
Fix frequency visualizer: align single-band with spectrogram

### DIFF
--- a/src/services/FrequencyVisualizer.ts
+++ b/src/services/FrequencyVisualizer.ts
@@ -109,11 +109,18 @@ class FrequencyVisualizer {
     const outputBinCount = opts.frequencyBinCount ?? DEFAULT_OUTPUT_BIN_COUNT;
     this.frequencyBinCount = outputBinCount;
 
+    const toneCtx = source.context ?? Tone.context;
+    const sampleRate = (toneCtx.rawContext as AudioContext).sampleRate;
+
     if (opts.workletAnalyser && opts.dualBand) {
       this.initializeWorkletDualBandPath(source, outputBinCount);
     } else if (opts.workletAnalyser) {
       this.workletAnalyser = opts.workletAnalyser;
-      this.initializeWorkletPath(opts.workletAnalyser, outputBinCount);
+      this.initializeWorkletPath(
+        opts.workletAnalyser,
+        outputBinCount,
+        sampleRate,
+      );
     } else if (opts.dualBand) {
       this.initializeDualBandPath(source, outputBinCount);
     } else {
@@ -178,6 +185,7 @@ class FrequencyVisualizer {
   private initializeWorkletPath(
     analyser: WorkletAnalyser,
     outputBinCount: number,
+    sampleRate: number,
   ): void {
     analyser.enableFrequencyAnalysis({
       fftSize: WORKLET_FFT_SIZE,
@@ -186,11 +194,13 @@ class FrequencyVisualizer {
     });
 
     const inputBinCount = analyser.frequencyBinCount;
+    const binWidth = sampleRate / WORKLET_FFT_SIZE;
     this.workletData = new Uint8Array(inputBinCount);
     this.workletOutput = new Uint8Array(outputBinCount);
     this.workletLogMapping = createLogFrequencyMapping(
       inputBinCount,
       outputBinCount,
+      binWidth,
     );
   }
 
@@ -323,11 +333,13 @@ class FrequencyVisualizer {
     source.connect(this.singleAnalyser as unknown as AudioNode);
 
     const inputBinCount = this.singleAnalyser.frequencyBinCount;
+    const binWidth = ctx.sampleRate / SINGLE_FFT_SIZE;
     this.singleData = new Uint8Array(inputBinCount);
     this.singleOutput = new Uint8Array(outputBinCount);
     this.singleLogMapping = createLogFrequencyMapping(
       inputBinCount,
       outputBinCount,
+      binWidth,
     );
   }
 

--- a/src/services/__tests__/logFrequencyMapping.test.ts
+++ b/src/services/__tests__/logFrequencyMapping.test.ts
@@ -4,6 +4,11 @@ import {
   createDualBandLogMapping,
   createLogFrequencyMapping,
 } from '../logFrequencyMapping';
+import {
+  calculateMergeParams,
+  REFERENCE_MIN_FREQUENCY,
+  SPLIT_FREQUENCY,
+} from '../dualBandAnalysis';
 import { fft, magnitudeToBytes } from '../fft';
 
 /**
@@ -135,7 +140,7 @@ describe('logFrequencyMapping', () => {
 
       const peakPositions: number[] = [];
       for (const freq of testFrequencies) {
-        const minFreq = BIN_WIDTH;
+        const minFreq = Math.min(REFERENCE_MIN_FREQUENCY, BIN_WIDTH);
         const maxFreq = (INPUT_BIN_COUNT - 1) * BIN_WIDTH;
         const t =
           (Math.log(freq) - Math.log(minFreq)) /
@@ -188,10 +193,11 @@ describe('logFrequencyMapping', () => {
       expect(cv).toBeLessThan(0.15);
     });
 
-    it('both mappings place the same tone at the same output bin', () => {
-      const uniformMapping = createLogFrequencyMapping(
+    it('frequency-aware single-band and dual-band place the same tone at the same output bin', () => {
+      const singleMapping = createLogFrequencyMapping(
         INPUT_BIN_COUNT,
         OUTPUT_BIN_COUNT,
+        BIN_WIDTH,
       );
       const dualBandMapping = createDualBandLogMapping(
         INPUT_BIN_COUNT,
@@ -202,7 +208,7 @@ describe('logFrequencyMapping', () => {
         OUTPUT_BIN_COUNT,
       );
 
-      const rev1 = buildReverseMap(uniformMapping);
+      const rev1 = buildReverseMap(singleMapping);
       const rev2 = buildReverseMap(dualBandMapping);
 
       // Check that semitone frequencies map to the same output bin in both.
@@ -214,7 +220,7 @@ describe('logFrequencyMapping', () => {
         const out2 = rev2.get(inputBin)!;
         expect(
           Math.abs(out1 - out2),
-          `${freq} Hz (bin ${inputBin}): uniform=${out1} vs dual-band=${out2}`,
+          `${freq} Hz (bin ${inputBin}): single=${out1} vs dual-band=${out2}`,
         ).toBeLessThanOrEqual(2);
       }
     });
@@ -253,6 +259,133 @@ describe('logFrequencyMapping', () => {
       const mapping = createDualBandLogMapping(800, 300, 2.5, 18, 43.07, 512);
       for (let i = 1; i < mapping.length; i++) {
         expect(mapping[i][0]).toBeGreaterThanOrEqual(mapping[i - 1][0]);
+      }
+    });
+  });
+
+  describe('single-band and dual-band frequency alignment', () => {
+    const SAMPLE_RATE = 44100;
+    const OUTPUT_BIN_COUNT = 512;
+
+    // Single-band parameters (FrequencyVisualizer without dualBand)
+    const SINGLE_FFT_SIZE = 2048;
+    const SINGLE_BIN_WIDTH = SAMPLE_RATE / SINGLE_FFT_SIZE;
+    const SINGLE_INPUT_BIN_COUNT = SINGLE_FFT_SIZE / 2;
+
+    /**
+     * Finds the fractional position (0–1) of a frequency in a mapping,
+     * where 0 = lowest output bin and 1 = highest.
+     */
+    function findFractionalPosition(
+      mapping: number[][],
+      inputBin: number,
+    ): number {
+      const outputBin = mapping.findIndex((pool) => pool.includes(inputBin));
+      if (outputBin === -1) return -1;
+      return outputBin / (mapping.length - 1);
+    }
+
+    function createOfflineSpectrogramMapping() {
+      const {
+        mergedBinCount,
+        lowBinCount,
+        lowBinWidth,
+        highBinStart,
+        highBinWidth,
+      } = calculateMergeParams(SAMPLE_RATE);
+
+      return {
+        mapping: createDualBandLogMapping(
+          mergedBinCount,
+          lowBinCount,
+          lowBinWidth,
+          highBinStart,
+          highBinWidth,
+        ),
+        lowBinCount,
+        lowBinWidth,
+        highBinStart,
+        highBinWidth,
+      };
+    }
+
+    /**
+     * Converts a frequency to its merged bin index in the offline
+     * spectrogram. Low-band frequencies use lowBinWidth; high-band
+     * frequencies are offset into the merged array.
+     */
+    function toMergedBin(
+      freq: number,
+      lowBinCount: number,
+      lowBinWidth: number,
+      highBinStart: number,
+      highBinWidth: number,
+    ): number {
+      if (freq < SPLIT_FREQUENCY) {
+        return Math.round(freq / lowBinWidth);
+      }
+      const highBin = Math.round(freq / highBinWidth);
+      return lowBinCount + (highBin - highBinStart);
+    }
+
+    it('single-band with binWidth aligns with offline spectrogram for A440', () => {
+      const singleMapping = createLogFrequencyMapping(
+        SINGLE_INPUT_BIN_COUNT,
+        OUTPUT_BIN_COUNT,
+        SINGLE_BIN_WIDTH,
+      );
+
+      const offline = createOfflineSpectrogramMapping();
+
+      const singleA440Bin = Math.round(440 / SINGLE_BIN_WIDTH);
+      const singleFraction = findFractionalPosition(
+        singleMapping,
+        singleA440Bin,
+      );
+
+      const offlineA440Bin = toMergedBin(
+        440,
+        offline.lowBinCount,
+        offline.lowBinWidth,
+        offline.highBinStart,
+        offline.highBinWidth,
+      );
+      const offlineFraction = findFractionalPosition(
+        offline.mapping,
+        offlineA440Bin,
+      );
+
+      // Both should place A440 within 5% of each other
+      expect(Math.abs(singleFraction - offlineFraction)).toBeLessThan(0.05);
+    });
+
+    it('single-band with binWidth aligns with dual-band across octaves', () => {
+      const singleMapping = createLogFrequencyMapping(
+        SINGLE_INPUT_BIN_COUNT,
+        OUTPUT_BIN_COUNT,
+        SINGLE_BIN_WIDTH,
+      );
+
+      const offline = createOfflineSpectrogramMapping();
+      const frequencies = [110, 220, 440, 880, 1760, 3520, 7040];
+
+      for (const freq of frequencies) {
+        const singleBin = Math.round(freq / SINGLE_BIN_WIDTH);
+        const offlineBin = toMergedBin(
+          freq,
+          offline.lowBinCount,
+          offline.lowBinWidth,
+          offline.highBinStart,
+          offline.highBinWidth,
+        );
+
+        const singlePos = findFractionalPosition(singleMapping, singleBin);
+        const offlinePos = findFractionalPosition(offline.mapping, offlineBin);
+
+        expect(
+          Math.abs(singlePos - offlinePos),
+          `${freq} Hz: single=${singlePos.toFixed(3)} vs offline=${offlinePos.toFixed(3)}`,
+        ).toBeLessThan(0.05);
       }
     });
   });

--- a/src/services/dualBandAnalysis.ts
+++ b/src/services/dualBandAnalysis.ts
@@ -13,6 +13,16 @@ export const HIGH_BAND_FFT_SIZE = 1024;
 export const SPLIT_FREQUENCY = 752;
 export const LOW_BAND_SAMPLE_RATE = 5120;
 
+/**
+ * Shared minimum frequency anchor for all log-frequency mappings.
+ *
+ * Both `createLogFrequencyMapping` and `createDualBandLogMapping` use
+ * this as the lower bound of the log scale, ensuring the same frequency
+ * maps to the same output bin position regardless of analysis mode.
+ * Derived from the offline spectrogram's low-band configuration.
+ */
+export const REFERENCE_MIN_FREQUENCY = LOW_BAND_SAMPLE_RATE / LOW_BAND_FFT_SIZE;
+
 export type MergeParams = {
   lowBinWidth: number;
   highBinWidth: number;

--- a/src/services/logFrequencyMapping.ts
+++ b/src/services/logFrequencyMapping.ts
@@ -6,6 +6,8 @@
  * human pitch perception.
  */
 
+import { REFERENCE_MIN_FREQUENCY } from './dualBandAnalysis';
+
 /**
  * Creates a mapping from output (log-spaced) bins to input (linear) bins.
  *
@@ -14,14 +16,29 @@
  * (expanding the low range); high-frequency output bins pool multiple
  * input bins (compressing the high range).
  *
- * Uses the same true logarithmic frequency scale as
- * `createDualBandLogMapping`: output bins are spaced so that equal visual
- * distances correspond to equal musical intervals. Bin 0 (DC) is skipped;
- * the mapping spans from input bin 1 to input bin `inputBinCount - 1`.
+ * When `binWidth` is provided, the mapping uses actual frequencies and
+ * the shared `REFERENCE_MIN_FREQUENCY` anchor, producing output that
+ * aligns with `createDualBandLogMapping` — the same frequency maps to
+ * the same output bin position regardless of FFT size. Output bins below
+ * the FFT's resolution clamp to the lowest input bin.
+ *
+ * Without `binWidth`, the mapping spans bin indices 1 to
+ * `inputBinCount - 1` on a log scale (legacy behaviour).
  */
 export function createLogFrequencyMapping(
   inputBinCount: number,
   outputBinCount: number = inputBinCount,
+  binWidth?: number,
+): number[][] {
+  if (binWidth !== undefined) {
+    return createFrequencyAwareMapping(inputBinCount, outputBinCount, binWidth);
+  }
+  return createBinIndexMapping(inputBinCount, outputBinCount);
+}
+
+function createBinIndexMapping(
+  inputBinCount: number,
+  outputBinCount: number,
 ): number[][] {
   const logMin = 0; // ln(1) — first non-DC bin
   const logMax = Math.log(inputBinCount - 1);
@@ -47,15 +64,49 @@ export function createLogFrequencyMapping(
     mapping[i] = [Math.min(closest, inputBinCount - 1)];
   }
 
-  for (let i = 0; i < outputBinCount - 1; i++) {
-    const df = mapping[i + 1][0] - mapping[i][0];
-    if (df <= 1) {
-      continue;
+  poolConsecutiveBins(mapping);
+  return mapping;
+}
+
+function createFrequencyAwareMapping(
+  inputBinCount: number,
+  outputBinCount: number,
+  binWidth: number,
+): number[][] {
+  const minFreq = Math.min(REFERENCE_MIN_FREQUENCY, binWidth);
+  const maxFreq = (inputBinCount - 1) * binWidth;
+  const logMin = Math.log(minFreq);
+  const logMax = Math.log(maxFreq);
+
+  const mapping: number[][] = new Array(outputBinCount);
+
+  for (let i = 0; i < outputBinCount; i++) {
+    const t = i / (outputBinCount - 1);
+    const targetFreq = Math.exp(logMin + t * (logMax - logMin));
+
+    // Convert target frequency to bin index, clamping to [1, inputBinCount-1]
+    const targetBin = targetFreq / binWidth;
+    const clampedTarget = Math.max(1, Math.min(targetBin, inputBinCount - 1));
+
+    let lo = 1;
+    let hi = inputBinCount - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (mid < clampedTarget) lo = mid + 1;
+      else hi = mid;
     }
-    for (let j = 1; j <= df; j++) {
-      mapping[i].push(mapping[i][0] + j);
+    let closest = lo;
+    if (
+      lo > 1 &&
+      Math.abs(clampedTarget - (lo - 1)) < Math.abs(lo - clampedTarget)
+    ) {
+      closest = lo - 1;
     }
+
+    mapping[i] = [closest];
   }
+
+  poolConsecutiveBins(mapping);
   return mapping;
 }
 
@@ -67,6 +118,9 @@ export function createLogFrequencyMapping(
  * band has much finer frequency resolution than the high band, so a mapping
  * based purely on bin index would incorrectly over-expand the low-frequency
  * region and compress the high-frequency region.
+ *
+ * Uses `REFERENCE_MIN_FREQUENCY` as the lower bound of the log scale,
+ * ensuring consistent output positions across all analysis modes.
  *
  * Each entry `mapping[i]` is an array of merged-bin indices that feed into
  * output bin `i`, using the same pooling convention as the uniform version.
@@ -87,7 +141,8 @@ export function createDualBandLogMapping(
     freq[i] = (highBinStart + (i - lowBinCount)) * highBinWidth;
   }
 
-  const minFreq = freq[1] || lowBinWidth;
+  const naturalMin = freq[1] || lowBinWidth;
+  const minFreq = Math.min(REFERENCE_MIN_FREQUENCY, naturalMin);
   const maxFreq = freq[mergedBinCount - 1];
   const logMin = Math.log(minFreq);
   const logMax = Math.log(maxFreq);
@@ -116,15 +171,18 @@ export function createDualBandLogMapping(
     mapping[i] = [closest];
   }
 
-  for (let i = 0; i < outputBinCount - 1; i++) {
+  poolConsecutiveBins(mapping);
+  return mapping;
+}
+
+function poolConsecutiveBins(mapping: number[][]): void {
+  for (let i = 0; i < mapping.length - 1; i++) {
     const df = mapping[i + 1][0] - mapping[i][0];
     if (df <= 1) continue;
     for (let j = 1; j <= df; j++) {
       mapping[i].push(mapping[i][0] + j);
     }
   }
-
-  return mapping;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Both `createLogFrequencyMapping` and `createDualBandLogMapping` now use a shared `REFERENCE_MIN_FREQUENCY` anchor (2.5 Hz), ensuring the same frequency maps to the same output bin position regardless of analysis mode
- `createLogFrequencyMapping` accepts an optional `binWidth` parameter for frequency-aware mapping that inherently aligns with the dual-band spectrogram
- FrequencyVisualizer's single-band paths pass `binWidth`, so the scrubber aligns with the spectrogram without needing `dualBand: true`
- Supersedes PR #228 — fixes the root cause (mapping divergence) instead of switching analysis modes

## Test plan
- [x] Added test verifying single-band with `binWidth` aligns within 5% of offline spectrogram for A440
- [x] Added test verifying alignment across octaves (110–7040 Hz)
- [x] Updated existing 12-TET equal-spacing and cross-mapping alignment tests
- [x] All 650 existing tests pass
- [x] ESLint passes, production build succeeds
- [ ] Manual verification: play audio and confirm the scrubber's frequency glow aligns with spectrogram content

https://claude.ai/code/session_012PjutxtzefQ3PVCqFKYRqk