### PR TITLE
Fix timeline compression during recording

### DIFF
--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -226,6 +226,38 @@ it('does not stop playback at end of scroll during recording', () => {
   expect(playbackService.transportTime).toBe(1.5);
 });
 
+it('does not stop playback when recording reaches total time of existing tracks', () => {
+  // Simulate existing tracks with a total duration of 10 seconds
+  playbackService.setTotalTime(10.0);
+
+  // Engine time matches totalTime — at ~60fps, some animation frame will
+  // land on (or round to) the same value as totalTime.
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(10.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+  recordingService.arm();
+  recordingService.startRecording();
+
+  render(<Scrubber {...defaultProps} />);
+
+  // The animation loop calls setTransportTime(10.0) which matches
+  // totalTime (10.0). Without the fix, this triggers stopAtEndOfTimeline
+  // which pauses the transport and freezes the recording spectrogram.
+  act(() => {
+    rafCallback(0);
+  });
+
+  expect(playbackService.isPlaying).toBe(true);
+  expect(playbackService.transportTime).toBe(10.0);
+});
+
 it('does not call getLoudness when playback is stopped', () => {
   const getLoudnessSpy = vi.spyOn(trackService, 'getLoudness');
 

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -122,6 +122,13 @@ export function useScrubber({
         // timeline stays frozen at the recording position.  Once the
         // count-in ends, scroll and transportTime resume updating.
         if (!recording.isCountingIn) {
+          // During recording the timeline grows beyond the duration of
+          // existing tracks.  Keep totalTime ahead of the transport so
+          // the end-of-timeline guard in setTransportTime does not stop
+          // playback and freeze the recording spectrogram.
+          if (recording.isActivelyRecording && time >= playback.totalTime) {
+            playback.setTotalTime(time + 1);
+          }
           playback.setTransportTime(time);
           setScrollPosition(time);
         }


### PR DESCRIPTION
## Summary
- When recording exceeds the total duration of existing tracks (~15-20s depending on track length), `setTransportTime()` triggered `stopAtEndOfTimeline()` which paused the transport and froze the scrubber animation loop. This caused the recording spectrogram to visually compress as new frames accumulated into a frozen content width.
- The animation loop in `useScrubber` now extends `totalTime` ahead of the current transport position during active recording, preventing the end-of-timeline guard from firing.
- Added a regression test that reproduces the exact scenario: recording active, engine time reaches totalTime of existing tracks, playback must continue.

## Test plan
- [x] New test `does not stop playback when recording reaches total time of existing tracks` passes
- [x] All 768 existing tests pass
- [ ] Manual: upload a ~10s audio file, start recording, verify the timeline scrolls normally past 10s without compressing

https://claude.ai/code/session_01APv4hjQKSDVYjbbcPryQqy