### PR TITLE
Fix e2e tests for back button link change

### DIFF
--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -8,7 +8,7 @@ test.describe('Project page', () => {
   test.describe('header', () => {
     test('displays a back button', async ({ page }) => {
       await expect(
-        page.getByRole('button', { name: 'Back', exact: true })
+        page.getByRole('link', { name: 'Back', exact: true })
       ).toBeVisible();
     });
 
@@ -19,7 +19,7 @@ test.describe('Project page', () => {
       await expect(page).toHaveURL(
         /\/project\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
       );
-      await page.getByRole('button', { name: 'Back', exact: true }).click();
+      await page.getByRole('link', { name: 'Back', exact: true }).click();
       await expect(page).toHaveURL('/');
     });
 


### PR DESCRIPTION
## Summary
- PR #251 changed the back button from a `<Button>` to a `<Link>` wrapping a `<Button>`, moving the `aria-label="Back"` to the anchor element (role `link` instead of `button`)
- Updates two e2e test selectors in `e2e/project.spec.ts` from `getByRole('button', { name: 'Back' })` to `getByRole('link', { name: 'Back' })` to match the new DOM structure

## Test plan
- [ ] e2e tests pass: `displays a back button` and `back button navigates to the home page`
- [ ] All existing unit tests continue to pass (782/782 verified locally)
- [ ] Build succeeds (`npm run build`)

https://claude.ai/code/session_01JMaXDZWwHc6QPFHyBcgFac