### PR TITLE
Fix mel spectrogram hop size and add classification debug logging

### DIFF
--- a/src/components/workstation/__tests__/workstationEffects.test.ts
+++ b/src/components/workstation/__tests__/workstationEffects.test.ts
@@ -202,7 +202,7 @@ describe('useClassificationMessages', () => {
     rerender({ tracks: [track1] });
 
     expect(mockMessage).toHaveBeenCalledWith(
-      'Instrument detection failed',
+      'Instrument detection failed — audio may be too short',
       expect.objectContaining({ type: 'error' }),
     );
   });

--- a/src/components/workstation/workstationEffects.ts
+++ b/src/components/workstation/workstationEffects.ts
@@ -185,7 +185,7 @@ export const useClassificationMessages = (tracks: Track[]) => {
         });
       } else if (state === 'error') {
         reportedRef.current.add(trackKey);
-        message('Instrument detection failed', {
+        message('Instrument detection failed — audio may be too short', {
           type: 'error',
           key: 'classification',
         });

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -166,9 +166,13 @@ class InstrumentClassificationService {
     try {
       const rawResult = await this.runInference(excerpt);
       return this.applyResult(trackId, rawResult);
-    } catch {
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[classification] Classification failed for track ${trackId}: ${detail}`,
+      );
       this.setEntry(trackId, { state: 'error' });
-      throw new Error(`Classification failed for track ${trackId}`);
+      throw new Error(`Classification failed for track ${trackId}: ${detail}`);
     }
   }
 
@@ -184,9 +188,15 @@ class InstrumentClassificationService {
       return await this.classifyInWorker(excerpt);
     } catch (workerError) {
       this.workerFailed = true;
+      const errorDetail =
+        workerError instanceof Error
+          ? workerError.message
+          : String(workerError);
       console.warn(
-        '[classification] Worker failed, falling back to main thread:',
-        workerError,
+        `[classification] Worker failed, falling back to main thread: ${errorDetail}`,
+      );
+      console.warn(
+        `[classification] Excerpt: ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${(excerpt.length / excerpt.sampleRate).toFixed(2)}s`,
       );
       return this.classifyOnMainThread(excerpt);
     }
@@ -328,8 +338,13 @@ class InstrumentClassificationService {
 
     return async (monoAudio: Float32Array) => {
       const patches = await computeMelSpectrogram(monoAudio);
+      console.log(
+        `[classification] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
+      );
       if (patches.length === 0) {
-        throw new Error('Audio too short to produce mel spectrogram patches');
+        throw new Error(
+          `Audio too short to produce mel spectrogram patches (${monoAudio.length} samples, ${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz — need ≥${MIN_AUDIO_DURATION_SECONDS}s)`,
+        );
       }
 
       // Run EffNet on all patches

--- a/src/services/__tests__/melSpectrogram.test.ts
+++ b/src/services/__tests__/melSpectrogram.test.ts
@@ -104,6 +104,6 @@ describe('computeMelSpectrogram', () => {
 
     await computeMelSpectrogram(audio);
 
-    expect(mockComputeFrameWise).toHaveBeenCalledWith(audio);
+    expect(mockComputeFrameWise).toHaveBeenCalledWith(audio, 256);
   });
 });

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -141,8 +141,13 @@ async function classify(
 
   // Compute mel spectrogram patches
   const patches = await computeMelSpectrogram(monoAudio);
+  console.log(
+    `[classification:worker] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
+  );
   if (patches.length === 0) {
-    throw new Error('Audio too short to produce mel spectrogram patches');
+    throw new Error(
+      `Audio too short to produce mel spectrogram patches (${monoAudio.length} samples, ${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz — need ≥2.1s)`,
+    );
   }
 
   // Run EffNet on each patch to get 1280-dim embeddings
@@ -256,9 +261,31 @@ const workerSelf = self as unknown as WorkerSelf;
 workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
   const { id, channelData, sampleRate, length } = event.data;
 
+  const channels = channelData.length;
+  const firstChannelLength = channelData[0]?.length ?? 0;
+  const durationSeconds = length / sampleRate;
+  console.log(
+    `[classification:worker] Received audio: ${channels}ch, ${length} samples (actual first channel: ${firstChannelLength}), ${sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
+  );
+
+  if (firstChannelLength === 0) {
+    const response: ClassifyResponse = {
+      id,
+      type: 'error',
+      message: `Worker received empty channel data (${channels} channels, first channel length: ${firstChannelLength}, expected: ${length})`,
+    };
+    workerSelf.postMessage(response);
+    return;
+  }
+
   try {
     const ctx = await loadContext();
     const monoSamples = downmixToMono(channelData, sampleRate, length);
+
+    console.log(
+      `[classification:worker] Mono audio after downmix: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
+    );
+
     const result = await classify(ctx, monoSamples);
 
     const response: ClassifyResponse = {
@@ -270,6 +297,7 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
     workerSelf.postMessage(response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    console.error(`[classification:worker] Classification failed: ${message}`);
     const response: ClassifyResponse = { id, type: 'error', message };
     workerSelf.postMessage(response);
   }

--- a/src/services/melSpectrogram.ts
+++ b/src/services/melSpectrogram.ts
@@ -9,6 +9,14 @@
 const PATCH_SIZE = 128;
 const MEL_BANDS = 96;
 
+// Hop size for frame generation. Must match the value used in the
+// MIN_AUDIO_DURATION_SECONDS calculation in InstrumentClassificationService.
+// At 16 kHz with frame=512 and hop=256: (128-1)*256 + 512 = 33,024 samples ≈ 2.07s.
+// Without this, essentia.js defaults hop to frameSize (512), requiring ~4.1s
+// for one 128-frame patch — causing "Audio too short" errors for recordings
+// between 2.1s and 4.1s.
+const HOP_SIZE = 256;
+
 // Log compression matching Essentia's TensorflowInputMusiCNN
 const LOG_COMPRESSION_FACTOR = 10_000;
 
@@ -51,7 +59,7 @@ export async function computeMelSpectrogram(
 
   // computeFrameWise returns { melSpectrum, melBandsSize, patchSize, ... }
   // melSpectrum is a flat Float32Array: totalFrames × melBandsSize
-  const features = extractor.computeFrameWise(monoAudio);
+  const features = extractor.computeFrameWise(monoAudio, HOP_SIZE);
   const melSpectrum: Float32Array = features.melSpectrum;
   const totalFrames = melSpectrum.length / MEL_BANDS;
   const patchCount = Math.floor(totalFrames / PATCH_SIZE);


### PR DESCRIPTION
## Summary

- **Fixed root cause**: `computeFrameWise()` in essentia.js defaults hop size to `frameSize` (512) when not provided. The `MIN_AUDIO_DURATION_SECONDS = 2.1` check assumed hop=256, so audio between 2.1s–4.1s passed the guard but produced 0 mel spectrogram patches in the worker, causing "Audio too short to produce mel spectrogram patches" errors. Fix: pass `hop=256` explicitly.
- **Added debug logging** to the classification worker message handler (logs received audio dimensions, channel data validity, mono downmix result, and patch count) and to the main-thread fallback path.
- **Improved user-facing error messages**: classification failure now shows "audio may be too short" hint, and internal error messages include sample counts and duration for debugging.

## Test plan

- [x] Failing test written first (`computeFrameWise` called without hop=256)
- [x] `melSpectrogram.test.ts` — 5 tests pass
- [x] `InstrumentClassificationService.test.ts` — 36 tests pass
- [x] `workstationEffects.test.ts` — 10 tests pass (updated error message assertion)
- [x] Full test suite — 793 tests pass across 60 files
- [ ] Manual test: upload a short audio file (2–4 seconds) and verify classification succeeds instead of failing with "Audio too short"
- [ ] Manual test: verify console shows detailed debug output during classification

https://claude.ai/code/session_01XKRuUHqSKJj9TES9S8ydX1