### PR TITLE
Fix instrument classification: EssentiaWASM is an object, not a factory

### DIFF
--- a/src/services/__tests__/melSpectrogram.test.ts
+++ b/src/services/__tests__/melSpectrogram.test.ts
@@ -8,7 +8,7 @@ const PATCH_SIZE = 128;
 const mockComputeFrameWise = vi.fn();
 
 vi.mock('essentia.js/dist/essentia-wasm.es.js', () => ({
-  EssentiaWASM: vi.fn().mockResolvedValue({}),
+  EssentiaWASM: {},
 }));
 
 vi.mock('essentia.js/dist/essentia.js-model.es.js', () => {

--- a/src/services/melSpectrogram.ts
+++ b/src/services/melSpectrogram.ts
@@ -28,8 +28,7 @@ async function getExtractor() {
       import('essentia.js/dist/essentia.js-model.es.js'),
     ]);
 
-    const wasmModule = await EssentiaWASM();
-    extractorInstance = new EssentiaTFInputExtractor(wasmModule, 'musicnn');
+    extractorInstance = new EssentiaTFInputExtractor(EssentiaWASM, 'musicnn');
     return extractorInstance;
   })();
 


### PR DESCRIPTION
## Summary
- PR #272 fixed the `EssentiaWASM` import from default to named export but the call site still treated it as a factory function: `await EssentiaWASM()`. The `essentia-wasm.es.js` module exports a pre-initialized Emscripten `Module` object — not a factory — so calling it as a function throws "t is not a function" (worker) / "e is not a function" (main thread) in the production build.
- Pass `EssentiaWASM` directly to `new EssentiaTFInputExtractor(EssentiaWASM, 'musicnn')` instead of calling it.
- Fix test mock to match the real module shape (plain object instead of `vi.fn().mockResolvedValue({})`).

## Test plan
- [x] Updated test mock to match real module exports (plain object, not function)
- [x] Verified test fails before fix (`TypeError: EssentiaWASM is not a function`)
- [x] Verified test passes after fix (5/5 pass)
- [x] Full test suite passes (787 tests)
- [ ] Manual test: upload an audio file and confirm instrument classification completes without console errors

https://claude.ai/code/session_01C9aUyrsbMkvN1Ak4hvqCp1