### PR TITLE
Fix cone-shaped transient artifacts in CQT spectrogram

### DIFF
--- a/src/services/CQTAnalyser.ts
+++ b/src/services/CQTAnalyser.ts
@@ -43,6 +43,16 @@ const Q_FACTOR = 1 / (2 ** (1 / BINS_PER_OCTAVE) - 1);
  */
 const HOP_SECONDS = 0.025;
 
+/**
+ * Maximum kernel length as a multiple of the hop size. Without a cap, the
+ * constant-Q formula gives kernel lengths up to ~46,000 samples (~1 second)
+ * at the lowest frequency bin. A transient then smears across ~40 frames,
+ * creating visible cone-shaped artifacts in the spectrogram. Capping at a
+ * few hops limits temporal smearing while preserving the CQT's log-frequency
+ * property at higher frequencies.
+ */
+const MAX_KERNEL_HOPS = 4;
+
 // ---------------------------------------------------------------------------
 // CQT kernel
 // ---------------------------------------------------------------------------
@@ -83,12 +93,16 @@ function computeNumberBins(sampleRate: number): number {
 function computeKernel(sampleRate: number): CQTKernel {
   const numberBins = computeNumberBins(sampleRate);
   const hopSize = Math.round(HOP_SECONDS * sampleRate);
+  const maxKernelLength = hopSize * MAX_KERNEL_HOPS;
 
   const bins: CQTBinKernel[] = new Array(numberBins);
 
   for (let k = 0; k < numberBins; k++) {
     const freq = MIN_FREQUENCY * 2 ** (k / BINS_PER_OCTAVE);
-    const Nk = Math.ceil((Q_FACTOR * sampleRate) / freq);
+    const Nk = Math.min(
+      Math.ceil((Q_FACTOR * sampleRate) / freq),
+      maxKernelLength,
+    );
     const norm = 1 / Nk;
     const angularFreq = (2 * Math.PI * freq) / sampleRate;
 
@@ -251,6 +265,7 @@ export {
   MIN_FREQUENCY,
   Q_FACTOR,
   HOP_SECONDS,
+  MAX_KERNEL_HOPS,
   MIN_DECIBELS,
   MAX_DECIBELS,
   computeNumberBins,

--- a/src/services/__tests__/CQTAnalyser.test.ts
+++ b/src/services/__tests__/CQTAnalyser.test.ts
@@ -7,6 +7,7 @@ import {
   HOP_SECONDS,
   magnitudeToByte,
   MAX_DECIBELS,
+  MAX_KERNEL_HOPS,
   MIN_DECIBELS,
   MIN_FREQUENCY,
   mixToMono,
@@ -67,12 +68,14 @@ describe('computeKernel', () => {
     expect(lowBin.length).toBeGreaterThan(highBin.length);
   });
 
-  it('kernel length matches Q-factor formula', () => {
+  it('kernel length matches Q-factor formula capped at max kernel hops', () => {
     const kernel = computeKernel(SAMPLE_RATE);
+    const maxKernelLength = kernel.hopSize * MAX_KERNEL_HOPS;
 
     for (let k = 0; k < kernel.numberBins; k++) {
       const freq = MIN_FREQUENCY * 2 ** (k / BINS_PER_OCTAVE);
-      const expectedLength = Math.ceil((Q_FACTOR * SAMPLE_RATE) / freq);
+      const uncappedLength = Math.ceil((Q_FACTOR * SAMPLE_RATE) / freq);
+      const expectedLength = Math.min(uncappedLength, maxKernelLength);
       expect(kernel.bins[k].length).toBe(expectedLength);
       expect(kernel.bins[k].cosValues).toHaveLength(expectedLength);
       expect(kernel.bins[k].sinValues).toHaveLength(expectedLength);
@@ -249,7 +252,9 @@ describe('analyseCQT', () => {
       if (midFrame[i] > midFrame[peakBin]) peakBin = i;
     }
 
-    expect(Math.abs(peakBin - expectedBin)).toBeLessThanOrEqual(1);
+    // Wider tolerance than the 440 Hz test because 200 Hz falls in the
+    // kernel-capped range where frequency resolution is reduced.
+    expect(Math.abs(peakBin - expectedBin)).toBeLessThanOrEqual(3);
   });
 
   it('handles multi-channel audio by mixing to mono', () => {
@@ -270,6 +275,23 @@ describe('analyseCQT', () => {
       result.frequencyFrames[Math.floor(result.frequencyFrames.length / 2)];
     const hasNonZero = midFrame.some((v) => v > 0);
     expect(hasNonZero).toBe(true);
+  });
+});
+
+describe('temporal smearing', () => {
+  it('caps kernel lengths to prevent cone-shaped transient artifacts', () => {
+    const kernel = computeKernel(SAMPLE_RATE);
+    const hopSize = kernel.hopSize;
+
+    // Without a kernel length cap, the lowest-frequency bin at 32.7 Hz has a
+    // kernel of ~46,000 samples (~1 second), causing transients to smear
+    // across ~40 frames and form visible cone shapes in the spectrogram.
+    // Kernel lengths should be capped so no bin spreads beyond a few hops.
+    const maxAllowedLength = hopSize * 4;
+
+    for (const bin of kernel.bins) {
+      expect(bin.length).toBeLessThanOrEqual(maxAllowedLength);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Cap CQT kernel lengths at 4× the hop size (`MAX_KERNEL_HOPS = 4`) to prevent low-frequency bins from smearing transients across dozens of frames
- Without the cap, the lowest bin (32.7 Hz) had a ~46,000-sample kernel (~1 second), causing transients to spread across ~40 frames and form visible cone shapes
- The cap limits temporal smearing to at most 4 frames while preserving full CQT resolution above ~340 Hz

## Test plan
- [x] Added failing test verifying kernel lengths are capped before implementing the fix
- [x] Updated existing kernel length test to account for the cap
- [x] Widened 200 Hz frequency detection tolerance (±3 bins) since it falls in the capped range
- [x] All 684 tests pass, lint and build clean
- [ ] Manual verification: upload audio with percussive content and confirm transients no longer form cone shapes at low frequencies

https://claude.ai/code/session_012WDXvamxmQXWLCcsPDGSfz