### PR TITLE
Redesign home page as project browser

### DIFF
--- a/src/components/home/EmptyProjectList.tsx
+++ b/src/components/home/EmptyProjectList.tsx
@@ -1,0 +1,21 @@
+import { Button, Typography } from 'antd';
+
+const { Title, Text } = Typography;
+
+type EmptyProjectListProps = {
+  onCreate: () => void;
+};
+
+const EmptyProjectList = ({ onCreate }: EmptyProjectListProps) => {
+  return (
+    <>
+      <Title>Mawimbi</Title>
+      <Text type="secondary">No projects yet. Create one to get started.</Text>
+      <Button type="primary" size="large" onClick={onCreate}>
+        Create Project
+      </Button>
+    </>
+  );
+};
+
+export default EmptyProjectList;

--- a/src/components/home/HomePage.css
+++ b/src/components/home/HomePage.css
@@ -4,4 +4,27 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 24px;
+  padding: 24px;
+}
+
+.home__project-list {
+  width: 100%;
+  max-width: 640px;
+}
+
+.home__project-list .ant-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.home__project-item {
+  cursor: pointer;
+}
+
+.home__project-info {
+  display: flex;
+  gap: 16px;
+  align-items: center;
 }

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,28 +1,93 @@
-import { Button, Typography } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  deleteProject,
+  getStorageEstimate,
+  listProjects,
+  type StoredProject,
+} from '../../services/ProjectStorageService';
 import { PageContent, PageLayout } from '../layout/PageLayout';
+import EmptyProjectList from './EmptyProjectList';
+import ProjectList from './ProjectList';
+import StorageUsage from './StorageUsage';
 import './HomePage.css';
+
+export type StorageInfo = {
+  usage: number | undefined;
+  quota: number | undefined;
+};
 
 const HomePage = () => {
   const navigate = useNavigate();
+  const [projects, setProjects] = useState<StoredProject[]>([]);
+  const [storage, setStorage] = useState<StorageInfo>({
+    usage: undefined,
+    quota: undefined,
+  });
+  const [isLoading, setIsLoading] = useState(true);
 
-  function handleClick() {
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  async function loadData() {
+    const [projectList, estimate] = await Promise.all([
+      listProjects(),
+      getStorageEstimate(),
+    ]);
+    setProjects(projectList);
+    setStorage({ usage: estimate.usage, quota: estimate.quota });
+    setIsLoading(false);
+  }
+
+  function handleCreate() {
     const id = crypto.randomUUID();
     navigate(`/project/${id}`);
   }
 
-  const { Title, Text } = Typography;
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await deleteProject(id);
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+      const estimate = await getStorageEstimate();
+      setStorage({ usage: estimate.usage, quota: estimate.quota });
+    },
+    [setProjects],
+  );
+
+  function handleOpen(id: string) {
+    navigate(`/project/${id}`);
+  }
+
+  if (isLoading) {
+    return (
+      <PageLayout>
+        <PageContent>
+          <div className="home" />
+        </PageContent>
+      </PageLayout>
+    );
+  }
+
+  const hasProjects = projects.length > 0;
 
   return (
     <PageLayout>
       <PageContent>
         <div className="home">
-          <Title>Mawimbi</Title>
-          <Text>
-            <Button type="primary" size="large" onClick={handleClick}>
-              Create Project
-            </Button>
-          </Text>
+          {hasProjects ? (
+            <ProjectList
+              projects={projects}
+              onOpen={handleOpen}
+              onCreate={handleCreate}
+              onDelete={handleDelete}
+            />
+          ) : (
+            <EmptyProjectList onCreate={handleCreate} />
+          )}
+          {hasProjects && (
+            <StorageUsage usage={storage.usage} quota={storage.quota} />
+          )}
         </div>
       </PageContent>
     </PageLayout>

--- a/src/components/home/ProjectList.tsx
+++ b/src/components/home/ProjectList.tsx
@@ -1,0 +1,82 @@
+import { Button, List, Popconfirm, Typography } from 'antd';
+import { type StoredProject } from '../../services/ProjectStorageService';
+import { formatRelativeTime } from './formatRelativeTime';
+
+const { Text } = Typography;
+
+type ProjectListProps = {
+  projects: StoredProject[];
+  onOpen: (id: string) => void;
+  onCreate: () => void;
+  onDelete: (id: string) => void;
+};
+
+const ProjectList = ({
+  projects,
+  onOpen,
+  onCreate,
+  onDelete,
+}: ProjectListProps) => {
+  return (
+    <div className="home__project-list">
+      <List
+        header={
+          <>
+            <Text strong>Projects</Text>
+            <Button type="primary" onClick={onCreate}>
+              New Project
+            </Button>
+          </>
+        }
+        dataSource={projects}
+        renderItem={(project) => (
+          <List.Item
+            className="home__project-item"
+            onClick={() => onOpen(project.id)}
+            actions={[
+              <Popconfirm
+                key="delete"
+                title="Delete project?"
+                description="This will permanently remove the project and all its audio data."
+                onConfirm={(e) => {
+                  e?.stopPropagation();
+                  onDelete(project.id);
+                }}
+                onCancel={(e) => e?.stopPropagation()}
+                okText="Delete"
+                cancelText="Cancel"
+                okButtonProps={{ danger: true }}
+              >
+                <Button
+                  type="text"
+                  danger
+                  size="small"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Delete
+                </Button>
+              </Popconfirm>,
+            ]}
+          >
+            <List.Item.Meta
+              title={project.title}
+              description={
+                <div className="home__project-info">
+                  <Text type="secondary">
+                    {project.tracks.length}{' '}
+                    {project.tracks.length === 1 ? 'track' : 'tracks'}
+                  </Text>
+                  <Text type="secondary">
+                    {formatRelativeTime(project.updatedAt)}
+                  </Text>
+                </div>
+              }
+            />
+          </List.Item>
+        )}
+      />
+    </div>
+  );
+};
+
+export default ProjectList;

--- a/src/components/home/StorageUsage.tsx
+++ b/src/components/home/StorageUsage.tsx
@@ -1,0 +1,30 @@
+import { Progress, Typography } from 'antd';
+import { formatBytes } from './formatBytes';
+
+const { Text } = Typography;
+
+type StorageUsageProps = {
+  usage: number | undefined;
+  quota: number | undefined;
+};
+
+const StorageUsage = ({ usage, quota }: StorageUsageProps) => {
+  if (usage === undefined || quota === undefined) return null;
+
+  const percent = quota > 0 ? (usage / quota) * 100 : 0;
+
+  return (
+    <div className="home__project-list">
+      <Text type="secondary">
+        Using {formatBytes(usage)} of {formatBytes(quota)}
+      </Text>
+      <Progress
+        percent={Number(percent.toFixed(1))}
+        size="small"
+        showInfo={false}
+      />
+    </div>
+  );
+};
+
+export default StorageUsage;

--- a/src/components/home/__tests__/HomePage.test.tsx
+++ b/src/components/home/__tests__/HomePage.test.tsx
@@ -1,14 +1,117 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useNavigate } from 'react-router-dom';
+import { beforeAll, vi } from 'vitest';
+import type { StoredProject } from '../../../services/ProjectStorageService';
 import HomePage from '../HomePage';
 
-it('navigates to project page with UUID on create', () => {
-  const { getByText } = render(<HomePage />);
+// Ant Design List uses responsive breakpoints via window.matchMedia
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
-  const buttonElement = getByText('Create Project');
-  expect(buttonElement).toBeInTheDocument();
+const { mockListProjects, mockDeleteProject, mockGetStorageEstimate } =
+  vi.hoisted(() => ({
+    mockListProjects: vi.fn(),
+    mockDeleteProject: vi.fn(),
+    mockGetStorageEstimate: vi.fn(),
+  }));
 
-  fireEvent.click(buttonElement);
+vi.mock('../../../services/ProjectStorageService', () => ({
+  listProjects: mockListProjects,
+  deleteProject: mockDeleteProject,
+  getStorageEstimate: mockGetStorageEstimate,
+}));
+
+const PROJECT_A: StoredProject = {
+  id: 'project-a',
+  title: 'My Song',
+  tracks: [
+    {
+      trackId: 'track-1',
+      color: { r: 77, g: 238, b: 234 },
+      fileName: 'drums.wav',
+      index: 0,
+    },
+    {
+      trackId: 'track-2',
+      color: { r: 116, g: 238, b: 21 },
+      fileName: 'bass.wav',
+      index: 1,
+    },
+  ],
+  nextColorId: 2,
+  nextIndex: 2,
+  createdAt: Date.now() - 3_600_000,
+  updatedAt: Date.now() - 60_000,
+};
+
+const PROJECT_B: StoredProject = {
+  id: 'project-b',
+  title: 'Demo',
+  tracks: [],
+  nextColorId: 0,
+  nextIndex: 0,
+  createdAt: Date.now() - 86_400_000,
+  updatedAt: Date.now() - 86_400_000,
+};
+
+function setupMocks(
+  projects: StoredProject[] = [],
+  estimate: StorageEstimate = { usage: 1024, quota: 1073741824 },
+) {
+  mockListProjects.mockResolvedValue(projects);
+  mockDeleteProject.mockResolvedValue(undefined);
+  mockGetStorageEstimate.mockResolvedValue(estimate);
+}
+
+it('shows empty state when no projects exist', async () => {
+  setupMocks([]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Mawimbi')).toBeInTheDocument();
+  });
+  expect(
+    screen.getByText('No projects yet. Create one to get started.'),
+  ).toBeInTheDocument();
+  expect(screen.getByText('Create Project')).toBeInTheDocument();
+});
+
+it('renders project list with track count and relative time', async () => {
+  setupMocks([PROJECT_A, PROJECT_B]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('My Song')).toBeInTheDocument();
+  });
+  expect(screen.getByText('Demo')).toBeInTheDocument();
+  expect(screen.getByText('2 tracks')).toBeInTheDocument();
+  expect(screen.getByText('0 tracks')).toBeInTheDocument();
+  expect(screen.getByText('1 minute ago')).toBeInTheDocument();
+  expect(screen.getByText('1 day ago')).toBeInTheDocument();
+});
+
+it('navigates to new project with UUID on create', async () => {
+  setupMocks([PROJECT_A]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('New Project')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText('New Project'));
 
   const navigate = useNavigate();
   expect(navigate).toHaveBeenCalledWith(
@@ -16,4 +119,89 @@ it('navigates to project page with UUID on create', () => {
       /^\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     ),
   );
+});
+
+it('navigates to new project from empty state', async () => {
+  setupMocks([]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Create Project')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText('Create Project'));
+
+  const navigate = useNavigate();
+  expect(navigate).toHaveBeenCalledWith(
+    expect.stringMatching(
+      /^\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    ),
+  );
+});
+
+it('opens a project on click', async () => {
+  setupMocks([PROJECT_A]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('My Song')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByText('My Song'));
+
+  const navigate = useNavigate();
+  expect(navigate).toHaveBeenCalledWith('/project/project-a');
+});
+
+it('deletes a project after confirmation', async () => {
+  setupMocks([PROJECT_A, PROJECT_B]);
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('My Song')).toBeInTheDocument();
+  });
+
+  const deleteButtons = screen.getAllByText('Delete');
+  fireEvent.click(deleteButtons[0]);
+
+  // Popconfirm should appear
+  await waitFor(() => {
+    expect(screen.getByText('Delete project?')).toBeInTheDocument();
+  });
+
+  // Confirm via the OK button in Popconfirm (the danger primary button)
+  const confirmButtons = screen.getAllByRole('button', { name: 'Delete' });
+  const confirmButton = confirmButtons.find((btn) =>
+    btn.classList.contains('ant-btn-primary'),
+  )!;
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(mockDeleteProject).toHaveBeenCalledWith('project-a');
+  });
+
+  // Project should be removed from the list
+  await waitFor(() => {
+    expect(screen.queryByText('My Song')).not.toBeInTheDocument();
+  });
+});
+
+it('displays storage usage when projects exist', async () => {
+  setupMocks([PROJECT_A], { usage: 47185920, quota: 2147483648 });
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Using 45.0 MB of 2.0 GB')).toBeInTheDocument();
+  });
+});
+
+it('hides storage usage when no projects exist', async () => {
+  setupMocks([], { usage: 0, quota: 2147483648 });
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Create Project')).toBeInTheDocument();
+  });
+
+  expect(screen.queryByText(/Using/)).not.toBeInTheDocument();
 });

--- a/src/components/home/__tests__/formatBytes.test.ts
+++ b/src/components/home/__tests__/formatBytes.test.ts
@@ -1,0 +1,24 @@
+import { formatBytes } from '../formatBytes';
+
+it('formats zero bytes', () => {
+  expect(formatBytes(0)).toBe('0 B');
+});
+
+it('formats bytes', () => {
+  expect(formatBytes(512)).toBe('512 B');
+});
+
+it('formats kilobytes', () => {
+  expect(formatBytes(1024)).toBe('1.0 KB');
+  expect(formatBytes(1536)).toBe('1.5 KB');
+});
+
+it('formats megabytes', () => {
+  expect(formatBytes(1048576)).toBe('1.0 MB');
+  expect(formatBytes(47185920)).toBe('45.0 MB');
+});
+
+it('formats gigabytes', () => {
+  expect(formatBytes(1073741824)).toBe('1.0 GB');
+  expect(formatBytes(2147483648)).toBe('2.0 GB');
+});

--- a/src/components/home/__tests__/formatRelativeTime.test.ts
+++ b/src/components/home/__tests__/formatRelativeTime.test.ts
@@ -1,0 +1,20 @@
+import { formatRelativeTime } from '../formatRelativeTime';
+
+it('formats timestamps less than a minute ago', () => {
+  expect(formatRelativeTime(Date.now() - 30_000)).toBe('just now');
+});
+
+it('formats timestamps in minutes', () => {
+  expect(formatRelativeTime(Date.now() - 60_000)).toBe('1 minute ago');
+  expect(formatRelativeTime(Date.now() - 300_000)).toBe('5 minutes ago');
+});
+
+it('formats timestamps in hours', () => {
+  expect(formatRelativeTime(Date.now() - 3_600_000)).toBe('1 hour ago');
+  expect(formatRelativeTime(Date.now() - 7_200_000)).toBe('2 hours ago');
+});
+
+it('formats timestamps in days', () => {
+  expect(formatRelativeTime(Date.now() - 86_400_000)).toBe('1 day ago');
+  expect(formatRelativeTime(Date.now() - 259_200_000)).toBe('3 days ago');
+});

--- a/src/components/home/formatBytes.ts
+++ b/src/components/home/formatBytes.ts
@@ -1,0 +1,17 @@
+const UNITS = ['B', 'KB', 'MB', 'GB'];
+const STEP = 1024;
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+
+  let unitIndex = 0;
+  let value = bytes;
+
+  while (value >= STEP && unitIndex < UNITS.length - 1) {
+    value /= STEP;
+    unitIndex++;
+  }
+
+  const formatted = unitIndex === 0 ? value.toString() : value.toFixed(1);
+  return `${formatted} ${UNITS[unitIndex]}`;
+}

--- a/src/components/home/formatRelativeTime.ts
+++ b/src/components/home/formatRelativeTime.ts
@@ -1,0 +1,20 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 86_400_000;
+
+export function formatRelativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+
+  if (diff < MINUTE_MS) return 'just now';
+  if (diff < HOUR_MS) {
+    const minutes = Math.floor(diff / MINUTE_MS);
+    return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`;
+  }
+  if (diff < DAY_MS) {
+    const hours = Math.floor(diff / HOUR_MS);
+    return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
+  }
+
+  const days = Math.floor(diff / DAY_MS);
+  return `${days} ${days === 1 ? 'day' : 'days'} ago`;
+}


### PR DESCRIPTION
## Summary
- Replace the simple landing page with a project browser that lists stored projects from IndexedDB
- Each project shows title, track count, and relative last-modified time
- Support project deletion with Popconfirm dialog, cascading removal of audio and spectrogram data
- Display storage usage (used / quota) via the Storage Manager API when projects exist
- Empty state preserves the original "Create Project" experience with contextual messaging
- Extract reusable components: `ProjectList`, `EmptyProjectList`, `StorageUsage`
- Extract utility functions: `formatBytes`, `formatRelativeTime`

## Test plan
- [x] 17 new/updated tests: 8 for HomePage (empty state, project list rendering, navigation, delete confirmation, storage display), 5 for formatBytes, 4 for formatRelativeTime
- [x] All 788 tests pass
- [x] ESLint clean
- [x] Production build succeeds

https://claude.ai/code/session_019H2d1dCUK8zqa7JJvwVnYN