### PR TITLE
Fix header: back button, editable project name, overflow menu

### DIFF
--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -8,7 +8,7 @@ test.describe('Project page', () => {
   test.describe('header', () => {
     test('displays a back button', async ({ page }) => {
       await expect(
-        page.getByRole('button', { name: 'Back', exact: true })
+        page.getByRole('link', { name: 'Back', exact: true })
       ).toBeVisible();
     });
 
@@ -19,7 +19,7 @@ test.describe('Project page', () => {
       await expect(page).toHaveURL(
         /\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
       );
-      await page.getByRole('button', { name: 'Back', exact: true }).click();
+      await page.getByRole('link', { name: 'Back', exact: true }).click();
       await expect(page).toHaveURL('/');
     });
 

--- a/src/components/project/ProjectPage.tsx
+++ b/src/components/project/ProjectPage.tsx
@@ -12,7 +12,11 @@ import {
   useTrackSideEffects,
   useUploadFile,
 } from './projectPageEffects';
-import { COLOR_PALETTE, type ProjectState } from './projectPageReducer';
+import {
+  COLOR_PALETTE,
+  RENAME_PROJECT,
+  type ProjectState,
+} from './projectPageReducer';
 import ProjectPageHeader from './ProjectPageHeader';
 import { ProjectDispatch } from './useProjectDispatch';
 import useProjectReducer from './useProjectReducer';
@@ -62,6 +66,7 @@ const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
               redo={undoControls.redo}
               canUndo={undoControls.canUndo}
               canRedo={undoControls.canRedo}
+              renameProject={(title) => dispatch([RENAME_PROJECT, { title }])}
             />
           </PageHeader>
           <PageContent>

--- a/src/components/project/ProjectPageHeader.css
+++ b/src/components/project/ProjectPageHeader.css
@@ -14,6 +14,13 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.back-link {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .project-page-header__extra {

--- a/src/components/project/ProjectPageHeader.tsx
+++ b/src/components/project/ProjectPageHeader.tsx
@@ -5,9 +5,10 @@ import {
   UndoOutlined,
   UploadOutlined,
 } from '@ant-design/icons';
-import { Button, Dropdown, Typography, Upload } from 'antd';
+import { Button, Dropdown, Input, Modal, Typography, Upload } from 'antd';
 import type { MenuProps, UploadProps } from 'antd';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import './ProjectPageHeader.css';
 
 type ProjectPageHeaderProps = {
@@ -19,23 +20,61 @@ type ProjectPageHeaderProps = {
   redo: () => void;
   canUndo: boolean;
   canRedo: boolean;
+  renameProject: (title: string) => void;
 };
 
 const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
-  const navigate = useNavigate();
+  const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState(props.title);
+
+  const openRenameModal = () => {
+    setNewTitle(props.title);
+    setIsRenameModalOpen(true);
+  };
+
+  const handleRename = () => {
+    const trimmed = newTitle.trim();
+    if (trimmed) {
+      props.renameProject(trimmed);
+    }
+    setIsRenameModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsRenameModalOpen(false);
+  };
 
   return (
     <div className="project-page-header">
-      <Button
-        type="link"
-        className="button back-button"
-        icon={<ArrowLeftOutlined />}
-        aria-label="Back"
-        onClick={() => navigate(-1)}
-      />
-      <Typography.Title level={4} className="project-page-header__title">
+      <Link to="/" className="back-link" aria-label="Back">
+        <Button
+          type="link"
+          className="button back-button"
+          icon={<ArrowLeftOutlined />}
+          tabIndex={-1}
+        />
+      </Link>
+      <Typography.Title
+        level={4}
+        className="project-page-header__title"
+        onClick={openRenameModal}
+      >
         {props.title}
       </Typography.Title>
+      <Modal
+        title="Rename project"
+        open={isRenameModalOpen}
+        onOk={handleRename}
+        onCancel={handleCancel}
+        okText="Update"
+      >
+        <Input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          onPressEnter={handleRename}
+          autoFocus
+        />
+      </Modal>
       <div className="project-page-header__extra">
         <Button
           type="link"
@@ -108,9 +147,13 @@ const OverflowMenu = (props: OverflowMenuProps) => {
 
   return (
     <Dropdown menu={{ items }} trigger={['click']}>
-      <Button type="link" className="button overflow-button">
-        <EllipsisOutlined />
-      </Button>
+      <Button
+        type="link"
+        className="button overflow-button"
+        icon={<EllipsisOutlined />}
+        aria-label="More"
+        onClick={(e) => e.stopPropagation()}
+      />
     </Dropdown>
   );
 };

--- a/src/components/project/__tests__/ProjectPageHeader.test.tsx
+++ b/src/components/project/__tests__/ProjectPageHeader.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render } from '@testing-library/react';
-import { useNavigate } from 'react-router-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import ProjectPageHeader from '../ProjectPageHeader';
 
 const mockUploadFile = vi.fn();
+const mockRenameProject = vi.fn();
 
 const mockUndo = vi.fn();
 const mockRedo = vi.fn();
@@ -17,30 +18,37 @@ const defaultProps = {
   redo: mockRedo,
   canUndo: false,
   canRedo: false,
+  renameProject: mockRenameProject,
 };
 
+const renderHeader = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <ProjectPageHeader {...defaultProps} {...props} />
+    </MemoryRouter>,
+  );
+
 it('renders without crashing', () => {
-  render(<ProjectPageHeader {...defaultProps} />);
+  renderHeader();
 });
 
 it('renders project title', () => {
-  const { getByText } = render(<ProjectPageHeader {...defaultProps} />);
+  const { getByText } = renderHeader();
 
   expect(getByText(defaultProps.title)).toBeInTheDocument();
 });
 
-it('navigates back from project page', () => {
-  const { container } = render(<ProjectPageHeader {...defaultProps} />);
+it('back button links to home page', () => {
+  const { container } = renderHeader();
 
-  const backButton = container.querySelector('[aria-label="Back"]');
-  fireEvent.click(backButton as Element);
+  const backLink = container.querySelector('a[href="/"]');
 
-  const navigate = useNavigate();
-  expect(navigate).toHaveBeenCalledWith(-1);
+  expect(backLink).toBeInTheDocument();
+  expect(backLink).toHaveAttribute('aria-label', 'Back');
 });
 
 it('accepts multiple audio files for upload', () => {
-  const { container } = render(<ProjectPageHeader {...defaultProps} />);
+  const { container } = renderHeader();
 
   const fileInput = container.querySelector('input[type="file"]');
 
@@ -50,7 +58,7 @@ it('accepts multiple audio files for upload', () => {
 });
 
 it('renders undo and redo buttons', () => {
-  const { container } = render(<ProjectPageHeader {...defaultProps} />);
+  const { container } = renderHeader();
 
   const undoButton = container.querySelector('[aria-label="Undo"]');
   const redoButton = container.querySelector('[aria-label="Redo"]');
@@ -60,27 +68,21 @@ it('renders undo and redo buttons', () => {
 });
 
 it('disables undo button when canUndo is false', () => {
-  const { container } = render(
-    <ProjectPageHeader {...defaultProps} canUndo={false} />,
-  );
+  const { container } = renderHeader({ canUndo: false });
 
   const undoButton = container.querySelector('[aria-label="Undo"]');
   expect(undoButton).toBeDisabled();
 });
 
 it('disables redo button when canRedo is false', () => {
-  const { container } = render(
-    <ProjectPageHeader {...defaultProps} canRedo={false} />,
-  );
+  const { container } = renderHeader({ canRedo: false });
 
   const redoButton = container.querySelector('[aria-label="Redo"]');
   expect(redoButton).toBeDisabled();
 });
 
 it('calls undo when undo button is clicked', () => {
-  const { container } = render(
-    <ProjectPageHeader {...defaultProps} canUndo={true} />,
-  );
+  const { container } = renderHeader({ canUndo: true });
 
   const undoButton = container.querySelector('[aria-label="Undo"]');
   fireEvent.click(undoButton as Element);
@@ -89,9 +91,7 @@ it('calls undo when undo button is clicked', () => {
 });
 
 it('calls redo when redo button is clicked', () => {
-  const { container } = render(
-    <ProjectPageHeader {...defaultProps} canRedo={true} />,
-  );
+  const { container } = renderHeader({ canRedo: true });
 
   const redoButton = container.querySelector('[aria-label="Redo"]');
   fireEvent.click(redoButton as Element);
@@ -100,7 +100,7 @@ it('calls redo when redo button is clicked', () => {
 });
 
 it('renders undo and redo buttons before the upload button', () => {
-  const { container } = render(<ProjectPageHeader {...defaultProps} />);
+  const { container } = renderHeader();
 
   const extra = container.querySelector('.project-page-header__extra');
   const buttons = extra?.querySelectorAll('button');
@@ -109,4 +109,57 @@ it('renders undo and redo buttons before the upload button', () => {
   expect(buttons).toBeDefined();
   expect(buttons![0]).toHaveAttribute('aria-label', 'Undo');
   expect(buttons![1]).toHaveAttribute('aria-label', 'Redo');
+});
+
+it('opens rename modal when title is clicked', () => {
+  renderHeader();
+
+  const title = screen.getByText(defaultProps.title);
+  fireEvent.click(title);
+
+  expect(screen.getByText('Rename project')).toBeInTheDocument();
+  expect(screen.getByRole('textbox')).toHaveValue(defaultProps.title);
+});
+
+it('calls renameProject with new title when Update is clicked', () => {
+  renderHeader();
+
+  fireEvent.click(screen.getByText(defaultProps.title));
+
+  const input = screen.getByRole('textbox');
+  fireEvent.change(input, { target: { value: 'New Name' } });
+
+  const modal = screen.getByRole('dialog');
+  const updateButton = within(modal).getByText('Update');
+  fireEvent.click(updateButton);
+
+  expect(mockRenameProject).toHaveBeenCalledWith('New Name');
+});
+
+it('does not rename when title is empty', () => {
+  renderHeader();
+
+  fireEvent.click(screen.getByText(defaultProps.title));
+
+  const input = screen.getByRole('textbox');
+  fireEvent.change(input, { target: { value: '   ' } });
+
+  const modal = screen.getByRole('dialog');
+  const updateButton = within(modal).getByText('Update');
+  fireEvent.click(updateButton);
+
+  expect(mockRenameProject).not.toHaveBeenCalled();
+});
+
+it('closes rename modal when Cancel is clicked', () => {
+  renderHeader();
+
+  fireEvent.click(screen.getByText(defaultProps.title));
+  expect(screen.getByText('Rename project')).toBeInTheDocument();
+
+  const modal = screen.getByRole('dialog');
+  const cancelButton = within(modal).getByText('Cancel');
+  fireEvent.click(cancelButton);
+
+  expect(mockRenameProject).not.toHaveBeenCalled();
 });

--- a/src/components/project/__tests__/projectPageReducer.test.ts
+++ b/src/components/project/__tests__/projectPageReducer.test.ts
@@ -4,6 +4,7 @@ import {
   COLOR_PALETTE,
   DELETE_TRACK,
   MOVE_TRACK,
+  RENAME_PROJECT,
   ProjectAction,
   projectReducer,
   ProjectState,
@@ -151,6 +152,15 @@ describe('reverseProjectAction', () => {
     expect(reverse).toEqual([MOVE_TRACK, { fromIndex: 2, toIndex: 0 }]);
   });
 
+  it('returns null for RENAME_PROJECT', () => {
+    const state = createState();
+    const action: ProjectAction = [RENAME_PROJECT, { title: 'New Title' }];
+
+    const reverse = reverseProjectAction(state, action);
+
+    expect(reverse).toBeNull();
+  });
+
   it('returns null for unknown actions', () => {
     const state = createState();
     const action = ['UNKNOWN_ACTION'] as unknown as ProjectAction;
@@ -158,5 +168,31 @@ describe('reverseProjectAction', () => {
     const reverse = reverseProjectAction(state, action);
 
     expect(reverse).toBeNull();
+  });
+});
+
+describe('RENAME_PROJECT', () => {
+  it('updates the project title', () => {
+    const state = createState([track1]);
+
+    const result = projectReducer(state, [
+      RENAME_PROJECT,
+      { title: 'New Title' },
+    ]);
+
+    expect(result.title).toBe('New Title');
+  });
+
+  it('preserves tracks and other state', () => {
+    const state = createState([track1, track2]);
+
+    const result = projectReducer(state, [
+      RENAME_PROJECT,
+      { title: 'New Title' },
+    ]);
+
+    expect(result.tracks).toEqual(state.tracks);
+    expect(result.nextColorId).toBe(state.nextColorId);
+    expect(result.nextIndex).toBe(state.nextIndex);
   });
 });

--- a/src/components/project/projectPageReducer.ts
+++ b/src/components/project/projectPageReducer.ts
@@ -26,10 +26,15 @@ type MoveTrackPayload = {
   toIndex: number;
 };
 
+type RenameProjectPayload = {
+  title: string;
+};
+
 export type ProjectAction =
   | [typeof ADD_TRACK, AddTrackPayload]
   | [typeof DELETE_TRACK, DeleteTrackPayload]
-  | [typeof MOVE_TRACK, MoveTrackPayload];
+  | [typeof MOVE_TRACK, MoveTrackPayload]
+  | [typeof RENAME_PROJECT, RenameProjectPayload];
 
 export const COLOR_PALETTE: TrackColor[] = [
   { r: 77, g: 238, b: 234 },
@@ -42,6 +47,7 @@ export const COLOR_PALETTE: TrackColor[] = [
 export const ADD_TRACK = 'ADD_TRACK';
 export const DELETE_TRACK = 'DELETE_TRACK';
 export const MOVE_TRACK = 'MOVE_TRACK';
+export const RENAME_PROJECT = 'RENAME_PROJECT';
 
 export function projectReducer(
   state: ProjectState,
@@ -54,6 +60,8 @@ export function projectReducer(
       return deleteTrack(state, action[1]);
     case MOVE_TRACK:
       return { ...state, tracks: moveTrack(state.tracks, action[1]) };
+    case RENAME_PROJECT:
+      return { ...state, title: action[1].title };
     default:
       throw new Error();
   }
@@ -76,6 +84,8 @@ export function reverseProjectAction(
         MOVE_TRACK,
         { fromIndex: action[1].toIndex, toIndex: action[1].fromIndex },
       ];
+    case RENAME_PROJECT:
+      return null;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- **Back button** now uses `<Link to="/">` instead of `navigate(-1)`, always returning to the home page regardless of browser history
- **Editable project name**: clicking the title opens a modal dialog with a text field and Update/Cancel buttons. Dispatches `RENAME_PROJECT` action (non-undoable, auto-saved)
- **Overflow menu** fixed by using the `icon` prop and `stopPropagation` on the trigger button to work correctly with Ant Design v5's Dropdown

## Test plan
- [x] Existing tests updated and passing (44/44)
- [x] New tests: rename modal open/close, rename with valid/empty title, back button link target
- [x] Lint and type check pass
- [ ] Manual: verify back button navigates to home page
- [ ] Manual: verify clicking title opens rename modal, Update saves, Cancel dismisses
- [ ] Manual: verify overflow menu opens and fullscreen toggle works

https://claude.ai/code/session_01YS3TsAdDWJSZaQwhsVfvcF