### PR TITLE
Show error toast when instrument classification fails

### DIFF
--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -13,6 +13,7 @@ import Timeline from './Timeline';
 import Toolbar from './Toolbar';
 import './Workstation.css';
 import {
+  useClassificationErrors,
   useCountIn,
   useMicrophone,
   useMixerHeight,
@@ -41,6 +42,7 @@ const Workstation = (props: WorkstationProps) => {
     useFileDropzone(uploadFile);
 
   useSpacebarPlaybackToggle();
+  useClassificationErrors(tracks);
   useTotalTime(tracks);
 
   const handleCountInComplete = useCallback(() => {

--- a/src/components/workstation/__tests__/Workstation.test.tsx
+++ b/src/components/workstation/__tests__/Workstation.test.tsx
@@ -5,6 +5,7 @@ import { useFileDropzone } from '../../dropzone/useFileDropzone';
 import { mockTrack } from '../../../testUtils';
 import Workstation from '../Workstation';
 import {
+  useClassificationErrors,
   useCountIn,
   useMixerHeight,
   useSpacebarPlaybackToggle,
@@ -82,12 +83,14 @@ it('uses workstation effect hooks', () => {
   expect(useFileDropzone).toHaveBeenCalled();
   expect(useMixerHeight).toHaveBeenCalled();
   expect(useSpacebarPlaybackToggle).toHaveBeenCalled();
+  expect(useClassificationErrors).toHaveBeenCalled();
   expect(useTotalTime).toHaveBeenCalled();
   expect(useCountIn).toHaveBeenCalled();
 });
 
 function mockWorkstationEffects() {
   return {
+    useClassificationErrors: vi.fn(),
     useCountIn: vi.fn(() => null),
     useMixerHeight: vi.fn(() => ({
       mixerContainerRef: { current: null },

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -179,14 +179,14 @@ describe('useClassificationErrors', () => {
   } as unknown as AudioBuffer;
 
   beforeEach(() => {
-    vi.spyOn(
-      classificationService as never,
-      'classifyInWorker' as never,
-    ).mockRejectedValue(new Error('worker failed'));
-    vi.spyOn(
-      classificationService as never,
-      'classifyOnMainThread' as never,
-    ).mockRejectedValue(new Error('main thread failed'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const service = classificationService as any;
+    vi.spyOn(service, 'classifyInWorker').mockRejectedValue(
+      new Error('worker failed'),
+    );
+    vi.spyOn(service, 'classifyOnMainThread').mockRejectedValue(
+      new Error('main thread failed'),
+    );
   });
 
   it('shows error message when classification fails for a track', async () => {

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -3,7 +3,9 @@ import { act, renderHook } from '@testing-library/react';
 import { vi } from 'vitest';
 import * as Tone from 'tone';
 import AudioService from '../../../services/AudioService';
+import { mockTrack } from '../../../testUtils';
 import {
+  useClassificationErrors,
   useSpacebarPlaybackToggle,
   useMicrophone,
 } from '../workstationEffects';
@@ -12,18 +14,26 @@ const audioService = AudioService.getInstance();
 const playbackService = audioService.playbackService;
 const recordingService = audioService.recordingService;
 const trackService = audioService.trackService;
+const classificationService = audioService.classificationService;
 
 const mockProjectDispatch = vi.fn();
 vi.mock('../../project/useProjectDispatch', () => ({
   default: () => mockProjectDispatch,
 }));
 
+const { mockError, mockSuccess, mockLoading, mockInfo } = vi.hoisted(() => ({
+  mockError: vi.fn(),
+  mockSuccess: vi.fn(),
+  mockLoading: vi.fn(),
+  mockInfo: vi.fn(),
+}));
+
 vi.mock('../../message', () => ({
   default: () => ({
-    success: vi.fn(),
-    error: vi.fn(),
-    loading: vi.fn(),
-    info: vi.fn(),
+    success: mockSuccess,
+    error: mockError,
+    loading: mockLoading,
+    info: mockInfo,
   }),
 }));
 
@@ -31,6 +41,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   playbackService.reset();
   recordingService.reset();
+  classificationService.reset();
   Tone.getTransport().seconds = 0;
   vi.clearAllMocks();
 });
@@ -154,5 +165,73 @@ describe('useMicrophone', () => {
 
     expect(playbackService.isPlaying).toBe(false);
     expect(playbackService.transportTime).toBe(5.0);
+  });
+});
+
+describe('useClassificationErrors', () => {
+  const track1 = mockTrack({ trackId: 'track-1' });
+
+  const mockAudioBuffer = {
+    numberOfChannels: 1,
+    length: 100,
+    sampleRate: 44100,
+    getChannelData: () => new Float32Array(100),
+  } as unknown as AudioBuffer;
+
+  beforeEach(() => {
+    vi.spyOn(
+      classificationService as never,
+      'classifyInWorker' as never,
+    ).mockRejectedValue(new Error('worker failed'));
+    vi.spyOn(
+      classificationService as never,
+      'classifyOnMainThread' as never,
+    ).mockRejectedValue(new Error('main thread failed'));
+  });
+
+  it('shows error message when classification fails for a track', async () => {
+    const { rerender } = renderHook(
+      ({ tracks }) => useClassificationErrors(tracks),
+      { initialProps: { tracks: [track1] } },
+    );
+
+    // Let the classify promise settle (worker fails → main-thread fails → error state)
+    await act(async () => {
+      await classificationService
+        .classify('track-1', mockAudioBuffer)
+        .catch(() => {});
+    });
+
+    rerender({ tracks: [track1] });
+
+    expect(mockError).toHaveBeenCalledWith('Instrument detection failed');
+  });
+
+  it('does not show error message when classification succeeds', () => {
+    renderHook(({ tracks }) => useClassificationErrors(tracks), {
+      initialProps: { tracks: [track1] },
+    });
+
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('does not show duplicate error messages for the same track', async () => {
+    const { rerender } = renderHook(
+      ({ tracks }) => useClassificationErrors(tracks),
+      { initialProps: { tracks: [track1] } },
+    );
+
+    await act(async () => {
+      await classificationService
+        .classify('track-1', mockAudioBuffer)
+        .catch(() => {});
+    });
+
+    rerender({ tracks: [track1] });
+
+    // Re-render again — should not show another error
+    rerender({ tracks: [track1] });
+
+    expect(mockError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useClassificationService } from '../../hooks/useClassificationService';
 import { usePlaybackService } from '../../hooks/usePlaybackService';
 import { useRecordingService } from '../../hooks/useRecordingService';
 import { useTrackService } from '../../hooks/useTrackService';
@@ -152,6 +153,23 @@ export const useTotalTime = (tracks: Track[]) => {
     playback.setTotalTime(trackHook.getTotalTime());
     // Hook objects reference stable service singletons via getters
   }, [tracks]); // eslint-disable-line react-hooks/exhaustive-deps
+};
+
+export const useClassificationErrors = (tracks: Track[]) => {
+  const classification = useClassificationService();
+  const reportedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    const msg = message({ key: 'classification' });
+
+    for (const track of tracks) {
+      const state = classification.getClassificationState(track.trackId);
+      if (state === 'error' && !reportedRef.current.has(track.trackId)) {
+        reportedRef.current.add(track.trackId);
+        msg.error('Instrument detection failed');
+      }
+    }
+  });
 };
 
 export const useMicrophone = (isRecording: boolean) => {


### PR DESCRIPTION
## Summary
- Add `useClassificationErrors` effect hook in `workstationEffects.ts` that watches classification state across all tracks and shows an Ant Design error message ("Instrument detection failed") when any track's classification transitions to the `error` state
- Uses a ref to deduplicate errors — each track only triggers one toast, even across re-renders
- Wire up the hook in `Workstation.tsx` alongside existing effect hooks

## Test plan
- [x] New tests in `workstationEffects.test.ts`: error message shown on failure, not shown on success, no duplicates for same track
- [x] Updated `Workstation.test.tsx` to include `useClassificationErrors` in the effect hooks mock and assertion
- [x] All 675 tests pass
- [x] ESLint clean

https://claude.ai/code/session_01LTuuMaNX72D5x6UVYw6NnZ