### PR TITLE
Use eighth note icon as fallback for instrument classification

### DIFF
--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -7,6 +7,7 @@ import {
 import { Button, Slider } from 'antd';
 import classNames from 'classnames';
 import { useClassificationService } from '../../hooks/useClassificationService';
+import { FALLBACK_LABEL } from '../../services/instrumentLabels';
 import { type Track } from '../../types/track';
 import './Channel.css';
 import { getInstrumentIcon } from './instrumentIcons';
@@ -37,7 +38,10 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
   const { getClassification, getClassificationState, downloadProgress } =
     useClassificationService();
   const classificationState = getClassificationState(trackId);
-  const instrument = getClassification(trackId)?.label ?? track.instrument;
+  const instrument =
+    getClassification(trackId)?.label ??
+    track.instrument ??
+    (classificationState === 'error' ? FALLBACK_LABEL : undefined);
   const isDownloading =
     classificationState === 'classifying' && downloadProgress !== null;
 

--- a/src/components/workstation/__tests__/instrumentIcons.test.tsx
+++ b/src/components/workstation/__tests__/instrumentIcons.test.tsx
@@ -14,6 +14,7 @@ const ALL_LABELS: InstrumentLabel[] = [
   'woodwind',
   'synth',
   'percussion',
+  'unknown',
 ];
 
 it.each(ALL_LABELS)('returns an icon for "%s"', (label) => {

--- a/src/components/workstation/instrumentIcons.tsx
+++ b/src/components/workstation/instrumentIcons.tsx
@@ -24,15 +24,14 @@ const INSTRUMENT_ICONS: Record<InstrumentLabel, React.ComponentType> = {
   woodwind: WoodwindSvg,
   synth: SynthSvg,
   percussion: PercussionSvg,
+  unknown: UnknownSvg,
 };
-
-const FALLBACK_ICON = UnknownSvg;
 
 export function getInstrumentIcon(label: string | undefined): React.ReactNode {
   const SvgComponent =
     label && label in INSTRUMENT_ICONS
       ? INSTRUMENT_ICONS[label as InstrumentLabel]
-      : FALLBACK_ICON;
+      : INSTRUMENT_ICONS.unknown;
 
   return <Icon component={SvgComponent} />;
 }

--- a/src/services/__tests__/instrumentLabels.test.ts
+++ b/src/services/__tests__/instrumentLabels.test.ts
@@ -35,7 +35,7 @@ describe('mapToInstrumentLabel', () => {
     expect(mapToInstrumentLabel(candidateLabel)).toBe(expected);
   });
 
-  it('falls back to percussion for unrecognised labels', () => {
-    expect(mapToInstrumentLabel('unknown label')).toBe('percussion');
+  it('falls back to unknown for unrecognised labels', () => {
+    expect(mapToInstrumentLabel('unknown label')).toBe('unknown');
   });
 });

--- a/src/services/instrumentLabels.ts
+++ b/src/services/instrumentLabels.ts
@@ -14,7 +14,10 @@ export type InstrumentLabel =
   | 'brass'
   | 'woodwind'
   | 'synth'
-  | 'percussion';
+  | 'percussion'
+  | 'unknown';
+
+export const FALLBACK_LABEL: InstrumentLabel = 'unknown';
 
 // Candidate label text → InstrumentLabel.
 // These phrases are passed to CLAP as the candidate set. CLAP returns the
@@ -39,9 +42,9 @@ export const CANDIDATE_LABELS = Object.keys(CANDIDATE_TO_INSTRUMENT);
 
 /**
  * Maps a CLAP candidate label to the corresponding InstrumentLabel.
- * Returns 'percussion' for any unrecognised label (shouldn't happen
+ * Returns 'unknown' for any unrecognised label (shouldn't happen
  * since CLAP always returns one of the provided candidates).
  */
 export function mapToInstrumentLabel(candidateLabel: string): InstrumentLabel {
-  return CANDIDATE_TO_INSTRUMENT[candidateLabel] ?? 'percussion';
+  return CANDIDATE_TO_INSTRUMENT[candidateLabel] ?? FALLBACK_LABEL;
 }


### PR DESCRIPTION
## Summary
- Added `'unknown'` to the `InstrumentLabel` type with exported `FALLBACK_LABEL` constant
- `mapToInstrumentLabel()` now falls back to `'unknown'` instead of `'percussion'` for unrecognized labels
- `INSTRUMENT_ICONS` record includes `unknown` mapped to the eighth note SVG, replacing the separate `FALLBACK_ICON` constant
- `Channel.tsx` shows the fallback eighth note icon when classification errors out, instead of showing nothing

## Test plan
- [x] `instrumentLabels.test.ts` — verifies fallback returns `'unknown'` for unrecognized labels
- [x] `instrumentIcons.test.tsx` — verifies all 11 labels (including `'unknown'`) render icons
- [x] `Channel.test.tsx` — all 23 existing tests pass with the new fallback logic

https://claude.ai/code/session_01RA9B2Z8p6myDzBpJwDHNBZ