### PR TITLE
Add parameterized project routes with UUID-based URLs

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -21,7 +21,7 @@ async function uploadAudioFile(
 
 test.describe('Audio file upload', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test('uploads an audio file and displays a track in the timeline', async ({
@@ -61,7 +61,7 @@ test.describe('Audio file upload', () => {
 
 test.describe('Playback controls', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     // Wait for track to appear
     await expect(page.locator('.timeline__track')).toBeVisible();
@@ -118,7 +118,7 @@ test.describe('Playback controls', () => {
     });
 
     // Re-navigate so the init script takes effect
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
@@ -170,7 +170,7 @@ test.describe('Playback controls', () => {
 
 test.describe('Mixer', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
   });
@@ -247,7 +247,7 @@ test.describe('Mixer', () => {
 
 test.describe('Spectrogram rendering', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test('renders spectrogram canvas for uploaded track', async ({ page }) => {
@@ -290,7 +290,7 @@ test.describe('Spectrogram rendering', () => {
 
 test.describe('Scrubber', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
   });
@@ -364,7 +364,7 @@ test.describe('Scrubber', () => {
 
 test.describe('Rewind control', () => {
   test('rewind button appears and resets playback', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
@@ -401,7 +401,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('timeline with single track', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
 
     const timeline = page.locator('.timeline');
@@ -413,7 +413,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('timeline with two tracks', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await uploadAudioFile(page, LONG_AUDIO);
 
@@ -427,7 +427,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('toolbar while playing', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
@@ -442,7 +442,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('mixer open with one channel', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
@@ -455,7 +455,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('mixer with muted channel', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
@@ -471,7 +471,7 @@ test.describe('Visual regression - audio states', () => {
   });
 
   test('mixer with solo channel', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toHaveCount(2);
@@ -488,7 +488,7 @@ test.describe('Visual regression - audio states', () => {
   test('scrubber scrolled forward with rewind button visible', async ({
     page,
   }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 

--- a/e2e/dragndrop.spec.ts
+++ b/e2e/dragndrop.spec.ts
@@ -68,7 +68,7 @@ async function drop(
 
 test.describe('Drag and drop – overlay visibility', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test('dropzone overlay is hidden before any drag', async ({ page }) => {
@@ -107,7 +107,7 @@ test.describe('Drag and drop – overlay visibility', () => {
 
 test.describe('Drag and drop – accept / reject states', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test('shows accept styling and hint text for valid audio files', async ({
@@ -137,7 +137,7 @@ test.describe('Drag and drop – accept / reject states', () => {
 
 test.describe('Drag and drop – file upload', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test('dropping an audio file creates a track in the timeline', async ({
@@ -200,7 +200,7 @@ test.describe('Visual regression – drag and drop states', () => {
   });
 
   test('dropzone overlay in accept state', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const dt = await createAudioDataTransfer(page, [SHORT_AUDIO]);
     await dragOver(page, dt);
 
@@ -211,7 +211,7 @@ test.describe('Visual regression – drag and drop states', () => {
   });
 
   test('dropzone overlay in reject state', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const dt = await createNonAudioDataTransfer(page);
     await dragOver(page, dt);
 

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -19,6 +19,8 @@ test.describe('Home page', () => {
     page,
   }) => {
     await page.getByRole('button', { name: 'Create Project' }).click();
-    await expect(page).toHaveURL('/project');
+    await expect(page).toHaveURL(
+      /\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+    );
   });
 });

--- a/e2e/mixer-reorder.spec.ts
+++ b/e2e/mixer-reorder.spec.ts
@@ -111,7 +111,7 @@ test.describe('Mixer channel reordering', () => {
     await page.addInitScript(() => {
       Math.random = () => 0;
     });
-    await page.goto('/project');
+    await page.goto('/project/test-id');
 
     // Upload two tracks
     await uploadAudioFile(page, SHORT_AUDIO);
@@ -139,7 +139,7 @@ test.describe('Mixer channel reordering', () => {
     await page.addInitScript(() => {
       Math.random = () => 0;
     });
-    await page.goto('/project');
+    await page.goto('/project/test-id');
 
     // Dismiss the fullscreen overlay shown on touch-capable devices
     await page.getByText('Dismiss').click();

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -12,9 +12,9 @@ test.describe('Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Mawimbi' })).toBeVisible();
   });
 
-  test('project page is accessible at /project', async ({ page }) => {
-    await page.goto('/project');
-    await expect(page).toHaveURL('/project');
+  test('project page is accessible at /project/:id', async ({ page }) => {
+    await page.goto('/project/test-id');
+    await expect(page).toHaveURL('/project/test-id');
     await expect(
       page.getByText('Start recording, or upload some audio files')
     ).toBeVisible();

--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Project page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
   });
 
   test.describe('header', () => {
@@ -16,7 +16,9 @@ test.describe('Project page', () => {
       // Navigate from home so there is history to go back to
       await page.goto('/');
       await page.getByRole('button', { name: 'Create Project' }).click();
-      await expect(page).toHaveURL('/project');
+      await expect(page).toHaveURL(
+        /\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+      );
       await page.getByRole('button', { name: 'Back', exact: true }).click();
       await expect(page).toHaveURL('/');
     });
@@ -75,7 +77,7 @@ test.describe('Project page overflow menu', () => {
   test('shows fullscreen option when overflow menu is opened', async ({
     page,
   }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await page.locator('.overflow-button').click();
     await expect(page.getByText('Enter Full Screen')).toBeVisible();
   });

--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -111,7 +111,7 @@ async function recordAudio(
 test.describe('Recording', () => {
   test.beforeEach(async ({ page }) => {
     await installAudioContextSpy(page);
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await ensureAudioContextRunning(page);
   });
 
@@ -189,7 +189,7 @@ test.describe('Recording', () => {
 test.describe('Recording with existing tracks', () => {
   test.beforeEach(async ({ page }) => {
     await installAudioContextSpy(page);
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await ensureAudioContextRunning(page);
 
     // Upload a backing track first

--- a/e2e/scrubber-seek.spec.ts
+++ b/e2e/scrubber-seek.spec.ts
@@ -33,7 +33,7 @@ async function wheelScrollTimeline(
 
 test.describe('Drag and scroll timeline to seek while playing', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
   });

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -100,7 +100,7 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
 
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
@@ -149,7 +149,7 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
 
 test.describe('Spectrogram timeline visualization during scroll', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
 
     const spectrogramCanvas = page.locator('.spectrogram__canvas');

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -64,7 +64,7 @@ test.describe('Swipe to scrub timeline during playback', () => {
   test.use({ hasTouch: true });
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await uploadAudioFile(page, LONG_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -8,20 +8,20 @@ test.describe('visual regression', () => {
   });
 
   test('project page - empty', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     await page.waitForSelector('text=Upload');
     await expect(page).toHaveScreenshot('project-empty.png');
   });
 
   test('project page - header', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const header = page.locator('.page__header');
     await expect(header).toBeVisible();
     await expect(header).toHaveScreenshot('project-header.png');
   });
 
   test('project page - toolbar', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const toolbar = page.locator('.toolbar');
     await expect(toolbar).toBeVisible();
     await expect(toolbar).toHaveScreenshot('toolbar.png');
@@ -52,7 +52,7 @@ test.describe('dark theme properties', () => {
   test('toolbar buttons use custom white color, not antd link blue', async ({
     page,
   }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const button = page.locator('.toolbar .button').first();
     await expect(button).toBeVisible();
     const color = await button.evaluate(
@@ -63,7 +63,7 @@ test.describe('dark theme properties', () => {
   });
 
   test('header has zero padding', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const header = page.locator('.page__header');
     await expect(header).toBeVisible();
     const padding = await header.evaluate(
@@ -76,7 +76,7 @@ test.describe('dark theme properties', () => {
   test('project page header inner container has correct padding', async ({
     page,
   }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const headerInner = page.locator('.project-page-header');
     await expect(headerInner).toBeVisible();
     const padding = await headerInner.evaluate(
@@ -87,7 +87,7 @@ test.describe('dark theme properties', () => {
   });
 
   test('project page header title has correct font size', async ({ page }) => {
-    await page.goto('/project');
+    await page.goto('/project/test-id');
     const title = page.locator('.project-page-header__title');
     await expect(title).toBeVisible();
     const fontSize = await title.evaluate(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,7 +6,7 @@ const App = () => {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
-      <Route path="/project" element={<ProjectPage />} />
+      <Route path="/project/:id" element={<ProjectPage />} />
       <Route path="*" element={<NoMatch />} />
     </Routes>
   );

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -20,14 +20,24 @@ it('renders route to home page', () => {
   expect(getByTestId('home-page')).toBeInTheDocument();
 });
 
-it('renders route to project page', () => {
+it('renders route to project page with id param', () => {
   const { getByTestId } = render(
-    <MemoryRouter initialEntries={['/project']}>
+    <MemoryRouter initialEntries={['/project/abc-123']}>
       <App />
     </MemoryRouter>,
   );
 
   expect(getByTestId('project-page')).toBeInTheDocument();
+});
+
+it('renders unknown route for /project without id', () => {
+  const { queryByTestId } = render(
+    <MemoryRouter initialEntries={['/project']}>
+      <App />
+    </MemoryRouter>,
+  );
+
+  expect(queryByTestId('project-page')).not.toBeInTheDocument();
 });
 
 it('renders unknown route', () => {

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -7,7 +7,8 @@ const HomePage = () => {
   const navigate = useNavigate();
 
   function handleClick() {
-    navigate('/project');
+    const id = crypto.randomUUID();
+    navigate(`/project/${id}`);
   }
 
   const { Title, Text } = Typography;

--- a/src/components/home/__tests__/HomePage.test.tsx
+++ b/src/components/home/__tests__/HomePage.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
 import HomePage from '../HomePage';
 
-it('renders create project button', () => {
+it('navigates to project page with UUID on create', () => {
   const { getByText } = render(<HomePage />);
 
   const buttonElement = getByText('Create Project');
@@ -11,5 +11,9 @@ it('renders create project button', () => {
   fireEvent.click(buttonElement);
 
   const navigate = useNavigate();
-  expect(navigate).toHaveBeenCalledWith('/project');
+  expect(navigate).toHaveBeenCalledWith(
+    expect.stringMatching(
+      /^\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    ),
+  );
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -146,5 +146,6 @@ vi.mock('react-router-dom', async () => {
     useLocation: () => ({
       pathname: 'path',
     }),
+    useParams: () => ({ id: 'test-project-id' }),
   };
 });


### PR DESCRIPTION
## Summary
- Change route from `/project` to `/project/:id` so each project is addressable by a unique URL
- Generate a UUID via `crypto.randomUUID()` when clicking "Create Project" and navigate to `/project/{uuid}`
- Add `useParams` mock to test setup for project ID access in components
- Update all e2e tests to use `/project/test-id` or UUID regex pattern matching

This is step 1 of #237 (local project storage with IndexedDB).

## Test plan
- [x] Unit tests pass (677 tests, all green)
- [x] Lint passes
- [ ] Verify "Create Project" navigates to `/project/<uuid>` in the browser
- [ ] Verify visiting `/project/some-id` directly renders the project page
- [ ] Verify `/project` without an ID shows the 404 page
- [ ] E2e tests pass with updated routes

https://claude.ai/code/session_01H8aAHD4c9cibMPwnRKeeo8