### PR TITLE
Add ProjectStorageService with IndexedDB persistence layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "globals": "^15.0.0",
         "husky": "^9.0.0",
+        "idb": "^8.0.3",
         "jsdom": "^24.1.1",
         "lint-staged": "^15.2.7",
         "prettier": "^3.3.2",
@@ -52,7 +53,8 @@
         "@playwright/test": "^1.56.0",
         "@types/throttle-debounce": "^5.0.2",
         "@vitest/coverage-v8": "^4.0.18",
-        "babel-plugin-react-compiler": "^1.0.0"
+        "babel-plugin-react-compiler": "^1.0.0",
+        "fake-indexeddb": "^6.2.5"
       },
       "engines": {
         "node": ">=22"
@@ -4851,6 +4853,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5385,6 +5397,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "globals": "^15.0.0",
     "husky": "^9.0.0",
+    "idb": "^8.0.3",
     "jsdom": "^24.1.1",
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.2",
@@ -86,7 +87,8 @@
     "@playwright/test": "^1.56.0",
     "@types/throttle-debounce": "^5.0.2",
     "@vitest/coverage-v8": "^4.0.18",
-    "babel-plugin-react-compiler": "^1.0.0"
+    "babel-plugin-react-compiler": "^1.0.0",
+    "fake-indexeddb": "^6.2.5"
   },
   "overrides": {
     "ajv": "^6.14.0"

--- a/src/services/ProjectStorageService.ts
+++ b/src/services/ProjectStorageService.ts
@@ -1,0 +1,146 @@
+import { type DBSchema, type IDBPDatabase, openDB } from 'idb';
+import { type Track } from '../types/track';
+
+const DB_NAME = 'mawimbi-db';
+const DB_VERSION = 1;
+
+export type StoredProject = {
+  id: string;
+  title: string;
+  tracks: Track[];
+  nextColorId: number;
+  nextIndex: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SpectrogramStoreData = {
+  trackId: string;
+  frequencyFrames: ArrayBuffer[];
+  timeResolution: number;
+  frequencyBinCount: number;
+  sampleRate: number;
+  duration: number;
+};
+
+interface MawimbiDB extends DBSchema {
+  projects: {
+    key: string;
+    value: StoredProject;
+    indexes: { 'by-updatedAt': number };
+  };
+  audioData: {
+    key: string;
+    value: { trackId: string; data: ArrayBuffer };
+  };
+  spectrograms: {
+    key: string;
+    value: SpectrogramStoreData;
+  };
+}
+
+let dbPromise: Promise<IDBPDatabase<MawimbiDB>> | null = null;
+
+function getDB(): Promise<IDBPDatabase<MawimbiDB>> {
+  if (!dbPromise) {
+    dbPromise = openDB<MawimbiDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        const projectStore = db.createObjectStore('projects', {
+          keyPath: 'id',
+        });
+        projectStore.createIndex('by-updatedAt', 'updatedAt');
+
+        db.createObjectStore('audioData', { keyPath: 'trackId' });
+        db.createObjectStore('spectrograms', { keyPath: 'trackId' });
+      },
+    });
+  }
+  return dbPromise;
+}
+
+export async function saveProject(project: StoredProject): Promise<void> {
+  const db = await getDB();
+  await db.put('projects', project);
+}
+
+export async function loadProject(id: string): Promise<StoredProject | null> {
+  const db = await getDB();
+  const project = await db.get('projects', id);
+  return project ?? null;
+}
+
+export async function listProjects(): Promise<StoredProject[]> {
+  const db = await getDB();
+  const all = await db.getAllFromIndex('projects', 'by-updatedAt');
+  return all.reverse();
+}
+
+export async function deleteProject(id: string): Promise<void> {
+  const db = await getDB();
+  const project = await db.get('projects', id);
+  if (project) {
+    const trackIds = project.tracks.map((t) => t.trackId);
+    const tx = db.transaction(
+      ['projects', 'audioData', 'spectrograms'],
+      'readwrite',
+    );
+    tx.objectStore('projects').delete(id);
+    for (const trackId of trackIds) {
+      tx.objectStore('audioData').delete(trackId);
+      tx.objectStore('spectrograms').delete(trackId);
+    }
+    await tx.done;
+  }
+}
+
+export async function saveAudioData(
+  trackId: string,
+  data: ArrayBuffer,
+): Promise<void> {
+  const db = await getDB();
+  await db.put('audioData', { trackId, data });
+}
+
+export async function loadAudioData(
+  trackId: string,
+): Promise<ArrayBuffer | null> {
+  const db = await getDB();
+  const entry = await db.get('audioData', trackId);
+  return entry?.data ?? null;
+}
+
+export async function deleteAudioData(trackId: string): Promise<void> {
+  const db = await getDB();
+  await db.delete('audioData', trackId);
+}
+
+export async function saveSpectrogramData(
+  data: SpectrogramStoreData,
+): Promise<void> {
+  const db = await getDB();
+  await db.put('spectrograms', data);
+}
+
+export async function loadSpectrogramData(
+  trackId: string,
+): Promise<SpectrogramStoreData | null> {
+  const db = await getDB();
+  const entry = await db.get('spectrograms', trackId);
+  return entry ?? null;
+}
+
+export async function deleteSpectrogramData(trackId: string): Promise<void> {
+  const db = await getDB();
+  await db.delete('spectrograms', trackId);
+}
+
+export async function getStorageEstimate(): Promise<StorageEstimate> {
+  if (navigator.storage?.estimate) {
+    return navigator.storage.estimate();
+  }
+  return { usage: undefined, quota: undefined };
+}
+
+export function resetDB(): void {
+  dbPromise = null;
+}

--- a/src/services/__tests__/ProjectStorageService.test.ts
+++ b/src/services/__tests__/ProjectStorageService.test.ts
@@ -1,0 +1,264 @@
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import {
+  saveProject,
+  loadProject,
+  listProjects,
+  deleteProject,
+  saveAudioData,
+  loadAudioData,
+  deleteAudioData,
+  saveSpectrogramData,
+  loadSpectrogramData,
+  deleteSpectrogramData,
+  getStorageEstimate,
+  resetDB,
+  type StoredProject,
+  type SpectrogramStoreData,
+} from '../ProjectStorageService';
+
+function createProject(overrides: Partial<StoredProject> = {}): StoredProject {
+  return {
+    id: 'project-1',
+    title: 'Test Project',
+    tracks: [],
+    nextColorId: 0,
+    nextIndex: 0,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function createSpectrogramData(trackId: string): SpectrogramStoreData {
+  return {
+    trackId,
+    frequencyFrames: [new ArrayBuffer(16), new ArrayBuffer(16)],
+    timeResolution: 512,
+    frequencyBinCount: 128,
+    sampleRate: 44100,
+    duration: 2.5,
+  };
+}
+
+beforeEach(() => {
+  // Fresh IndexedDB for each test
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    configurable: true,
+  });
+  resetDB();
+});
+
+describe('ProjectStorageService', () => {
+  describe('project CRUD', () => {
+    it('saves and loads a project', async () => {
+      const project = createProject();
+      await saveProject(project);
+
+      const loaded = await loadProject('project-1');
+      expect(loaded).toEqual(project);
+    });
+
+    it('returns null for non-existent project', async () => {
+      const loaded = await loadProject('does-not-exist');
+      expect(loaded).toBeNull();
+    });
+
+    it('updates an existing project on save', async () => {
+      await saveProject(createProject());
+      await saveProject(createProject({ title: 'Updated', updatedAt: 2000 }));
+
+      const loaded = await loadProject('project-1');
+      expect(loaded?.title).toBe('Updated');
+      expect(loaded?.updatedAt).toBe(2000);
+    });
+
+    it('lists projects sorted by updatedAt descending', async () => {
+      await saveProject(createProject({ id: 'a', updatedAt: 100 }));
+      await saveProject(createProject({ id: 'b', updatedAt: 300 }));
+      await saveProject(createProject({ id: 'c', updatedAt: 200 }));
+
+      const projects = await listProjects();
+      expect(projects.map((p) => p.id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('returns empty array when no projects exist', async () => {
+      const projects = await listProjects();
+      expect(projects).toEqual([]);
+    });
+
+    it('deletes a project', async () => {
+      await saveProject(createProject());
+      await deleteProject('project-1');
+
+      const loaded = await loadProject('project-1');
+      expect(loaded).toBeNull();
+    });
+
+    it('deleting a non-existent project does not throw', async () => {
+      await expect(deleteProject('does-not-exist')).resolves.toBeUndefined();
+    });
+
+    it('saves and loads project with tracks', async () => {
+      const project = createProject({
+        tracks: [
+          {
+            trackId: 'track-1',
+            color: { r: 77, g: 238, b: 234 },
+            fileName: 'drums.wav',
+            index: 0,
+          },
+        ],
+        nextColorId: 1,
+        nextIndex: 1,
+      });
+      await saveProject(project);
+
+      const loaded = await loadProject('project-1');
+      expect(loaded?.tracks).toHaveLength(1);
+      expect(loaded?.tracks[0].fileName).toBe('drums.wav');
+    });
+  });
+
+  describe('deleteProject cleans up related data', () => {
+    it('deletes associated audio and spectrogram data', async () => {
+      const project = createProject({
+        tracks: [
+          {
+            trackId: 'track-1',
+            color: { r: 77, g: 238, b: 234 },
+            fileName: 'drums.wav',
+            index: 0,
+          },
+          {
+            trackId: 'track-2',
+            color: { r: 116, g: 238, b: 21 },
+            fileName: 'bass.wav',
+            index: 1,
+          },
+        ],
+      });
+      await saveProject(project);
+      await saveAudioData('track-1', new ArrayBuffer(100));
+      await saveAudioData('track-2', new ArrayBuffer(200));
+      await saveSpectrogramData(createSpectrogramData('track-1'));
+      await saveSpectrogramData(createSpectrogramData('track-2'));
+
+      await deleteProject('project-1');
+
+      expect(await loadAudioData('track-1')).toBeNull();
+      expect(await loadAudioData('track-2')).toBeNull();
+      expect(await loadSpectrogramData('track-1')).toBeNull();
+      expect(await loadSpectrogramData('track-2')).toBeNull();
+    });
+  });
+
+  describe('audio data CRUD', () => {
+    it('saves and loads audio data', async () => {
+      const buffer = new ArrayBuffer(1024);
+      new Uint8Array(buffer).fill(42);
+
+      await saveAudioData('track-1', buffer);
+      const loaded = await loadAudioData('track-1');
+
+      expect(loaded!.byteLength).toBe(1024);
+      expect(new Uint8Array(loaded!)[0]).toBe(42);
+    });
+
+    it('returns null for non-existent audio data', async () => {
+      const loaded = await loadAudioData('does-not-exist');
+      expect(loaded).toBeNull();
+    });
+
+    it('overwrites existing audio data', async () => {
+      await saveAudioData('track-1', new ArrayBuffer(100));
+      await saveAudioData('track-1', new ArrayBuffer(200));
+
+      const loaded = await loadAudioData('track-1');
+      expect(loaded!.byteLength).toBe(200);
+    });
+
+    it('deletes audio data', async () => {
+      await saveAudioData('track-1', new ArrayBuffer(100));
+      await deleteAudioData('track-1');
+
+      const loaded = await loadAudioData('track-1');
+      expect(loaded).toBeNull();
+    });
+
+    it('deleting non-existent audio data does not throw', async () => {
+      await expect(deleteAudioData('does-not-exist')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('spectrogram data CRUD', () => {
+    it('saves and loads spectrogram data', async () => {
+      const data = createSpectrogramData('track-1');
+      await saveSpectrogramData(data);
+
+      const loaded = await loadSpectrogramData('track-1');
+      expect(loaded?.trackId).toBe('track-1');
+      expect(loaded?.timeResolution).toBe(512);
+      expect(loaded?.frequencyBinCount).toBe(128);
+      expect(loaded?.sampleRate).toBe(44100);
+      expect(loaded?.duration).toBe(2.5);
+      expect(loaded?.frequencyFrames).toHaveLength(2);
+    });
+
+    it('returns null for non-existent spectrogram data', async () => {
+      const loaded = await loadSpectrogramData('does-not-exist');
+      expect(loaded).toBeNull();
+    });
+
+    it('overwrites existing spectrogram data', async () => {
+      await saveSpectrogramData(createSpectrogramData('track-1'));
+      const updated = createSpectrogramData('track-1');
+      updated.duration = 5.0;
+      await saveSpectrogramData(updated);
+
+      const loaded = await loadSpectrogramData('track-1');
+      expect(loaded?.duration).toBe(5.0);
+    });
+
+    it('deletes spectrogram data', async () => {
+      await saveSpectrogramData(createSpectrogramData('track-1'));
+      await deleteSpectrogramData('track-1');
+
+      const loaded = await loadSpectrogramData('track-1');
+      expect(loaded).toBeNull();
+    });
+
+    it('deleting non-existent spectrogram data does not throw', async () => {
+      await expect(
+        deleteSpectrogramData('does-not-exist'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getStorageEstimate', () => {
+    it('returns storage estimate from navigator API', async () => {
+      Object.defineProperty(navigator, 'storage', {
+        value: {
+          estimate: vi.fn().mockResolvedValue({ usage: 1024, quota: 1048576 }),
+        },
+        configurable: true,
+      });
+
+      const estimate = await getStorageEstimate();
+      expect(estimate.usage).toBe(1024);
+      expect(estimate.quota).toBe(1048576);
+    });
+
+    it('returns undefined values when storage API is unavailable', async () => {
+      Object.defineProperty(navigator, 'storage', {
+        value: undefined,
+        configurable: true,
+      });
+
+      const estimate = await getStorageEstimate();
+      expect(estimate.usage).toBeUndefined();
+      expect(estimate.quota).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ProjectStorageService` — IndexedDB persistence layer using the `idb` library with three object stores: `projects` (metadata), `audioData` (ArrayBuffers), and `spectrograms` (serialized spectrogram data)
- Public API: `saveProject`, `loadProject`, `listProjects`, `deleteProject`, `saveAudioData`, `loadAudioData`, `deleteAudioData`, `saveSpectrogramData`, `loadSpectrogramData`, `deleteSpectrogramData`, `getStorageEstimate`
- Schema versioning via `idb` upgrade callback for future migrations
- `deleteProject` cascades to associated audio and spectrogram data in a single transaction

Implements step 2 of #237.

## Test plan

- [x] 21 unit tests covering all CRUD operations using `fake-indexeddb`
- [x] Project metadata: save, load, update, list (sorted by updatedAt descending), delete
- [x] Audio data: save, load, overwrite, delete
- [x] Spectrogram data: save, load, overwrite, delete
- [x] Cascade delete: removing a project cleans up all associated audio and spectrogram data
- [x] Storage estimate: navigator.storage.estimate() wrapper with graceful fallback
- [x] All 704 existing tests still pass
- [x] Build succeeds

https://claude.ai/code/session_019XhrbB25H3T7TwqaGsLgDr