### PR TITLE
Use getContainer for rename modal (same pattern as overflow menu)

### DIFF
--- a/src/components/project/ProjectPageHeader.tsx
+++ b/src/components/project/ProjectPageHeader.tsx
@@ -26,23 +26,11 @@ type ProjectPageHeaderProps = {
 const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [newTitle, setNewTitle] = useState(props.title);
-  const [wasFullscreen, setWasFullscreen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const openRenameModal = () => {
     setNewTitle(props.title);
-    if (props.isFullscreen) {
-      props.toggleFullscreen(false);
-      setWasFullscreen(true);
-    }
     setIsRenameModalOpen(true);
-  };
-
-  const closeRenameModal = () => {
-    setIsRenameModalOpen(false);
-    if (wasFullscreen) {
-      props.toggleFullscreen(true);
-      setWasFullscreen(false);
-    }
   };
 
   const handleRename = () => {
@@ -50,15 +38,15 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
     if (trimmed) {
       props.renameProject(trimmed);
     }
-    closeRenameModal();
+    setIsRenameModalOpen(false);
   };
 
   const handleCancel = () => {
-    closeRenameModal();
+    setIsRenameModalOpen(false);
   };
 
   return (
-    <div className="project-page-header">
+    <div className="project-page-header" ref={containerRef}>
       <Link to="/" className="back-link" aria-label="Back">
         <Button
           type="link"
@@ -80,6 +68,7 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
         onOk={handleRename}
         onCancel={handleCancel}
         okText="Update"
+        getContainer={() => containerRef.current!}
       >
         <Input
           value={newTitle}
@@ -109,6 +98,7 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
         <OverflowMenu
           isFullscreen={props.isFullscreen}
           toggleFullscreen={props.toggleFullscreen}
+          getPopupContainer={() => containerRef.current!}
         />
       </div>
     </div>
@@ -145,11 +135,11 @@ const UploadButton = (props: UploadButtonProps) => {
 type OverflowMenuProps = {
   isFullscreen: boolean;
   toggleFullscreen: (state?: boolean) => void;
+  getPopupContainer: () => HTMLElement;
 };
 
 const OverflowMenu = (props: OverflowMenuProps) => {
-  const { isFullscreen, toggleFullscreen } = props;
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { isFullscreen, toggleFullscreen, getPopupContainer } = props;
 
   const items: MenuProps['items'] = [
     {
@@ -160,21 +150,19 @@ const OverflowMenu = (props: OverflowMenuProps) => {
   ];
 
   return (
-    <div ref={containerRef}>
-      <Dropdown
-        menu={{ items }}
-        trigger={['click']}
-        getPopupContainer={() => containerRef.current!}
-      >
-        <Button
-          type="link"
-          className="button overflow-button"
-          icon={<EllipsisOutlined />}
-          aria-label="More"
-          onClick={(e) => e.stopPropagation()}
-        />
-      </Dropdown>
-    </div>
+    <Dropdown
+      menu={{ items }}
+      trigger={['click']}
+      getPopupContainer={getPopupContainer}
+    >
+      <Button
+        type="link"
+        className="button overflow-button"
+        icon={<EllipsisOutlined />}
+        aria-label="More"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </Dropdown>
   );
 };
 

--- a/src/components/project/__tests__/ProjectPageHeader.test.tsx
+++ b/src/components/project/__tests__/ProjectPageHeader.test.tsx
@@ -164,50 +164,13 @@ it('closes rename modal when Cancel is clicked', () => {
   expect(mockRenameProject).not.toHaveBeenCalled();
 });
 
-it('exits fullscreen when rename modal opens', () => {
-  const toggleFullscreen = vi.fn();
-  renderHeader({ isFullscreen: true, toggleFullscreen });
+it('renders rename modal inside its parent container', () => {
+  const { container } = renderHeader();
 
   fireEvent.click(screen.getByText(defaultProps.title));
 
-  expect(toggleFullscreen).toHaveBeenCalledWith(false);
-});
-
-it('does not exit fullscreen when rename modal opens outside fullscreen', () => {
-  const toggleFullscreen = vi.fn();
-  renderHeader({ isFullscreen: false, toggleFullscreen });
-
-  fireEvent.click(screen.getByText(defaultProps.title));
-
-  expect(toggleFullscreen).not.toHaveBeenCalled();
-});
-
-it('re-enters fullscreen when rename modal closes after exiting fullscreen', () => {
-  const toggleFullscreen = vi.fn();
-  renderHeader({ isFullscreen: true, toggleFullscreen });
-
-  fireEvent.click(screen.getByText(defaultProps.title));
-  expect(toggleFullscreen).toHaveBeenCalledWith(false);
-
-  const modal = screen.getByRole('dialog');
-  const updateButton = within(modal).getByText('Update');
-  fireEvent.click(updateButton);
-
-  expect(toggleFullscreen).toHaveBeenCalledWith(true);
-});
-
-it('re-enters fullscreen when rename modal is cancelled after exiting fullscreen', () => {
-  const toggleFullscreen = vi.fn();
-  renderHeader({ isFullscreen: true, toggleFullscreen });
-
-  fireEvent.click(screen.getByText(defaultProps.title));
-  expect(toggleFullscreen).toHaveBeenCalledWith(false);
-
-  const modal = screen.getByRole('dialog');
-  const cancelButton = within(modal).getByText('Cancel');
-  fireEvent.click(cancelButton);
-
-  expect(toggleFullscreen).toHaveBeenCalledWith(true);
+  const modal = container.querySelector('.ant-modal-root');
+  expect(modal).toBeInTheDocument();
 });
 
 it('renders overflow menu popup inside its parent container', () => {


### PR DESCRIPTION
## Summary
- Replaces the fullscreen exit/re-enter approach for the rename modal with `getContainer`, reusing the same pattern as the overflow menu's `getPopupContainer`
- Both popups (Modal and Dropdown) now render inside a shared `containerRef` on the header div, keeping them visible in fullscreen mode
- Removes the wrapper `<div>` around the Dropdown that was causing the header height to increase from 64px to 96px, fixing the e2e visual regression (8 failing e2e tests)

## Test plan
- [x] All 785 unit tests pass
- [x] All 83 e2e tests pass
- [x] Build succeeds
- [x] Lint passes
- [ ] Manual: enter fullscreen, click title to rename — modal should appear inline
- [ ] Manual: enter fullscreen, click overflow menu — dropdown should appear inline

https://claude.ai/code/session_01SUm7yUHBp6hiHqop82WRgS