### PR TITLE
Fix timeline scale factor not updating on fullscreen resize

### DIFF
--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -302,9 +302,7 @@ it('recalculates timeline scale when container resizes with mixer open', () => {
   const observedElements: Element[] = [];
   const OriginalResizeObserver = globalThis.ResizeObserver;
   globalThis.ResizeObserver = class MockResizeObserver {
-    private cb: ResizeObserverCallback;
     constructor(cb: ResizeObserverCallback) {
-      this.cb = cb;
       observerCallbacks.push(cb);
     }
     observe(el: Element) {

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -113,12 +113,12 @@ it('renders plasma playhead canvas in the cursor container', () => {
 });
 
 it('renders idle playhead after cursor container is resized', () => {
-  // Override the no-op ResizeObserver stub to capture the callback
-  let resizeCallback: ResizeObserverCallback | undefined;
+  // Override the no-op ResizeObserver stub to capture all callbacks
+  const resizeCallbacks: ResizeObserverCallback[] = [];
   const OriginalResizeObserver = globalThis.ResizeObserver;
   globalThis.ResizeObserver = class MockResizeObserver {
     constructor(cb: ResizeObserverCallback) {
-      resizeCallback = cb;
+      resizeCallbacks.push(cb);
     }
     observe() {}
     unobserve() {}
@@ -158,11 +158,17 @@ it('renders idle playhead after cursor container is resized', () => {
     getContextSpy.mockClear();
 
     // Simulate the ResizeObserver firing (container gains height)
+    // Fire all registered callbacks since the cursor observer may not
+    // be the last one registered.
     act(() => {
-      resizeCallback?.(
-        [{ contentRect: { height: 400 } }] as unknown as ResizeObserverEntry[],
-        {} as ResizeObserver,
-      );
+      for (const cb of resizeCallbacks) {
+        cb(
+          [
+            { contentRect: { height: 400 } },
+          ] as unknown as ResizeObserverEntry[],
+          {} as ResizeObserver,
+        );
+      }
     });
 
     // renderIdle should have been called, which calls getContext to draw
@@ -288,6 +294,81 @@ it('does not rewind when rewind button is clicked during recording', () => {
 
   expect(playbackService.isPlaying).toBe(true);
   expect(playbackService.transportTime).toBe(5.0);
+});
+
+it('recalculates timeline scale when container resizes with mixer open', () => {
+  // Capture all ResizeObserver callbacks so we can trigger them manually
+  const observerCallbacks: ResizeObserverCallback[] = [];
+  const observedElements: Element[] = [];
+  const OriginalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class MockResizeObserver {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+      observerCallbacks.push(cb);
+    }
+    observe(el: Element) {
+      observedElements.push(el);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  // Mock offsetHeight on the timeline scroll container to simulate height change
+  let mockOffsetHeight = 600;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight',
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return mockOffsetHeight;
+    },
+  });
+
+  try {
+    const { container } = render(
+      <Scrubber
+        {...{ ...defaultProps, drawerHeight: 120, isMixerOpen: true }}
+      />,
+    );
+
+    const timeline = container.querySelector('.scrubber__timeline');
+
+    // Initial scale: (600 - 120) / 600 = 0.8
+    expect(timeline?.outerHTML).toEqual(expect.stringContaining('scaleY(0.8)'));
+
+    // Simulate entering fullscreen — container height increases to 900
+    mockOffsetHeight = 900;
+
+    // Fire all ResizeObserver callbacks to simulate the resize
+    act(() => {
+      for (const cb of observerCallbacks) {
+        cb(
+          [
+            { contentRect: { height: 900 } },
+          ] as unknown as ResizeObserverEntry[],
+          {} as ResizeObserver,
+        );
+      }
+    });
+
+    // Scale should now be (900 - 120) / 900 ≈ 0.867
+    expect(timeline?.outerHTML).toEqual(expect.stringContaining('scaleY(0.8'));
+    expect(timeline?.outerHTML).not.toEqual(
+      expect.stringContaining('scaleY(0.8)'),
+    );
+  } finally {
+    globalThis.ResizeObserver = OriginalResizeObserver;
+    if (originalDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetHeight',
+        originalDescriptor,
+      );
+    }
+  }
 });
 
 it('does not update transportTime during count-in', () => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -242,13 +242,28 @@ export function useScrubber({
 
   const [timelineScaleFactor, setTimelineScaleFactor] = useState(1.0);
 
+  // Recalculate the scale factor when the timeline container resizes (e.g.
+  // entering/exiting fullscreen) or when the drawer height changes.
   useLayoutEffect(() => {
-    if (timelineScrollRef.current) {
-      // TODO: or use clientHeight?
-      const timelineHeight = timelineScrollRef.current.offsetHeight;
-      const scaleFactor = (timelineHeight - drawerHeight) / timelineHeight;
-      setTimelineScaleFactor(scaleFactor);
-    }
+    const el = timelineScrollRef.current;
+    if (!el) return;
+
+    const updateScaleFactor = () => {
+      const timelineHeight = el.offsetHeight;
+      if (timelineHeight > 0) {
+        const scaleFactor = (timelineHeight - drawerHeight) / timelineHeight;
+        setTimelineScaleFactor(scaleFactor);
+      }
+    };
+
+    updateScaleFactor();
+
+    const observer = new ResizeObserver(() => {
+      updateScaleFactor();
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
   }, [drawerHeight]);
 
   const timelineScaleStyle = getTimelineStyle(isMixerOpen, timelineScaleFactor);

--- a/src/hooks/__tests__/useContainerHeight.test.ts
+++ b/src/hooks/__tests__/useContainerHeight.test.ts
@@ -152,3 +152,35 @@ it('updates height when the container resizes', async () => {
   // Timeline from ever rendering tracks for the first recording.
   expect(reportedHeight).toBe(500);
 });
+
+it('updates height when fullscreen changes the container size', async () => {
+  // Simulate a container that starts at normal viewport height and then
+  // expands when fullscreen is entered (and later shrinks when exited).
+  mockHeight = 400;
+  let reportedHeight = -1;
+
+  const { getByTestId } = render(
+    createElement(HeightReporter, {
+      onHeight: (h: number) => {
+        reportedHeight = h;
+      },
+    }),
+  );
+
+  expect(reportedHeight).toBe(400);
+
+  // Simulate entering fullscreen — container height increases
+  const container = getByTestId('container');
+  await act(async () => {
+    triggerResizeObserver(container, { height: 900 });
+  });
+
+  expect(reportedHeight).toBe(900);
+
+  // Simulate exiting fullscreen — container height returns to original
+  await act(async () => {
+    triggerResizeObserver(container, { height: 400 });
+  });
+
+  expect(reportedHeight).toBe(400);
+});


### PR DESCRIPTION
## Summary
- Added a `ResizeObserver` on the timeline scroll container in `useScrubber` so the `timelineScaleFactor` recalculates when the container resizes (e.g. entering/exiting fullscreen), not just when `drawerHeight` changes
- Added a guard against zero-height containers to prevent division-by-zero
- Updated the existing "renders idle playhead after cursor container is resized" test to handle multiple ResizeObserver instances
- Added test verifying scale factor updates on container resize with mixer open
- Added test verifying `useContainerHeight` handles fullscreen enter/exit resize events

## Test plan
- [x] New test: `recalculates timeline scale when container resizes with mixer open` — verifies scale factor updates from 0.8 to ~0.867 when container height changes from 600 to 900
- [x] New test: `updates height when fullscreen changes the container size` — verifies useContainerHeight tracks both fullscreen enter (400→900) and exit (900→400)
- [x] All 786 existing tests pass

https://claude.ai/code/session_01ARtNrNTnesdNXPTMWMHPkF