### PR TITLE
Fix instrument icons not appearing after classification

### DIFF
--- a/src/hooks/__tests__/useClassificationService.test.tsx
+++ b/src/hooks/__tests__/useClassificationService.test.tsx
@@ -1,0 +1,108 @@
+import { render, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import AudioService from '../../services/AudioService';
+import { useClassificationService } from '../useClassificationService';
+
+type MockWorker = {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+let mockWorker: MockWorker;
+
+// Must be a regular function (not arrow) to support `new` in Vitest v4
+vi.stubGlobal(
+  'Worker',
+  vi.fn().mockImplementation(function () {
+    mockWorker = {
+      postMessage: vi.fn(),
+      onmessage: null,
+      onerror: null,
+      terminate: vi.fn(),
+    };
+    return mockWorker;
+  }),
+);
+
+function createAudioBuffer(): AudioBuffer {
+  const data = new Float32Array(48000);
+  return {
+    numberOfChannels: 1,
+    length: 48000,
+    sampleRate: 48000,
+    duration: 1,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer;
+}
+
+function lastPostedMessageId(): number {
+  const calls = mockWorker.postMessage.mock.calls;
+  return calls[calls.length - 1][0].id;
+}
+
+// Test component that renders classification state from the hook
+function ClassificationDisplay({ trackId }: { trackId: string }) {
+  const { getClassificationState, getClassification } =
+    useClassificationService();
+  const state = getClassificationState(trackId);
+  const label = getClassification(trackId)?.label ?? '';
+  return (
+    <div>
+      <span data-testid="state">{state}</span>
+      <span data-testid="label">{label}</span>
+    </div>
+  );
+}
+
+const service = AudioService.getInstance().classificationService;
+
+afterEach(() => {
+  service.reset();
+});
+
+it('re-renders when classification transitions from idle to classifying', () => {
+  const { getByTestId } = render(
+    <ClassificationDisplay trackId="react-test-1" />,
+  );
+
+  expect(getByTestId('state').textContent).toBe('idle');
+
+  // classify() synchronously sets state to 'classifying' before posting
+  // to the worker. The hook should subscribe to the signal so the
+  // component re-renders.
+  act(() => {
+    service.classify('react-test-1', createAudioBuffer());
+  });
+
+  expect(getByTestId('state').textContent).toBe('classifying');
+});
+
+it('re-renders when classification transitions from classifying to done', async () => {
+  const { getByTestId } = render(
+    <ClassificationDisplay trackId="react-test-2" />,
+  );
+
+  expect(getByTestId('state').textContent).toBe('idle');
+
+  // Start classification
+  let classifyPromise: Promise<string>;
+  act(() => {
+    classifyPromise = service.classify('react-test-2', createAudioBuffer());
+  });
+
+  expect(getByTestId('state').textContent).toBe('classifying');
+
+  // Simulate worker completing classification using the actual message id
+  const messageId = lastPostedMessageId();
+  await act(async () => {
+    mockWorker.onmessage!({
+      data: { id: messageId, type: 'result', label: 'guitar', score: 0.85 },
+    } as MessageEvent);
+    await classifyPromise!;
+  });
+
+  expect(getByTestId('state').textContent).toBe('done');
+  expect(getByTestId('label').textContent).toBe('guitar');
+});

--- a/src/hooks/useClassificationService.ts
+++ b/src/hooks/useClassificationService.ts
@@ -21,11 +21,12 @@ export function useClassificationService() {
       return service.signals.classifications.value;
     },
 
-    // --- Lookups ---
+    // --- Lookups (read from signal so useSignals() tracks the subscription) ---
 
-    getClassification: (trackId: TrackId) => service.getClassification(trackId),
+    getClassification: (trackId: TrackId) =>
+      service.signals.classifications.value.get(trackId)?.result,
     getClassificationState: (trackId: TrackId): ClassificationState =>
-      service.getClassificationState(trackId),
+      service.signals.classifications.value.get(trackId)?.state ?? 'idle',
 
     // --- Cleanup ---
 


### PR DESCRIPTION
## Summary
- **Bug**: `useClassificationService` hook's `getClassification()` and `getClassificationState()` read from the service's raw cache instead of the reactive `classifications` signal. Since `useSignals()` never tracked a subscription, components never re-rendered when classification completed — instrument icons stayed permanently hidden.
- **Fix**: Switch both lookup functions to read from `service.signals.classifications.value` so the signal access is tracked during render and triggers component re-renders.
- **Test**: Added `useClassificationService.test.tsx` with a test component that verifies the hook triggers re-renders on classification state transitions (idle → classifying → done).

## Test plan
- [x] New unit tests verify reactive re-rendering on classification state changes
- [x] All 678 existing tests pass
- [ ] Manual: upload an audio file, open the mixer, verify instrument icon appears in the channel strip after classification completes

https://claude.ai/code/session_01SK3KNY1Ko8ixuJKhSPmqYd