### PR TITLE
Fix CLAP classification by extracting loudest audio segment

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -17,6 +17,7 @@ import {
   type WorkerMessage,
   type ClassifyResponse,
 } from './classification.worker';
+import { extractLoudestSegment } from './audioSegment';
 import {
   CANDIDATE_LABELS,
   mapToInstrumentLabel,
@@ -256,7 +257,8 @@ class InstrumentClassificationService {
   ): Promise<{ label: string; score: number }> {
     const classify = await this.loadClassifier();
     const monoSamples = downmixToMono(audioBuffer, MODEL_SAMPLE_RATE);
-    return classify(monoSamples);
+    const segment = extractLoudestSegment(monoSamples, MODEL_SAMPLE_RATE);
+    return classify(segment);
   }
 
   private async loadClassifier(): Promise<Classifier> {

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -423,6 +423,33 @@ describe('InstrumentClassificationService', () => {
       );
     });
 
+    it('extracts the loudest segment from long audio', async () => {
+      // 30 seconds at 48kHz — longer than the 10s segment window
+      const buffer = createAudioBuffer(1, 48000 * 30, 48000);
+
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
+      // Should be trimmed to 10 seconds (480,000 samples), not the full 30s
+      expect(passedAudio.length).toBe(48000 * 10);
+    });
+
+    it('passes short audio unchanged to the classifier', async () => {
+      // 5 seconds — shorter than the 10s segment window
+      const buffer = createAudioBuffer(1, 48000 * 5, 48000);
+
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      const passedAudio = mockClassifier.mock.calls[0][0] as Float32Array;
+      expect(passedAudio.length).toBe(48000 * 5);
+    });
+
     it('reuses the pipeline across multiple calls', async () => {
       const { pipeline } = await import('@huggingface/transformers');
       const buffer = createAudioBuffer();

--- a/src/services/__tests__/audioSegment.test.ts
+++ b/src/services/__tests__/audioSegment.test.ts
@@ -1,0 +1,119 @@
+import { extractLoudestSegment } from '../audioSegment';
+
+const SAMPLE_RATE = 48_000;
+const SEGMENT_SAMPLES = 10 * SAMPLE_RATE; // 10 seconds
+
+describe('extractLoudestSegment', () => {
+  it('returns the original samples when audio is shorter than segment duration', () => {
+    const short = new Float32Array(SAMPLE_RATE * 5); // 5 seconds
+    short.fill(0.5);
+
+    const result = extractLoudestSegment(short, SAMPLE_RATE);
+
+    expect(result).toBe(short);
+  });
+
+  it('returns the original samples when audio is exactly the segment duration', () => {
+    const exact = new Float32Array(SEGMENT_SAMPLES);
+    exact.fill(0.5);
+
+    const result = extractLoudestSegment(exact, SAMPLE_RATE);
+
+    expect(result).toBe(exact);
+  });
+
+  it('returns a segment of the expected length for longer audio', () => {
+    const long = new Float32Array(SAMPLE_RATE * 30); // 30 seconds
+    long.fill(0.1);
+
+    const result = extractLoudestSegment(long, SAMPLE_RATE);
+
+    expect(result.length).toBe(SEGMENT_SAMPLES);
+  });
+
+  it('selects the segment containing the loudest region', () => {
+    // 30 seconds of silence with a loud burst at 15–16 seconds
+    const long = new Float32Array(SAMPLE_RATE * 30);
+    const burstStart = 15 * SAMPLE_RATE;
+    const burstEnd = 16 * SAMPLE_RATE;
+    for (let i = burstStart; i < burstEnd; i++) {
+      long[i] = 0.9;
+    }
+
+    const result = extractLoudestSegment(long, SAMPLE_RATE);
+
+    // The selected segment should contain the loud burst
+    // The burst is at 15s, so the segment should start somewhere
+    // between 6s and 15s to include the burst in a 10s window
+    const resultSum = result.reduce((sum, s) => sum + s * s, 0);
+    expect(resultSum).toBeGreaterThan(0);
+
+    // Verify the burst is actually in the extracted segment
+    let hasBurst = false;
+    for (let i = 0; i < result.length; i++) {
+      if (result[i] > 0.5) {
+        hasBurst = true;
+        break;
+      }
+    }
+    expect(hasBurst).toBe(true);
+  });
+
+  it('prefers the beginning when energy is uniform', () => {
+    // Uniform audio — all windows have equal energy.
+    // The function should return the first window (offset 0).
+    const uniform = new Float32Array(SAMPLE_RATE * 20);
+    uniform.fill(0.3);
+
+    const result = extractLoudestSegment(uniform, SAMPLE_RATE);
+
+    // Check that it's a subarray starting from offset 0
+    // (shares the same underlying buffer with offset 0)
+    expect(result.byteOffset).toBe(0);
+  });
+
+  it('handles different sample rates', () => {
+    const rate = 44_100;
+    const segmentLength = Math.round(10 * rate);
+    const long = new Float32Array(rate * 20); // 20 seconds at 44.1kHz
+    long.fill(0.1);
+
+    const result = extractLoudestSegment(long, rate);
+
+    expect(result.length).toBe(segmentLength);
+  });
+
+  it('finds a loud segment at the end of the audio', () => {
+    const long = new Float32Array(SAMPLE_RATE * 30);
+    // Loud burst in the last 2 seconds
+    const burstStart = 28 * SAMPLE_RATE;
+    for (let i = burstStart; i < long.length; i++) {
+      long[i] = 0.8;
+    }
+
+    const result = extractLoudestSegment(long, SAMPLE_RATE);
+
+    // Should contain the loud ending
+    let hasBurst = false;
+    for (let i = 0; i < result.length; i++) {
+      if (result[i] > 0.5) {
+        hasBurst = true;
+        break;
+      }
+    }
+    expect(hasBurst).toBe(true);
+  });
+
+  it('finds a loud segment at the beginning of the audio', () => {
+    const long = new Float32Array(SAMPLE_RATE * 30);
+    // Loud burst in the first 2 seconds
+    for (let i = 0; i < 2 * SAMPLE_RATE; i++) {
+      long[i] = 0.8;
+    }
+
+    const result = extractLoudestSegment(long, SAMPLE_RATE);
+
+    // The 10s segment starting at 0 should contain the burst
+    expect(result[0]).toBeCloseTo(0.8);
+  });
+});

--- a/src/services/audioSegment.ts
+++ b/src/services/audioSegment.ts
@@ -1,0 +1,57 @@
+// audioSegment — extracts the loudest segment from audio samples.
+//
+// CLAP's audio encoder processes a fixed-length window (~7 s at 48 kHz).
+// When the full audio is passed, the pipeline truncates from the start —
+// which is often silence or a quiet intro for stems. This module finds
+// the segment with the highest energy and returns it so the classifier
+// receives representative audio content.
+
+// Duration of the segment to extract (seconds). Slightly longer than
+// CLAP's window to ensure the encoder has enough content even after
+// internal padding/truncation.
+const SEGMENT_DURATION_S = 10;
+
+// Window size for the sliding RMS calculation (seconds). A 1-second
+// hop keeps the search fast while being granular enough to locate the
+// loudest region.
+const HOP_DURATION_S = 1;
+
+/**
+ * Extracts the loudest segment of `SEGMENT_DURATION_S` seconds from
+ * mono audio samples. If the audio is shorter than the segment duration,
+ * the original samples are returned unchanged.
+ *
+ * Uses a sliding window with a 1-second hop to find the segment with
+ * the maximum RMS energy.
+ */
+export function extractLoudestSegment(
+  samples: Float32Array,
+  sampleRate: number,
+): Float32Array {
+  const segmentLength = Math.round(SEGMENT_DURATION_S * sampleRate);
+
+  if (samples.length <= segmentLength) {
+    return samples;
+  }
+
+  const hopLength = Math.round(HOP_DURATION_S * sampleRate);
+  let bestOffset = 0;
+  let bestEnergy = -1;
+
+  for (
+    let offset = 0;
+    offset + segmentLength <= samples.length;
+    offset += hopLength
+  ) {
+    let energy = 0;
+    for (let i = offset; i < offset + segmentLength; i++) {
+      energy += samples[i] * samples[i];
+    }
+    if (energy > bestEnergy) {
+      bestEnergy = energy;
+      bestOffset = offset;
+    }
+  }
+
+  return samples.subarray(bestOffset, bestOffset + segmentLength);
+}

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -13,6 +13,7 @@
 // Audio preprocessing (downmix + resample) also runs here to avoid
 // blocking the main thread with CPU-intensive sample manipulation.
 
+import { extractLoudestSegment } from './audioSegment';
 import { CANDIDATE_LABELS } from './instrumentLabels';
 import { isModelCached, revalidateCache } from './ModelCache';
 
@@ -199,7 +200,8 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
   try {
     const classify = await loadPipeline();
     const monoSamples = downmixToMono(channelData, sampleRate, length);
-    const result = await classify(monoSamples);
+    const segment = extractLoudestSegment(monoSamples, MODEL_SAMPLE_RATE);
+    const result = await classify(segment);
 
     const response: ClassifyResponse = {
       id,


### PR DESCRIPTION
## Summary
- CLAP's audio encoder processes a fixed ~7s window and truncates from the start. Stems often begin with silence, giving the model non-representative audio and biasing results toward generic labels like "singing vocals"
- Added `extractLoudestSegment()` that finds the 10-second window with the highest RMS energy using a sliding window with 1-second hops
- Applied in both the worker and main-thread fallback classification paths, before audio is sent to the CLAP model

## Why not filename-based classification (#259)?
PR #259 added filename keyword matching as the primary classification method. This approach is too fragile:
- **Recorded audio has no filename** — `createRecordedTrack()` doesn't receive a filename, so recorded tracks would never be classified
- **Unrealistic assumptions** — most users don't name files with instrument keywords (e.g. `track_01.wav`, `Session1-Take3.wav`)
- **Root cause unaddressed** — the CLAP model works well when given representative audio content; the problem was *what* audio we were feeding it, not the model itself

This PR fixes the root cause: ensuring the model receives the most representative segment of the audio.

## Test plan
- [x] All 798 existing tests pass
- [x] 8 new tests for `extractLoudestSegment()` (short audio passthrough, segment selection, edge cases)
- [x] 2 new tests for main-thread fallback (long audio trimmed, short audio unchanged)
- [x] ESLint passes
- [x] Production build succeeds
- [ ] Manual: upload stems with silent intros and verify classification accuracy improves
- [ ] Manual: record audio in-app and verify classification runs

Closes #249

https://claude.ai/code/session_0184Ht67Rz62CXkcmXe7Fp1S