### PR TITLE
Fix instrument classification CORS failure on upload

### DIFF
--- a/e2e/classification.spec.ts
+++ b/e2e/classification.spec.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
+
+async function uploadAudioFile(
+  page: import('@playwright/test').Page,
+  filePath: string,
+) {
+  const fileInput = page.locator('.project-page-header input[type="file"]');
+  await fileInput.setInputFiles(filePath);
+}
+
+test.describe('Instrument classification on upload', () => {
+  test('classifies instrument without CORS errors after file upload', async ({
+    page,
+  }) => {
+    const corsErrors: string[] = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (
+        text.includes('CORS') ||
+        (text.includes('essentia.upf.edu') && msg.type() === 'error')
+      ) {
+        corsErrors.push(text);
+      }
+    });
+
+    await page.goto('/project/test-classification');
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__track')).toBeVisible();
+
+    // Open the mixer to see the channel with classification state
+    await page.getByTitle('Show mixer').click();
+    await expect(page.locator('.channel')).toBeVisible();
+
+    // Wait for classification to finish (loading spinner should disappear).
+    // The channel__instrument div shows a LoadingOutlined icon while
+    // classifying, then switches to an instrument icon or nothing.
+    const instrumentDiv = page.locator('.channel__instrument');
+
+    // Classification should complete — the loading spinner should disappear
+    // within a reasonable timeout. With the CORS bug, the worker fails and
+    // the main-thread fallback also fails, so classification enters 'error'
+    // state and shows the unknown icon. Without the bug, models would load
+    // and classification would show the correct instrument icon.
+    await expect(instrumentDiv.locator('.anticon-loading')).toBeHidden({
+      timeout: 15_000,
+    });
+
+    // No CORS errors should appear — model fetches must go through a
+    // same-origin proxy to avoid cross-origin restrictions.
+    expect(corsErrors).toEqual([]);
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   publish = "dist"
 
 [[redirects]]
+  from = "/models/*"
+  to = "https://essentia.upf.edu/models/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -38,10 +38,12 @@ export type { InstrumentLabel };
 // EffNet expects 16 kHz mono audio
 const MODEL_SAMPLE_RATE = 16_000;
 
+// Same-origin paths proxied to essentia.upf.edu (Vite proxy in dev,
+// Netlify redirect in production) to avoid CORS restrictions.
 const EFFNET_URL =
-  'https://essentia.upf.edu/models/feature-extractors/discogs-effnet/discogs-effnet-bsdynamic-1.onnx';
+  '/models/feature-extractors/discogs-effnet/discogs-effnet-bsdynamic-1.onnx';
 const INSTRUMENT_HEAD_URL =
-  'https://essentia.upf.edu/models/classification-heads/mtg_jamendo_instrument/mtg_jamendo_instrument-discogs-effnet-1.onnx';
+  '/models/classification-heads/mtg_jamendo_instrument/mtg_jamendo_instrument-discogs-effnet-1.onnx';
 
 // EffNet input dimensions
 const PATCH_FRAMES = 128;

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -239,7 +239,6 @@ class InstrumentClassificationService {
         }
       };
       this.worker.onerror = () => {
-        this.workerFailed = true;
         this._downloadProgress.value = null;
         this.rejectAllPending(
           new Error(

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -351,19 +351,29 @@ describe('InstrumentClassificationService', () => {
 
       simulateDownloadProgress(50);
 
-      // Trigger onerror (catastrophic worker failure) — sets workerFailed
-      // and rejects all pending requests. Since workerFailed is already set,
-      // the catch block skips the main-thread fallback and throws.
+      // Trigger onerror (catastrophic worker failure) — rejects all pending
+      // requests and falls back to main-thread inference.
       mockWorker.onerror!({} as ErrorEvent);
-      await expect(promise).rejects.toThrow(
-        'Classification failed for track track-1',
-      );
+      await promise;
 
       expect(service.downloadProgress).toBeNull();
     });
   });
 
   describe('worker error handling', () => {
+    it('falls back to main thread when the worker crashes (onerror)', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      // Simulate catastrophic worker failure (e.g., module failed to load)
+      mockWorker.onerror!({} as ErrorEvent);
+      await promise;
+
+      // Should have fallen back to main-thread ONNX pipeline
+      expect(mockFetchModel).toHaveBeenCalled();
+      expect(service.getClassification('track-1')?.label).toBe('guitar');
+    });
+
     it('falls back to main thread when the worker responds with an error', async () => {
       const buffer = createAudioBuffer();
       const promise = service.classify('track-1', buffer);

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -12,10 +12,12 @@ import { computeMelSpectrogram } from './melSpectrogram';
 import { JAMENDO_CLASSES } from './instrumentLabels';
 import { fetchModel, isModelCached } from './ModelCache';
 
+// Same-origin paths proxied to essentia.upf.edu (Vite proxy in dev,
+// Netlify redirect in production) to avoid CORS restrictions.
 const EFFNET_URL =
-  'https://essentia.upf.edu/models/feature-extractors/discogs-effnet/discogs-effnet-bsdynamic-1.onnx';
+  '/models/feature-extractors/discogs-effnet/discogs-effnet-bsdynamic-1.onnx';
 const INSTRUMENT_HEAD_URL =
-  'https://essentia.upf.edu/models/classification-heads/mtg_jamendo_instrument/mtg_jamendo_instrument-discogs-effnet-1.onnx';
+  '/models/classification-heads/mtg_jamendo_instrument/mtg_jamendo_instrument-discogs-effnet-1.onnx';
 
 // EffNet expects 16 kHz mono audio
 const MODEL_SAMPLE_RATE = 16_000;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
     react(),
     svgr(),
   ],
-  server: {},
+  server: {
+    proxy: {
+      '/models': {
+        target: 'https://essentia.upf.edu',
+        changeOrigin: true,
+      },
+    },
+  },
   worker: {
     format: 'es',
   },


### PR DESCRIPTION
## Summary

- Fix CORS errors blocking ONNX model downloads from `essentia.upf.edu` during instrument classification — the server doesn't serve `Access-Control-Allow-Origin` headers, so `fetch()` from the browser origin fails
- Proxy model requests through same origin: Vite dev server proxy (`/models` → `essentia.upf.edu`) and Netlify redirect (`/models/*` → `essentia.upf.edu/models/:splat`)
- Fix worker `onerror` handler prematurely setting `workerFailed=true`, which prevented the main-thread fallback from being attempted when the worker crashed

## Test plan

- [x] New e2e test `classification.spec.ts` — verifies no CORS errors during file upload classification
- [x] New unit test — verifies worker crash (onerror) falls back to main-thread inference
- [x] Updated unit test — `clears download progress on worker error` now expects successful fallback
- [x] All 787 existing unit tests pass
- [x] ESLint clean

https://claude.ai/code/session_01SJcpf3zyWMxbXv7eqw4yLN