### PR TITLE
Fix live spectrogram stretching during recording

### DIFF
--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -203,13 +203,18 @@ function drawRecordingFrame(
   // Map buffer frames (1 frame = 1 pixel in the buffer) to display pixels.
   // bufferFrames maps to contentWidth display pixels.
   const framesPerPixel = buffer.frameCount / contentWidth;
+  // Clamp destination width so the buffer is never stretched beyond the
+  // actual content area. Without this, when the recording is shorter than
+  // the viewport the buffer was drawn across the full viewport width,
+  // making the spectrogram appear to move faster than existing tracks.
+  const destWidth = Math.min(viewportWidth, contentWidth - contentOffset);
   const srcX = Math.floor(contentOffset * framesPerPixel);
   const srcWidth = Math.min(
-    Math.ceil(viewportWidth * framesPerPixel),
+    Math.ceil(destWidth * framesPerPixel),
     buffer.frameCount - srcX,
   );
 
-  buffer.drawTo(ctx, srcX, srcWidth, 0, viewportWidth, height);
+  buffer.drawTo(ctx, srcX, srcWidth, 0, destWidth, height);
 }
 
 function drawTilesFrame(

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -522,6 +522,65 @@ describe('recording mode', () => {
     vi.restoreAllMocks();
   });
 
+  it('draws buffer content to content width, not viewport width, when recording is shorter than viewport', () => {
+    // Bug: when the recording content is narrower than the viewport, the
+    // buffer was stretched across the full viewport width. This made the
+    // live spectrogram appear to move faster than existing tracks initially,
+    // gradually slowing down as the content grew to fill the viewport.
+    const VIEWPORT_WIDTH = 800;
+    const PPS = 200;
+
+    recordingService.arm();
+    recordingService.startRecording();
+    // elapsed = 1.0 - 0 = 1.0s → contentWidth = 200px (< 800px viewport)
+    vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.0);
+    vi.spyOn(recordingService, 'isOverdubRecording').mockReturnValue(true);
+    vi.spyOn(recordingService, 'getRecordingStartTime').mockReturnValue(0);
+    mockGetVisualizationData.mockReturnValue(new Uint8Array(774).fill(128));
+
+    const mockCtx = {
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      globalCompositeOperation: 'source-over' as string,
+      fillStyle: '' as string,
+      canvas: { width: VIEWPORT_WIDTH, height: 128 },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+
+    const { container } = render(
+      <div className="scrubber__timeline">
+        <Spectrogram {...recordingProps} pixelsPerSecond={PPS} />
+      </div>,
+    );
+
+    const scrollParent = container.querySelector('.scrubber__timeline')!;
+    Object.defineProperty(scrollParent, 'clientWidth', {
+      value: VIEWPORT_WIDTH,
+      configurable: true,
+    });
+
+    // First frame: accumulate a frame and draw
+    const calls = vi.mocked(useAnimationFrame).mock.calls;
+    const callback = calls[calls.length - 1]?.[0];
+    callback?.();
+
+    const contentWidth = 1.0 * PPS; // 200px
+    // RecordingBuffer.drawTo calls ctx.drawImage with 9 arguments:
+    // (canvas, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight)
+    const drawCall = mockCtx.drawImage.mock.calls[0];
+    expect(drawCall).toBeDefined();
+    // destWidth (8th arg, index 7) should be contentWidth, NOT viewportWidth
+    const destWidth = drawCall[7];
+    expect(destWidth).toBe(contentWidth);
+
+    vi.restoreAllMocks();
+  });
+
   it('updates container width based on elapsed recording time', () => {
     recordingService.arm();
     recordingService.startRecording();


### PR DESCRIPTION
## Summary
- Fixed a bug where the live recording spectrogram appeared to move faster than existing tracks during the first seconds of recording, gradually slowing down to the correct speed
- **Root cause**: `drawRecordingFrame()` always drew the recording buffer to the full viewport width. When the recording content was narrower than the viewport (early in recording), the buffer was stretched across too many pixels, making the spectrogram appear to scroll faster than it should
- **Fix**: Clamp the destination width to `Math.min(viewportWidth, contentWidth - contentOffset)` so the buffer-to-pixel mapping stays consistent regardless of content size

## Test plan
- [x] Added failing test that verifies buffer content is drawn to `contentWidth` (200px), not `viewportWidth` (800px), when recording is shorter than viewport
- [x] Confirmed the test fails before the fix (`expected 200, received 800`)
- [x] Confirmed the test passes after the fix
- [x] Full test suite passes (767 tests across 61 files)

https://claude.ai/code/session_01REFttSWw2er3UJuKBPhKqk