### PR TITLE
Fix instrument classification: use named export for EssentiaWASM

### DIFF
--- a/src/services/__tests__/melSpectrogram.test.ts
+++ b/src/services/__tests__/melSpectrogram.test.ts
@@ -8,7 +8,7 @@ const PATCH_SIZE = 128;
 const mockComputeFrameWise = vi.fn();
 
 vi.mock('essentia.js/dist/essentia-wasm.es.js', () => ({
-  default: vi.fn().mockResolvedValue({}),
+  EssentiaWASM: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock('essentia.js/dist/essentia.js-model.es.js', () => {

--- a/src/services/melSpectrogram.ts
+++ b/src/services/melSpectrogram.ts
@@ -23,11 +23,10 @@ async function getExtractor() {
 
   initPromise = (async () => {
     // Dynamic imports — WASM module + model extractor
-    const [{ default: EssentiaWASM }, { EssentiaTFInputExtractor }] =
-      await Promise.all([
-        import('essentia.js/dist/essentia-wasm.es.js'),
-        import('essentia.js/dist/essentia.js-model.es.js'),
-      ]);
+    const [{ EssentiaWASM }, { EssentiaTFInputExtractor }] = await Promise.all([
+      import('essentia.js/dist/essentia-wasm.es.js'),
+      import('essentia.js/dist/essentia.js-model.es.js'),
+    ]);
 
     const wasmModule = await EssentiaWASM();
     extractorInstance = new EssentiaTFInputExtractor(wasmModule, 'musicnn');

--- a/src/types/essentia.d.ts
+++ b/src/types/essentia.d.ts
@@ -1,5 +1,5 @@
 declare module 'essentia.js/dist/essentia-wasm.es.js' {
-  export default function EssentiaWASM(): Promise<unknown>;
+  export function EssentiaWASM(): Promise<unknown>;
 }
 
 declare module 'essentia.js/dist/essentia.js-model.es.js' {


### PR DESCRIPTION
## Summary
- Fix `EssentiaWASM` import in `melSpectrogram.ts` — the essentia-wasm ES module uses a **named export** (`export { Module as EssentiaWASM }`), not a default export. The destructuring `{ default: EssentiaWASM }` resolved to `undefined`, causing "t is not a function" in the worker and "e is not a function" on the main-thread fallback.
- Fix test mock in `melSpectrogram.test.ts` to match the real module's export structure (named export instead of default).

## Test plan
- [x] Verified test fails before fix (mock corrected to named export, code still uses default → test breaks)
- [x] Verified test passes after fix (code updated to named export)
- [x] Full test suite passes (787 tests)
- [ ] Manual test: upload an audio file and confirm instrument classification completes without console errors

https://claude.ai/code/session_01N855W46RUNxPMtg2hRPyAs