### PR TITLE
Switch to music-trained CLAP model for instrument classification

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -277,7 +277,7 @@ class InstrumentClassificationService {
 
     const pipe = await pipeline(
       'zero-shot-audio-classification',
-      'Xenova/clap-htsat-unfused',
+      'Xenova/larger_clap_music_and_speech',
       { device: 'wasm', dtype: 'q8' },
     );
     console.log('[classification] Model loaded on main thread');

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -407,7 +407,7 @@ describe('InstrumentClassificationService', () => {
       expect(passedAudio.length).toBe(48000);
     });
 
-    it('loads the CLAP pipeline lazily on first classify call', async () => {
+    it('loads the music-trained CLAP model on first classify call', async () => {
       const { pipeline } = await import('@huggingface/transformers');
       const buffer = createAudioBuffer();
 
@@ -418,7 +418,7 @@ describe('InstrumentClassificationService', () => {
 
       expect(pipeline).toHaveBeenCalledWith(
         'zero-shot-audio-classification',
-        'Xenova/clap-htsat-unfused',
+        'Xenova/larger_clap_music_and_speech',
         { device: 'wasm', dtype: 'q8' },
       );
     });

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -17,7 +17,7 @@ import { extractLoudestSegment } from './audioSegment';
 import { CANDIDATE_LABELS } from './instrumentLabels';
 import { isModelCached, revalidateCache } from './ModelCache';
 
-const MODEL_ID = 'Xenova/clap-htsat-unfused';
+const MODEL_ID = 'Xenova/larger_clap_music_and_speech';
 const TASK = 'zero-shot-audio-classification';
 
 // CLAP model expects 48 kHz mono audio


### PR DESCRIPTION
## Summary
- Swapped CLAP model from `Xenova/clap-htsat-unfused` (general audio) to `Xenova/larger_clap_music_and_speech` (music-trained variant) in both the Web Worker and main-thread fallback paths
- The general-purpose model was biased toward classifying every stem as "singing vocals"; the music-trained variant is specifically designed for music and speech classification
- Updated test assertion to verify the new model ID is used

## Test plan
- [x] Wrote failing test verifying the music-trained model is loaded, confirmed it failed before the fix
- [x] All 766 tests pass after the change
- [x] Production build succeeds
- [ ] Manual accuracy testing: upload isolated stems (vocals, guitar, bass, drums) and verify classification accuracy

Fixes #249

https://claude.ai/code/session_01WkVebxsmFyoPaPrtfkcG4M