### PR TITLE
Remove redundant scrubber fade overlay

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -159,12 +159,11 @@ test.describe('Playback controls', () => {
     const playhead = page.locator('.plasma-playhead');
     await expect(playhead).toBeVisible();
 
-    const reveal = page.locator('.scrubber__reveal');
     await page.getByTitle('Play').click();
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Pause')).toBeVisible();
 
     await page.getByTitle('Pause').click();
-    await expect(reveal).not.toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Play')).toBeVisible();
   });
 });
 

--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -156,9 +156,6 @@ test.describe('Recording', () => {
 
     await playButton.click();
     await expect(page.getByTitle('Pause')).toBeVisible();
-
-    const reveal = page.locator('.scrubber__reveal');
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
   });
 
   test('recorded track plays from the beginning after recording stops', async ({
@@ -180,9 +177,6 @@ test.describe('Recording', () => {
     // Press play — playback should start from the beginning
     await page.getByTitle('Play').click();
     await expect(page.getByTitle('Pause')).toBeVisible();
-
-    const reveal = page.locator('.scrubber__reveal');
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
   });
 });
 
@@ -219,8 +213,5 @@ test.describe('Recording with existing tracks', () => {
 
     await page.getByTitle('Play').click();
     await expect(page.getByTitle('Pause')).toBeVisible();
-
-    const reveal = page.locator('.scrubber__reveal');
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
   });
 });

--- a/e2e/scrubber-seek.spec.ts
+++ b/e2e/scrubber-seek.spec.ts
@@ -118,25 +118,17 @@ test.describe('Drag and scroll timeline to seek while playing', () => {
     expect(scrollLeft).toBeGreaterThan(initialScrollLeft + 50);
   });
 
-  test('reveal loses active class when scroll pauses playback', async ({
-    page,
-  }) => {
-    const reveal = page.locator('.scrubber__reveal');
-
+  test('scroll pauses and resumes playback', async ({ page }) => {
     // Start playback
     await page.getByTitle('Play').click();
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Pause')).toBeVisible();
 
     // Scroll to pause
     await wheelScrollTimeline(page, 400);
-
-    // Reveal should lose the active class while paused
-    await expect(reveal).not.toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Play')).toBeVisible();
 
     // Wait for debounce and resume
     await page.waitForTimeout(400);
-
-    // Reveal should regain the active class
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Pause')).toBeVisible();
   });
 });

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -115,25 +115,17 @@ test.describe('Swipe to scrub timeline during playback', () => {
     await expect(page.getByTitle('Play')).toBeVisible();
   });
 
-  test('reveal loses active class when swipe pauses playback', async ({
-    page,
-  }) => {
-    const reveal = page.locator('.scrubber__reveal');
-
+  test('swipe pauses and resumes playback', async ({ page }) => {
     // Start playback
     await page.getByTitle('Play').click();
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Pause')).toBeVisible();
 
     // Swipe to pause
     await swipeTimeline(page, 400);
-
-    // Reveal should lose the active class while paused
-    await expect(reveal).not.toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Play')).toBeVisible();
 
     // Wait for debounce and resume
     await page.waitForTimeout(400);
-
-    // Reveal should regain the active class
-    await expect(reveal).toHaveClass(/scrubber__reveal--active/);
+    await expect(page.getByTitle('Pause')).toBeVisible();
   });
 });

--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -59,28 +59,6 @@
   );
 }
 
-/* Spectrogram reveal: dims the upcoming (right of playhead) audio */
-.scrubber__reveal {
-  position: absolute;
-  top: 0;
-  left: calc(var(--cursor-position) * 100vw);
-  right: 0;
-  bottom: var(--timeline-margin);
-  padding-top: var(--timeline-margin);
-  pointer-events: none;
-  background: linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0.35),
-    rgba(0, 0, 0, 0.5)
-  );
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-.scrubber__reveal--active {
-  opacity: 1;
-}
-
 .plasma-playhead {
   display: block;
   width: 100%;

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -33,7 +33,6 @@ const Scrubber = (props: ScrubberProps) => {
     timelineScrollRef,
     cursorContainerRef,
     plasmaRef,
-    playing,
     isRewindButtonHidden,
     timelineScaleStyle,
     rewindButtonStyle,
@@ -55,10 +54,6 @@ const Scrubber = (props: ScrubberProps) => {
     'scrubber__rewind--hidden': isRewindButtonHidden,
   });
 
-  const revealClass = classNames('scrubber__reveal', {
-    'scrubber__reveal--active': playing,
-  });
-
   return (
     <div className="scrubber scrubber--firefox-scroll-fix">
       <div
@@ -75,7 +70,6 @@ const Scrubber = (props: ScrubberProps) => {
       <div className="scrubber__shade" style={timelineScaleStyle}>
         <div className="shade"></div>
       </div>
-      <div className={revealClass} style={timelineScaleStyle}></div>
       <div
         ref={cursorContainerRef}
         className="scrubber__cursor"

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -278,7 +278,6 @@ export function useScrubber({
     timelineScrollRef,
     cursorContainerRef,
     plasmaRef,
-    playing,
     isRewindButtonHidden,
     timelineScaleStyle,
     rewindButtonStyle,


### PR DESCRIPTION
## Summary
- Removed the `scrubber__reveal` overlay that dimmed the area to the right of the playhead during playback
- The existing `.shade` element already provides a right-side fade-out gradient, making the reveal overlay redundant
- Cleaned up associated CSS rules and the unused `playing` return value from `useScrubber`

## Test plan
- [x] Existing Scrubber tests pass (17/17)
- [x] Lint passes
- [ ] Verify visually that the shade fade-out on the right side of the timeline still works correctly during playback
- [ ] Confirm no visual regression when playback starts/stops

https://claude.ai/code/session_018bHYyRdvCycGF7MaBmmBUV