### PR TITLE
Add audio data persistence via IndexedDB

### DIFF
--- a/src/components/project/ProjectPage.tsx
+++ b/src/components/project/ProjectPage.tsx
@@ -5,8 +5,10 @@ import Workstation from '../workstation/Workstation';
 import './ProjectPage.css';
 import {
   useAutoSave,
+  useDeleteTrackAudio,
   useFullscreen,
   useLoadProject,
+  useRestoreAudio,
   useTrackSideEffects,
   useUploadFile,
 } from './projectPageEffects';
@@ -35,10 +37,16 @@ const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
 
   const uploadFile = useUploadFile(dispatch);
   const [fullScreenHandle, toggleFullscreen] = useFullscreen();
+  const isRestoringAudio = useRestoreAudio(initialState.tracks);
   useTrackSideEffects(state.tracks);
+  useDeleteTrackAudio(state.tracks);
   useAutoSave(state);
 
   const recordingColor = COLOR_PALETTE[state.nextColorId];
+
+  if (isRestoringAudio) {
+    return null;
+  }
 
   return (
     <ProjectDispatch.Provider value={dispatch}>

--- a/src/components/project/__tests__/projectPageEffects.test.ts
+++ b/src/components/project/__tests__/projectPageEffects.test.ts
@@ -4,12 +4,20 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import {
   saveProject,
+  saveAudioData,
   loadProject,
+  loadAudioData,
   resetDB,
   type StoredProject,
 } from '../../../services/ProjectStorageService';
-import { useAutoSave, useLoadProject } from '../projectPageEffects';
+import {
+  useAutoSave,
+  useDeleteTrackAudio,
+  useLoadProject,
+  useRestoreAudio,
+} from '../projectPageEffects';
 import { type ProjectState } from '../projectPageReducer';
+import { type Track } from '../../../types/track';
 
 function createStoredProject(
   overrides: Partial<StoredProject> = {},
@@ -179,5 +187,167 @@ describe('useAutoSave', () => {
     expect(saved!.title).toBe('C');
 
     saveSpy.mockRestore();
+  });
+});
+
+const mockRestoreTrack = vi.fn().mockResolvedValue({ trackId: 'track-1' });
+
+vi.mock('../../../hooks/useTrackService', () => ({
+  useTrackService: () => ({
+    restoreTrack: mockRestoreTrack,
+  }),
+}));
+
+function createTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    trackId: 'track-1',
+    color: { r: 77, g: 238, b: 234 },
+    fileName: 'drums.wav',
+    index: 0,
+    ...overrides,
+  };
+}
+
+describe('useRestoreAudio', () => {
+  it('returns true while restoring audio', () => {
+    const tracks = [createTrack()];
+    saveAudioData('track-1', new ArrayBuffer(16));
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false after audio is restored', async () => {
+    const tracks = [createTrack()];
+    await saveAudioData('track-1', new ArrayBuffer(16));
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('calls restoreTrack for each track with audio data', async () => {
+    const tracks = [
+      createTrack({ trackId: 'track-1' }),
+      createTrack({ trackId: 'track-2', index: 1 }),
+    ];
+    await saveAudioData('track-1', new ArrayBuffer(16));
+    await saveAudioData('track-2', new ArrayBuffer(32));
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    expect(mockRestoreTrack).toHaveBeenCalledTimes(2);
+    expect(mockRestoreTrack).toHaveBeenCalledWith(
+      'track-1',
+      expect.anything(),
+      0,
+    );
+    expect(mockRestoreTrack).toHaveBeenCalledWith(
+      'track-2',
+      expect.anything(),
+      0,
+    );
+  });
+
+  it('uses startTime from track metadata', async () => {
+    const tracks = [createTrack({ trackId: 'track-1', startTime: 3.5 })];
+    await saveAudioData('track-1', new ArrayBuffer(16));
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    expect(mockRestoreTrack).toHaveBeenCalledWith(
+      'track-1',
+      expect.anything(),
+      3.5,
+    );
+  });
+
+  it('skips tracks with missing audio data', async () => {
+    const tracks = [createTrack({ trackId: 'track-1' })];
+    // No audio data saved for track-1
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+
+    expect(mockRestoreTrack).not.toHaveBeenCalled();
+  });
+
+  it('returns false immediately when no tracks exist', async () => {
+    const { result } = renderHook(() => useRestoreAudio([]));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('handles restoreTrack failure gracefully', async () => {
+    mockRestoreTrack.mockRejectedValueOnce(new Error('decode failed'));
+    const tracks = [createTrack()];
+    await saveAudioData('track-1', new ArrayBuffer(16));
+
+    const { result } = renderHook(() => useRestoreAudio(tracks));
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+});
+
+describe('useDeleteTrackAudio', () => {
+  it('deletes audio data when a track is removed', async () => {
+    await saveAudioData('track-1', new ArrayBuffer(16));
+
+    const initialTracks = [createTrack({ trackId: 'track-1' })];
+    const { rerender } = renderHook(
+      ({ tracks }) => useDeleteTrackAudio(tracks),
+      { initialProps: { tracks: initialTracks } },
+    );
+
+    // Remove the track
+    rerender({ tracks: [] });
+
+    await waitFor(async () => {
+      const audio = await loadAudioData('track-1');
+      expect(audio).toBeNull();
+    });
+  });
+
+  it('does not delete audio for tracks that remain', async () => {
+    await saveAudioData('track-1', new ArrayBuffer(16));
+    await saveAudioData('track-2', new ArrayBuffer(32));
+
+    const initialTracks = [
+      createTrack({ trackId: 'track-1' }),
+      createTrack({ trackId: 'track-2', index: 1 }),
+    ];
+    const { rerender } = renderHook(
+      ({ tracks }) => useDeleteTrackAudio(tracks),
+      { initialProps: { tracks: initialTracks } },
+    );
+
+    // Remove only track-1
+    rerender({ tracks: [createTrack({ trackId: 'track-2', index: 0 })] });
+
+    await waitFor(async () => {
+      const audio1 = await loadAudioData('track-1');
+      expect(audio1).toBeNull();
+    });
+
+    const audio2 = await loadAudioData('track-2');
+    expect(audio2).not.toBeNull();
   });
 });

--- a/src/components/project/projectPageEffects.ts
+++ b/src/components/project/projectPageEffects.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTrackService } from '../../hooks/useTrackService';
 import useDebounced from '../../hooks/useDebounced';
 import {
+  deleteAudioData,
+  loadAudioData,
   loadProject,
+  saveAudioData,
   saveProject,
   type StoredProject,
 } from '../../services/ProjectStorageService';
@@ -34,6 +37,7 @@ export const useUploadFile = (dispatch: React.Dispatch<ProjectAction>) => {
         trackHook
           .createTrack(arrayBuffer)
           .then(({ trackId }) => {
+            saveAudioData(trackId, arrayBuffer);
             dispatch([ADD_TRACK, { trackId, fileName }]);
             msg.success(fileName);
           })
@@ -172,6 +176,74 @@ export const useAutoSave = (state: ProjectState) => {
     save();
     // save is stable (useMemo in useDebounced)
   }, [state, save]);
+};
+
+export const useRestoreAudio = (tracks: Track[]) => {
+  const trackHook = useTrackService();
+  const [isRestoring, setIsRestoring] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const restore = async () => {
+      const results = await Promise.all(
+        tracks.map(async (track) => {
+          const audioData = await loadAudioData(track.trackId);
+          return { track, audioData };
+        }),
+      );
+
+      if (cancelled) return;
+
+      for (const { track, audioData } of results) {
+        if (cancelled) break;
+        if (!audioData) continue;
+        try {
+          await trackHook.restoreTrack(
+            track.trackId,
+            audioData,
+            track.startTime ?? 0,
+          );
+        } catch {
+          // Audio data corrupted or decode failed — skip this track
+        }
+      }
+
+      if (!cancelled) {
+        setIsRestoring(false);
+      }
+    };
+
+    if (tracks.length === 0) {
+      setIsRestoring(false);
+    } else {
+      restore();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+    // Runs once on mount with the initial tracks from the stored project
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return isRestoring;
+};
+
+export const useDeleteTrackAudio = (tracks: Track[]) => {
+  const previousTracksRef = useRef<Track[]>(tracks);
+
+  useEffect(() => {
+    const previousTracks = previousTracksRef.current;
+    const currIds = new Set(tracks.map((t) => t.trackId));
+
+    for (const track of previousTracks) {
+      if (!currIds.has(track.trackId)) {
+        deleteAudioData(track.trackId);
+      }
+    }
+
+    previousTracksRef.current = tracks;
+  }, [tracks]);
 };
 
 export const useFullscreen = () => {

--- a/src/components/project/projectPageReducer.ts
+++ b/src/components/project/projectPageReducer.ts
@@ -13,6 +13,7 @@ export type ProjectState = {
 type AddTrackPayload = {
   trackId: TrackId;
   fileName?: string;
+  startTime?: number;
   restore?: Track;
 };
 
@@ -113,13 +114,14 @@ function deleteTrack(
 function createTrack(
   index: number,
   colorIdx: number,
-  { trackId, fileName }: AddTrackPayload,
+  { trackId, fileName, startTime }: AddTrackPayload,
 ): Track {
   return {
     color: COLOR_PALETTE[colorIdx],
     fileName: fileName ?? '',
     trackId,
     index,
+    startTime: startTime ?? 0,
   };
 }
 

--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -21,6 +21,10 @@ vi.mock('../../project/useProjectDispatch', () => ({
   default: () => mockProjectDispatch,
 }));
 
+vi.mock('../../../services/ProjectStorageService', () => ({
+  saveAudioData: vi.fn().mockResolvedValue(undefined),
+}));
+
 const { mockError, mockSuccess, mockLoading, mockInfo } = vi.hoisted(() => ({
   mockError: vi.fn(),
   mockSuccess: vi.fn(),
@@ -116,7 +120,7 @@ describe('useMicrophone', () => {
     );
     expect(mockProjectDispatch).toHaveBeenCalledWith([
       'ADD_TRACK',
-      { trackId: 'recorded-track-1', fileName: 'Recording' },
+      { trackId: 'recorded-track-1', fileName: 'Recording', startTime: 0 },
     ]);
   });
 

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -5,6 +5,7 @@ import { useRecordingService } from '../../hooks/useRecordingService';
 import { useTrackService } from '../../hooks/useTrackService';
 import { useContainerHeight } from '../../hooks/useContainerHeight';
 import useKeypress from '../../hooks/useKeypress';
+import { saveAudioData } from '../../services/ProjectStorageService';
 import message from '../message';
 import { type Track } from '../../types/track';
 import { ADD_TRACK } from '../project/projectPageReducer';
@@ -207,9 +208,10 @@ export const useMicrophone = (isRecording: boolean) => {
           arrayBuffer,
           startTime,
         );
+        saveAudioData(trackId, arrayBuffer);
         projectDispatch([
           ADD_TRACK,
-          { trackId, fileName: RECORDING_FILE_NAME },
+          { trackId, fileName: RECORDING_FILE_NAME, startTime },
         ]);
         recording.stopRecording();
         // Pause at current position so the user can immediately press

--- a/src/hooks/useTrackService.ts
+++ b/src/hooks/useTrackService.ts
@@ -40,6 +40,11 @@ export function useTrackService() {
       arrayBuffer: ArrayBuffer,
       startTime: number,
     ) => service.createRecordedTrack(audioBuffer, arrayBuffer, startTime),
+    restoreTrack: (
+      trackId: string,
+      arrayBuffer: ArrayBuffer,
+      startTime: number,
+    ) => service.restoreTrack(trackId, arrayBuffer, startTime),
 
     // --- Signal management ---
 

--- a/src/services/TrackService.ts
+++ b/src/services/TrackService.ts
@@ -163,6 +163,42 @@ class TrackService {
     return { trackId, initialVolume };
   }
 
+  // Restores a track from persisted audio data using a known track ID.
+  // Unlike createTrack(), this does not generate a new ID.
+  async restoreTrack(
+    trackId: string,
+    arrayBuffer: ArrayBuffer,
+    startTime: number,
+  ): Promise<TrackCreationResult> {
+    const audioBuffer = await this.context.decodeAudioData(arrayBuffer);
+    const blob = new Blob([arrayBuffer], { type: 'audio/*' });
+    const blobUrl = URL.createObjectURL(blob);
+    const normalizationGainDb =
+      LoudnessNormalizer.calculateNormalizationGain(audioBuffer);
+    const initialVolume =
+      LoudnessNormalizer.gainToInitialVolume(normalizationGainDb);
+
+    this.mixer.createChannel(
+      trackId,
+      audioBuffer,
+      normalizationGainDb,
+      startTime,
+    );
+    this.audioSourceRepository.add({
+      id: trackId,
+      audioBuffer,
+      blobUrl,
+      normalizationGainDb,
+      initialVolume,
+      startTime,
+    });
+
+    this.createSignals(trackId, initialVolume);
+    this.onTrackCreated?.(trackId, audioBuffer);
+
+    return { trackId, initialVolume };
+  }
+
   // --- Track signal management ---
 
   createSignals(trackId: TrackId, initialVolume?: number): TrackSignals {

--- a/src/services/__tests__/TrackService.test.ts
+++ b/src/services/__tests__/TrackService.test.ts
@@ -366,4 +366,73 @@ describe('TrackService', () => {
       expect(service.getTotalTime()).toBe(13.0);
     });
   });
+
+  describe('restoreTrack', () => {
+    it('uses the provided track ID instead of generating a new one', async () => {
+      const arrayBuffer = new ArrayBuffer(16);
+
+      const { trackId } = await service.restoreTrack(
+        'restored-id',
+        arrayBuffer,
+        0,
+      );
+
+      expect(trackId).toBe('restored-id');
+    });
+
+    it('decodes audio data and creates signals', async () => {
+      const arrayBuffer = new ArrayBuffer(16);
+
+      await service.restoreTrack('restored-id', arrayBuffer, 0);
+
+      expect(Tone.context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+      expect(service.getSignals('restored-id')).toBeDefined();
+    });
+
+    it('creates a mixer channel for the restored track', async () => {
+      const arrayBuffer = new ArrayBuffer(16);
+
+      await service.restoreTrack('restored-id', arrayBuffer, 0);
+
+      expect(service.retrieveChannel('restored-id')).toBeDefined();
+    });
+
+    it('stores the blob URL for the restored track', async () => {
+      const arrayBuffer = new ArrayBuffer(16);
+
+      await service.restoreTrack('restored-id', arrayBuffer, 0);
+
+      const blobUrl = service.retrieveBlobUrl('restored-id');
+      expect(blobUrl).toBeDefined();
+      expect(blobUrl).toContain('blob:');
+    });
+
+    it('preserves the start time for restored tracks', async () => {
+      const arrayBuffer = new ArrayBuffer(16);
+
+      await service.restoreTrack('restored-id', arrayBuffer, 3.5);
+
+      expect(service.retrieveStartTime('restored-id')).toBe(3.5);
+    });
+
+    it('includes restored track in total time calculation', async () => {
+      vi.mocked(Tone.context.decodeAudioData).mockResolvedValueOnce(
+        mockAudioBuffer({ duration: 5.0 }),
+      );
+
+      await service.restoreTrack('restored-id', new ArrayBuffer(16), 2.0);
+
+      // Total = startTime (2) + duration (5) = 7
+      expect(service.getTotalTime()).toBe(7.0);
+    });
+
+    it('fires the onTrackCreated callback', async () => {
+      const callback = vi.fn();
+      service.setOnTrackCreated(callback);
+
+      await service.restoreTrack('restored-id', new ArrayBuffer(16), 0);
+
+      expect(callback).toHaveBeenCalledWith('restored-id', expect.any(Object));
+    });
+  });
 });

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -12,4 +12,5 @@ export type Track = {
   fileName: string;
   index: number;
   instrument?: string;
+  startTime?: number;
 };


### PR DESCRIPTION
## Summary
- Add `TrackService.restoreTrack()` method to rebuild audio engine state from persisted data using a known track ID (unlike `createTrack()` which generates a new UUID)
- Save audio `ArrayBuffer` to IndexedDB when tracks are created via file upload (`useUploadFile`) or recording (`useMicrophone`)
- Add `useRestoreAudio` hook that loads all track audio from IndexedDB on project mount and restores the full audio engine state
- Add `useDeleteTrackAudio` hook that cleans up audio data from IndexedDB when tracks are removed
- Persist `startTime` on `Track` type so recorded tracks restore at the correct timeline position
- Show loading state (render `null`) while audio is being restored to prevent rendering tracks without audio

## Test plan
- [x] `TrackService.restoreTrack` unit tests — verifies track ID preservation, audio decoding, signal creation, mixer channel, blob URL, start time, and onTrackCreated callback (7 tests)
- [x] `useRestoreAudio` hook tests — verifies loading state, parallel restoration, startTime from metadata, missing audio graceful skip, empty track list, and decode failure handling (7 tests)
- [x] `useDeleteTrackAudio` hook tests — verifies audio cleanup on track removal and preservation of remaining tracks (2 tests)
- [x] Existing `useMicrophone` test updated to verify `startTime` in `ADD_TRACK` payload
- [x] All 728 tests pass, lint clean, build succeeds

https://claude.ai/code/session_01Vic9LPQXPbUGzeZ52UKxFb