### PR TITLE
Add spectrogram persistence via IndexedDB

### DIFF
--- a/src/components/project/__tests__/projectPageEffects.test.ts
+++ b/src/components/project/__tests__/projectPageEffects.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import {
   saveProject,
   saveAudioData,
+  saveSpectrogramData,
   loadProject,
   loadAudioData,
+  loadSpectrogramData,
   resetDB,
   type StoredProject,
 } from '../../../services/ProjectStorageService';
@@ -349,5 +351,29 @@ describe('useDeleteTrackAudio', () => {
 
     const audio2 = await loadAudioData('track-2');
     expect(audio2).not.toBeNull();
+  });
+
+  it('deletes spectrogram data when a track is removed', async () => {
+    await saveSpectrogramData({
+      trackId: 'track-1',
+      frequencyFrames: [new ArrayBuffer(4)],
+      timeResolution: 0.025,
+      frequencyBinCount: 2,
+      sampleRate: 44100,
+      duration: 0.05,
+    });
+
+    const initialTracks = [createTrack({ trackId: 'track-1' })];
+    const { rerender } = renderHook(
+      ({ tracks }) => useDeleteTrackAudio(tracks),
+      { initialProps: { tracks: initialTracks } },
+    );
+
+    rerender({ tracks: [] });
+
+    await waitFor(async () => {
+      const spectrogram = await loadSpectrogramData('track-1');
+      expect(spectrogram).toBeNull();
+    });
   });
 });

--- a/src/components/project/projectPageEffects.ts
+++ b/src/components/project/projectPageEffects.ts
@@ -3,6 +3,7 @@ import { useTrackService } from '../../hooks/useTrackService';
 import useDebounced from '../../hooks/useDebounced';
 import {
   deleteAudioData,
+  deleteSpectrogramData,
   loadAudioData,
   loadProject,
   saveAudioData,
@@ -239,6 +240,7 @@ export const useDeleteTrackAudio = (tracks: Track[]) => {
     for (const track of previousTracks) {
       if (!currIds.has(track.trackId)) {
         deleteAudioData(track.trackId);
+        deleteSpectrogramData(track.trackId);
       }
     }
 

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -59,11 +59,17 @@ const { mockRetrieveAudioBuffer, mockRetrieveStartTime } = vi.hoisted(() => ({
   mockRetrieveStartTime: vi.fn().mockReturnValue(0),
 }));
 
+vi.mock('../../../../services/ProjectStorageService', () => ({
+  loadSpectrogramData: vi.fn().mockResolvedValue(null),
+  saveSpectrogramData: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../../../../hooks/useAudioService', () => ({
   useAudioService: () => ({
     spectrogramCache: {
       analyse: mockAnalyse,
       getEntry: mockGetEntry,
+      restore: vi.fn(),
     },
   }),
 }));

--- a/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
@@ -1,0 +1,214 @@
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SpectrogramData } from '../../../../services/OfflineAnalyser';
+import {
+  loadSpectrogramData,
+  resetDB,
+  saveSpectrogramData,
+  type SpectrogramStoreData,
+} from '../../../../services/ProjectStorageService';
+import type { TrackSpectrogramEntry } from '../../../../services/SpectrogramCache';
+import { type TrackColor } from '../../../../types/track';
+import {
+  fromSpectrogramStoreData,
+  toSpectrogramStoreData,
+  useSpectrogramCache,
+} from '../useSpectrogramCache';
+
+const COLOR: TrackColor = { r: 77, g: 238, b: 234 };
+
+const MOCK_DATA: SpectrogramData = {
+  frequencyFrames: [new Uint8Array([10, 20]), new Uint8Array([30, 40])],
+  timeResolution: 0.025,
+  frequencyBinCount: 2,
+  sampleRate: 44100,
+  duration: 0.05,
+};
+
+const MOCK_ENTRY: TrackSpectrogramEntry = {
+  data: MOCK_DATA,
+  tiles: [],
+};
+
+const mockGetEntry = vi.fn();
+const mockAnalyse = vi.fn();
+const mockRestore = vi.fn();
+
+vi.mock('../../../../hooks/useAudioService', () => ({
+  useAudioService: () => ({
+    spectrogramCache: {
+      getEntry: mockGetEntry,
+      analyse: mockAnalyse,
+      restore: mockRestore,
+    },
+  }),
+}));
+
+function mockAudioBuffer(): AudioBuffer {
+  return {
+    numberOfChannels: 1,
+    length: 3,
+    sampleRate: 44100,
+    duration: 3 / 44100,
+    getChannelData: vi.fn().mockReturnValue(new Float32Array([0.1, 0.2, 0.3])),
+  } as unknown as AudioBuffer;
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    configurable: true,
+  });
+  resetDB();
+  vi.clearAllMocks();
+});
+
+describe('toSpectrogramStoreData', () => {
+  it('converts Uint8Array frames to ArrayBuffer copies', () => {
+    const result = toSpectrogramStoreData('track-1', MOCK_DATA);
+
+    expect(result.trackId).toBe('track-1');
+    expect(result.frequencyFrames).toHaveLength(2);
+    expect(result.frequencyFrames[0]).toBeInstanceOf(ArrayBuffer);
+    expect(result.frequencyFrames[1]).toBeInstanceOf(ArrayBuffer);
+    expect(new Uint8Array(result.frequencyFrames[0])).toEqual(
+      new Uint8Array([10, 20]),
+    );
+    expect(new Uint8Array(result.frequencyFrames[1])).toEqual(
+      new Uint8Array([30, 40]),
+    );
+    expect(result.timeResolution).toBe(0.025);
+    expect(result.frequencyBinCount).toBe(2);
+    expect(result.sampleRate).toBe(44100);
+    expect(result.duration).toBe(0.05);
+  });
+
+  it('creates independent copies of frame buffers', () => {
+    const result = toSpectrogramStoreData('track-1', MOCK_DATA);
+
+    // Mutating the stored buffer should not affect the original
+    new Uint8Array(result.frequencyFrames[0])[0] = 255;
+    expect(MOCK_DATA.frequencyFrames[0][0]).toBe(10);
+  });
+});
+
+describe('fromSpectrogramStoreData', () => {
+  it('converts ArrayBuffer frames back to Uint8Arrays', () => {
+    const stored: SpectrogramStoreData = {
+      trackId: 'track-1',
+      frequencyFrames: [
+        new Uint8Array([10, 20]).buffer.slice(0),
+        new Uint8Array([30, 40]).buffer.slice(0),
+      ],
+      timeResolution: 0.025,
+      frequencyBinCount: 2,
+      sampleRate: 44100,
+      duration: 0.05,
+    };
+
+    const result = fromSpectrogramStoreData(stored);
+
+    expect(result.frequencyFrames).toHaveLength(2);
+    expect(result.frequencyFrames[0]).toBeInstanceOf(Uint8Array);
+    expect(result.frequencyFrames[0]).toEqual(new Uint8Array([10, 20]));
+    expect(result.frequencyFrames[1]).toEqual(new Uint8Array([30, 40]));
+    expect(result.timeResolution).toBe(0.025);
+    expect(result.frequencyBinCount).toBe(2);
+    expect(result.sampleRate).toBe(44100);
+    expect(result.duration).toBe(0.05);
+  });
+
+  it('round-trips through to/from without data loss', () => {
+    const stored = toSpectrogramStoreData('track-1', MOCK_DATA);
+    const restored = fromSpectrogramStoreData(stored);
+
+    expect(restored.frequencyFrames).toHaveLength(
+      MOCK_DATA.frequencyFrames.length,
+    );
+    for (let i = 0; i < restored.frequencyFrames.length; i++) {
+      expect(restored.frequencyFrames[i]).toEqual(MOCK_DATA.frequencyFrames[i]);
+    }
+    expect(restored.timeResolution).toBe(MOCK_DATA.timeResolution);
+    expect(restored.frequencyBinCount).toBe(MOCK_DATA.frequencyBinCount);
+    expect(restored.sampleRate).toBe(MOCK_DATA.sampleRate);
+    expect(restored.duration).toBe(MOCK_DATA.duration);
+  });
+});
+
+describe('useSpectrogramCache', () => {
+  it('returns undefined when audioBuffer is not available', () => {
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', undefined, COLOR),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns in-memory cached entry immediately', () => {
+    mockGetEntry.mockReturnValue(MOCK_ENTRY);
+
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', mockAudioBuffer(), COLOR),
+    );
+
+    expect(result.current).toBe(MOCK_ENTRY);
+    expect(mockAnalyse).not.toHaveBeenCalled();
+    expect(mockRestore).not.toHaveBeenCalled();
+  });
+
+  it('restores from IndexedDB when available, skipping analysis', async () => {
+    mockGetEntry
+      .mockReturnValueOnce(undefined) // initial check: not in memory
+      .mockReturnValue(MOCK_ENTRY); // after restore: entry available
+
+    const storeData = toSpectrogramStoreData('track-1', MOCK_DATA);
+    await saveSpectrogramData(storeData);
+
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', mockAudioBuffer(), COLOR),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(MOCK_ENTRY);
+    });
+
+    expect(mockRestore).toHaveBeenCalledWith(
+      'track-1',
+      expect.objectContaining({
+        frequencyBinCount: 2,
+        timeResolution: 0.025,
+        sampleRate: 44100,
+        duration: 0.05,
+      }),
+      COLOR,
+    );
+    expect(mockAnalyse).not.toHaveBeenCalled();
+  });
+
+  it('runs analysis and saves to IndexedDB when no cached data exists', async () => {
+    mockGetEntry
+      .mockReturnValueOnce(undefined) // initial check
+      .mockReturnValue(MOCK_ENTRY); // after analyse
+
+    mockAnalyse.mockResolvedValue(undefined);
+
+    const buffer = mockAudioBuffer();
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', buffer, COLOR),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(MOCK_ENTRY);
+    });
+
+    expect(mockAnalyse).toHaveBeenCalledWith('track-1', buffer, COLOR);
+
+    // Verify spectrogram data was saved to IndexedDB
+    const stored = await loadSpectrogramData('track-1');
+    expect(stored).not.toBeNull();
+    expect(stored!.trackId).toBe('track-1');
+    expect(stored!.timeResolution).toBe(0.025);
+  });
+});

--- a/src/components/workstation/spectrogram/useSpectrogramCache.ts
+++ b/src/components/workstation/spectrogram/useSpectrogramCache.ts
@@ -1,7 +1,43 @@
 import { useEffect, useState } from 'react';
 import { useAudioService } from '../../../hooks/useAudioService';
+import { type SpectrogramData } from '../../../services/OfflineAnalyser';
+import {
+  loadSpectrogramData,
+  saveSpectrogramData,
+  type SpectrogramStoreData,
+} from '../../../services/ProjectStorageService';
 import { type TrackSpectrogramEntry } from '../../../services/SpectrogramCache';
 import { type TrackColor } from '../../../types/track';
+
+export function toSpectrogramStoreData(
+  trackId: string,
+  data: SpectrogramData,
+): SpectrogramStoreData {
+  return {
+    trackId,
+    frequencyFrames: data.frequencyFrames.map(
+      (frame) => frame.buffer.slice(0) as ArrayBuffer,
+    ),
+    timeResolution: data.timeResolution,
+    frequencyBinCount: data.frequencyBinCount,
+    sampleRate: data.sampleRate,
+    duration: data.duration,
+  };
+}
+
+export function fromSpectrogramStoreData(
+  stored: SpectrogramStoreData,
+): SpectrogramData {
+  return {
+    frequencyFrames: stored.frequencyFrames.map(
+      (buffer) => new Uint8Array(buffer),
+    ),
+    timeResolution: stored.timeResolution,
+    frequencyBinCount: stored.frequencyBinCount,
+    sampleRate: stored.sampleRate,
+    duration: stored.duration,
+  };
+}
 
 export function useSpectrogramCache(
   trackId: string,
@@ -21,13 +57,37 @@ export function useSpectrogramCache(
     }
 
     let cancelled = false;
-    audioService.spectrogramCache
-      .analyse(trackId, audioBuffer, color)
-      .then(() => {
-        if (!cancelled) {
-          setEntry(audioService.spectrogramCache.getEntry(trackId));
-        }
-      });
+
+    const loadOrAnalyse = async () => {
+      // Check IndexedDB for previously stored spectrogram data
+      const stored = await loadSpectrogramData(trackId);
+
+      if (cancelled) return;
+
+      if (stored) {
+        const data = fromSpectrogramStoreData(stored);
+        audioService.spectrogramCache.restore(trackId, data, color);
+        setEntry(audioService.spectrogramCache.getEntry(trackId));
+        return;
+      }
+
+      // No cached data — run full analysis
+      await audioService.spectrogramCache.analyse(trackId, audioBuffer, color);
+
+      if (cancelled) return;
+
+      const analysedEntry = audioService.spectrogramCache.getEntry(trackId);
+      setEntry(analysedEntry);
+
+      // Persist for future loads
+      if (analysedEntry) {
+        const storeData = toSpectrogramStoreData(trackId, analysedEntry.data);
+        saveSpectrogramData(storeData);
+      }
+    };
+
+    loadOrAnalyse();
+
     return () => {
       cancelled = true;
     };

--- a/src/services/SpectrogramCache.ts
+++ b/src/services/SpectrogramCache.ts
@@ -40,6 +40,11 @@ class SpectrogramCache {
     this.entries.set(trackId, { data: result.data, tiles: result.tiles });
   }
 
+  restore(trackId: string, data: SpectrogramData, color: TrackColor): void {
+    const tiles = renderTiles(data, color);
+    this.entries.set(trackId, { data, tiles });
+  }
+
   getEntry(trackId: string): TrackSpectrogramEntry | undefined {
     return this.entries.get(trackId);
   }

--- a/src/services/__tests__/SpectrogramCache.test.ts
+++ b/src/services/__tests__/SpectrogramCache.test.ts
@@ -268,6 +268,34 @@ describe('getEntry', () => {
   });
 });
 
+describe('restore', () => {
+  it('populates the cache from pre-computed SpectrogramData', async () => {
+    const { renderTiles: mockRenderTiles } = vi.mocked(
+      await import('../SpectrogramTileRenderer'),
+    );
+    const restoredTile = { close: vi.fn() } as unknown as ImageBitmap;
+    mockRenderTiles.mockReturnValue([restoredTile]);
+
+    cache.restore('track-1', MOCK_SPECTROGRAM_DATA, COLOR);
+
+    const entry = cache.getEntry('track-1');
+    expect(entry).toBeDefined();
+    expect(entry!.data).toBe(MOCK_SPECTROGRAM_DATA);
+    expect(entry!.tiles).toEqual([restoredTile]);
+  });
+
+  it('renders tiles from data without running analysis', async () => {
+    const { renderTiles: mockRenderTiles } = vi.mocked(
+      await import('../SpectrogramTileRenderer'),
+    );
+    mockRenderTiles.mockReturnValue([]);
+
+    cache.restore('track-1', MOCK_SPECTROGRAM_DATA, COLOR);
+
+    expect(mockRenderTiles).toHaveBeenCalledWith(MOCK_SPECTROGRAM_DATA, COLOR);
+  });
+});
+
 describe('invalidate', () => {
   it('removes the entry for the given track', async () => {
     const promise = cache.analyse('track-1', mockAudioBuffer(), COLOR);


### PR DESCRIPTION
## Summary
- Cache computed spectrogram data in IndexedDB to avoid expensive FFT recomputation on project reload
- Add `SpectrogramCache.restore()` method that re-renders tiles from stored frequency data without running analysis
- `useSpectrogramCache` now checks IndexedDB before triggering analysis; on cache hit, restores directly; on miss, analyses then persists for next time
- Track deletion now cleans up spectrogram data alongside audio data from IndexedDB

## Test plan
- [x] Verify `SpectrogramCache.restore()` populates cache and renders tiles without analysis (2 new tests)
- [x] Verify `toSpectrogramStoreData`/`fromSpectrogramStoreData` round-trip without data loss (4 new tests)
- [x] Verify `useSpectrogramCache` returns cached entry from IndexedDB, skipping analysis
- [x] Verify `useSpectrogramCache` runs analysis and saves to IndexedDB when no cached data exists
- [x] Verify `useDeleteTrackAudio` deletes spectrogram data when a track is removed
- [x] All 772 tests pass, ESLint clean, production build succeeds

https://claude.ai/code/session_01BjmDcvQJkPVVQ2KVWmM8kw