### PR TITLE
Fix uploaded audio not persisting to IndexedDB

### DIFF
--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,0 +1,53 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
+
+async function uploadAudioFile(
+  page: import('@playwright/test').Page,
+  filePath: string,
+) {
+  const fileInput = page.locator('.project-page-header input[type="file"]');
+  await fileInput.setInputFiles(filePath);
+}
+
+test.describe('Project data persistence across page reload', () => {
+  test('uploaded track survives a hard page reload', async ({ page }) => {
+    // Create a project from the home page
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await expect(page).toHaveURL(/\/project\//);
+
+    // Upload a track
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__track')).toBeVisible();
+
+    // Wait for auto-save debounce (250ms) plus buffer
+    await page.waitForTimeout(500);
+
+    // Hard reload
+    await page.reload();
+
+    // Track should still be visible after reload
+    await expect(page.locator('.timeline__track')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('project appears on home page after reload', async ({ page }) => {
+    // Create a project and upload a track
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Create Project' }).click();
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__track')).toBeVisible();
+    await page.waitForTimeout(500);
+
+    // Navigate home — project should be listed with its track count
+    await page.goto('/');
+    await expect(page.getByText('1 track')).toBeVisible();
+  });
+});

--- a/src/components/project/projectPageEffects.ts
+++ b/src/components/project/projectPageEffects.ts
@@ -36,10 +36,13 @@ export const useUploadFile = (dispatch: React.Dispatch<ProjectAction>) => {
       reader.onerror = () => message(fileName, { type: 'error', key });
       reader.onload = () => {
         const arrayBuffer = reader.result as ArrayBuffer;
+        // Clone before createTrack — decodeAudioData detaches the original
+        // ArrayBuffer, making it unusable for IndexedDB storage.
+        const audioDataForStorage = arrayBuffer.slice(0);
         trackHook
           .createTrack(arrayBuffer)
           .then(({ trackId }) => {
-            saveAudioData(trackId, arrayBuffer);
+            saveAudioData(trackId, audioDataForStorage);
             dispatch([ADD_TRACK, { trackId, fileName }]);
             message(fileName, { type: 'success', key });
           })


### PR DESCRIPTION
## Summary
- Fix audio data not surviving page reload after upload
- `decodeAudioData` detaches the original `ArrayBuffer`, so `saveAudioData` was silently writing an empty buffer to IndexedDB. Clone the buffer before passing it to `createTrack` so a valid copy is available for storage.
- Add e2e tests verifying tracks survive a hard page reload and appear on the home page

## Test plan
- [x] New e2e test: uploaded track survives hard page reload
- [x] New e2e test: project with track appears on home page after reload
- [x] All 788 unit tests pass
- [x] All 85 e2e tests pass (including 2 new)
- [x] ESLint passes

https://claude.ai/code/session_01Y8xNRE5iAo66M3GSZLf5jy