### PR TITLE
Simplify audio preprocessing: trim silence instead of extracting loudest segment

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -44,9 +44,9 @@ const MODEL_SAMPLE_RATE = 16_000;
 // Rounded up to give a small margin.
 const MIN_AUDIO_DURATION_SECONDS = 2.1;
 
-// Duration of the loudest excerpt extracted before classification (seconds).
-// Keeps inference fast while providing enough context (~2–3 patches).
-const EXCERPT_DURATION_SECONDS = 5;
+// RMS threshold below which a sample frame is considered silence.
+// Chosen to be just above the noise floor for typical recordings.
+const SILENCE_THRESHOLD = 0.01;
 
 // Same-origin paths proxied to essentia.upf.edu (Vite proxy in dev,
 // Netlify redirect in production) to avoid CORS restrictions.
@@ -138,14 +138,21 @@ class InstrumentClassificationService {
     if (this.cache.has(trackId)) {
       const cached = this.cache.get(trackId)!;
       if (cached.state === 'done' && cached.result) {
+        console.debug(
+          `[classification] Track ${trackId} already classified as "${cached.result.label}" (cached)`,
+        );
         return cached.result.label;
       }
     }
 
     const durationSeconds = audioBuffer.length / audioBuffer.sampleRate;
+    console.debug(
+      `[classification] Track ${trackId}: ${audioBuffer.numberOfChannels}ch, ${audioBuffer.length} samples, ${audioBuffer.sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
+    );
+
     if (durationSeconds < MIN_AUDIO_DURATION_SECONDS) {
       console.log(
-        `[classification] Track ${trackId} too short (${durationSeconds.toFixed(1)}s) — skipping`,
+        `[classification] Track ${trackId} too short (${durationSeconds.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
       );
       const result: ClassificationResult = {
         label: FALLBACK_LABEL,
@@ -155,10 +162,23 @@ class InstrumentClassificationService {
       return FALLBACK_LABEL;
     }
 
-    const excerpt = extractLoudestExcerpt(
-      audioBuffer,
-      EXCERPT_DURATION_SECONDS,
+    const excerpt = trimSilence(audioBuffer);
+    const trimmedDuration = excerpt.length / excerpt.sampleRate;
+    console.debug(
+      `[classification] Track ${trackId} after silence trim: ${excerpt.length} samples, ${trimmedDuration.toFixed(2)}s (removed ${(durationSeconds - trimmedDuration).toFixed(2)}s of silence)`,
     );
+
+    if (trimmedDuration < MIN_AUDIO_DURATION_SECONDS) {
+      console.log(
+        `[classification] Track ${trackId} too short after trimming (${trimmedDuration.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
+      );
+      const result: ClassificationResult = {
+        label: FALLBACK_LABEL,
+        score: 0,
+      };
+      this.setEntry(trackId, { state: 'done', result });
+      return FALLBACK_LABEL;
+    }
 
     this.setEntry(trackId, { state: 'classifying' });
     console.log(`[classification] Classifying track ${trackId}`);
@@ -181,9 +201,16 @@ class InstrumentClassificationService {
   private async runInference(
     excerpt: AudioExcerpt,
   ): Promise<RawClassificationResult> {
+    const excerptDuration = (excerpt.length / excerpt.sampleRate).toFixed(2);
     if (this.workerFailed) {
+      console.debug(
+        `[classification] Using main-thread inference (worker previously failed): ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
+      );
       return this.classifyOnMainThread(excerpt);
     }
+    console.debug(
+      `[classification] Sending to worker: ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
+    );
     try {
       return await this.classifyInWorker(excerpt);
     } catch (workerError) {
@@ -194,9 +221,6 @@ class InstrumentClassificationService {
           : String(workerError);
       console.warn(
         `[classification] Worker failed, falling back to main thread: ${errorDetail}`,
-      );
-      console.warn(
-        `[classification] Excerpt: ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${(excerpt.length / excerpt.sampleRate).toFixed(2)}s`,
       );
       return this.classifyOnMainThread(excerpt);
     }
@@ -260,27 +284,42 @@ class InstrumentClassificationService {
         // Handle download progress updates (service-level, not per-request)
         if (type === 'download-progress') {
           this._downloadProgress.value = event.data.progress;
+          console.debug(
+            `[classification] Model download progress: ${event.data.progress}%`,
+          );
           return;
         }
 
         const response = event.data as ClassifyResponse;
         const pending = this.pendingRequests.get(response.id);
-        if (!pending) return;
+        if (!pending) {
+          console.warn(
+            `[classification] Received worker response for unknown request id=${response.id}`,
+          );
+          return;
+        }
         this.pendingRequests.delete(response.id);
 
         // Model is loaded — clear download progress
         this._downloadProgress.value = null;
 
         if (response.type === 'error') {
+          console.error(
+            `[classification] Worker returned error for request id=${response.id}: ${response.message}`,
+          );
           pending.reject(new Error(response.message));
         } else {
+          console.debug(
+            `[classification] Worker result for request id=${response.id}: "${response.label}" (score: ${response.score.toFixed(3)})`,
+          );
           pending.resolve({
             label: response.label,
             score: response.score,
           });
         }
       };
-      this.worker.onerror = () => {
+      this.worker.onerror = (event) => {
+        console.error('[classification] Worker crashed (onerror):', event);
         this._downloadProgress.value = null;
         this.rejectAllPending(
           new Error(
@@ -304,8 +343,14 @@ class InstrumentClassificationService {
   private async classifyOnMainThread(
     excerpt: AudioExcerpt,
   ): Promise<{ label: string; score: number }> {
+    console.debug(
+      '[classification] Loading classifier for main-thread inference...',
+    );
     const classify = await this.loadClassifier();
     const monoSamples = downmixExcerptToMono(excerpt, MODEL_SAMPLE_RATE);
+    console.debug(
+      `[classification] Main-thread mono audio: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
+    );
     return classify(monoSamples);
   }
 
@@ -337,6 +382,9 @@ class InstrumentClassificationService {
     console.log('[classification] Models loaded on main thread');
 
     return async (monoAudio: Float32Array) => {
+      console.debug(
+        `[classification] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
+      );
       const patches = await computeMelSpectrogram(monoAudio);
       console.log(
         `[classification] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
@@ -354,6 +402,9 @@ class InstrumentClassificationService {
         inputData.set(patches[i], i * PATCH_FRAMES * MEL_BANDS);
       }
 
+      console.debug(
+        `[classification] Running EffNet on ${batchSize} patches...`,
+      );
       const effnetInput = new ort.Tensor('float32', inputData, [
         batchSize,
         PATCH_FRAMES,
@@ -366,6 +417,9 @@ class InstrumentClassificationService {
         data: Float32Array;
         dims: readonly number[];
       };
+      console.debug(
+        `[classification] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
+      );
 
       // Average embeddings across patches
       const embeddingDim = embeddings.dims[1];
@@ -377,6 +431,9 @@ class InstrumentClassificationService {
       }
 
       // Run instrument classification head
+      console.debug(
+        `[classification] Running instrument head (embedding dim: ${embeddingDim})...`,
+      );
       const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
         1,
         embeddingDim,
@@ -397,6 +454,17 @@ class InstrumentClassificationService {
           bestIndex = i;
         }
       }
+
+      // Log top-3 predictions for debugging
+      const scored = Array.from(predictions.data)
+        .map((score, i) => ({ label: JAMENDO_CLASSES[i], score }))
+        .sort((a, b) => b.score - a.score);
+      console.log(
+        `[classification] Top predictions: ${scored
+          .slice(0, 3)
+          .map((p) => `${p.label}=${p.score.toFixed(3)}`)
+          .join(', ')}`,
+      );
 
       return {
         label: JAMENDO_CLASSES[bestIndex],
@@ -429,67 +497,72 @@ class InstrumentClassificationService {
   }
 }
 
-// --- Audio excerpt extraction ---
+// --- Silence trimming ---
 
-function extractLoudestExcerpt(
-  audioBuffer: AudioBuffer,
-  excerptSeconds: number,
-): AudioExcerpt {
+function trimSilence(audioBuffer: AudioBuffer): AudioExcerpt {
   const sampleRate = audioBuffer.sampleRate;
-  const excerptSamples = Math.min(
-    Math.round(excerptSeconds * sampleRate),
-    audioBuffer.length,
-  );
+  const totalSamples = audioBuffer.length;
 
-  // Audio is shorter than the excerpt duration — use full audio
-  if (audioBuffer.length <= excerptSamples) {
-    const channelData: Float32Array[] = [];
-    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-      channelData.push(new Float32Array(audioBuffer.getChannelData(ch)));
-    }
-    return { channelData, sampleRate, length: audioBuffer.length };
-  }
-
-  // Downmix to mono for energy calculation
-  const mono = new Float32Array(audioBuffer.length);
+  // Downmix to mono for RMS calculation
+  const mono = new Float32Array(totalSamples);
   for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
     const data = audioBuffer.getChannelData(ch);
-    for (let i = 0; i < audioBuffer.length; i++) {
+    for (let i = 0; i < totalSamples; i++) {
       mono[i] += data[i] / audioBuffer.numberOfChannels;
     }
   }
 
-  // Cumulative energy for O(1) window energy queries
-  const cumEnergy = new Float64Array(audioBuffer.length + 1);
-  for (let i = 0; i < audioBuffer.length; i++) {
-    cumEnergy[i + 1] = cumEnergy[i] + mono[i] * mono[i];
-  }
+  // Use a small window (10ms) to compute local RMS for silence detection
+  const windowSize = Math.max(1, Math.round(sampleRate * 0.01));
 
-  // Slide a window in 100ms steps to find the loudest segment
-  const step = Math.max(1, Math.round(sampleRate * 0.1));
-  let bestStart = 0;
-  let bestEnergy = -1;
-  for (
-    let start = 0;
-    start <= audioBuffer.length - excerptSamples;
-    start += step
-  ) {
-    const energy = cumEnergy[start + excerptSamples] - cumEnergy[start];
-    if (energy > bestEnergy) {
-      bestEnergy = energy;
-      bestStart = start;
+  // Find first non-silent sample from the start
+  let trimStart = 0;
+  for (let i = 0; i < totalSamples - windowSize; i += windowSize) {
+    const end = Math.min(i + windowSize, totalSamples);
+    let sumSq = 0;
+    for (let j = i; j < end; j++) {
+      sumSq += mono[j] * mono[j];
+    }
+    const rms = Math.sqrt(sumSq / (end - i));
+    if (rms >= SILENCE_THRESHOLD) {
+      trimStart = i;
+      break;
     }
   }
 
+  // Find last non-silent sample from the end
+  let trimEnd = totalSamples;
+  for (let i = totalSamples; i > trimStart + windowSize; i -= windowSize) {
+    const start = Math.max(i - windowSize, 0);
+    let sumSq = 0;
+    for (let j = start; j < i; j++) {
+      sumSq += mono[j] * mono[j];
+    }
+    const rms = Math.sqrt(sumSq / (i - start));
+    if (rms >= SILENCE_THRESHOLD) {
+      trimEnd = i;
+      break;
+    }
+  }
+
+  // If the entire audio is silent, return the full buffer untrimmed
+  if (trimStart >= trimEnd) {
+    console.debug(
+      `[classification] Entire audio appears silent (threshold=${SILENCE_THRESHOLD}), using full buffer`,
+    );
+    const channelData: Float32Array[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      channelData.push(new Float32Array(audioBuffer.getChannelData(ch)));
+    }
+    return { channelData, sampleRate, length: totalSamples };
+  }
+
+  const trimmedLength = trimEnd - trimStart;
   const channelData: Float32Array[] = [];
   for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-    channelData.push(
-      audioBuffer
-        .getChannelData(ch)
-        .slice(bestStart, bestStart + excerptSamples),
-    );
+    channelData.push(audioBuffer.getChannelData(ch).slice(trimStart, trimEnd));
   }
-  return { channelData, sampleRate, length: excerptSamples };
+  return { channelData, sampleRate, length: trimmedLength };
 }
 
 // --- Audio utilities (main-thread fallback) ---

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -538,39 +538,14 @@ describe('InstrumentClassificationService', () => {
     });
   });
 
-  describe('loudest excerpt extraction', () => {
-    it('sends only a 5-second excerpt to the worker for long audio', async () => {
-      // 30 seconds at 16kHz
-      const buffer = createAudioBuffer(1, 480000, 16000);
-      const promise = service.classify('track-long', buffer);
-
-      simulateWorkerResult('electricguitar', 0.85);
-      await promise;
-
-      // Should have sent a 5-second excerpt (80000 samples at 16kHz)
-      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
-      expect(postedMessage.length).toBe(80000);
-    });
-
-    it('sends the full audio when shorter than the excerpt duration', async () => {
-      // 3 seconds at 16kHz — shorter than the 5-second excerpt
-      const buffer = createAudioBuffer(1, 48000, 16000);
-      const promise = service.classify('track-short-ok', buffer);
-
-      simulateWorkerResult('electricguitar', 0.85);
-      await promise;
-
-      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
-      expect(postedMessage.length).toBe(48000);
-    });
-
-    it('picks the loudest segment from long audio', async () => {
-      // Create 10 seconds at 16kHz with a loud section at seconds 3-5
-      const length = 160000;
+  describe('silence trimming', () => {
+    it('trims leading silence before sending to the worker', async () => {
+      // 5 seconds at 16kHz: 1s silence + 4s signal
+      const length = 80000;
       const channelData = new Float32Array(length);
-      // Fill seconds 3-5 (samples 48000-80000) with loud signal
-      for (let i = 48000; i < 80000; i++) {
-        channelData[i] = 0.9 * Math.sin(i * 0.1);
+      // Fill samples 16000–80000 with audible signal
+      for (let i = 16000; i < length; i++) {
+        channelData[i] = 0.5 * Math.sin(i * 0.1);
       }
       const buffer = {
         numberOfChannels: 1,
@@ -580,19 +555,98 @@ describe('InstrumentClassificationService', () => {
         getChannelData: () => channelData,
       } as unknown as AudioBuffer;
 
-      const promise = service.classify('track-loud', buffer);
-
+      const promise = service.classify('track-trim', buffer);
       simulateWorkerResult('electricguitar', 0.85);
       await promise;
 
-      // The 5-second excerpt should overlap with the loud section (samples 48000-80000)
-      const postedData = mockWorker.postMessage.mock.calls[0][0].channelData[0];
-      const excerptEnergy = postedData.reduce(
-        (sum: number, v: number) => sum + v * v,
-        0,
-      );
-      // The excerpt should have significant energy (from the loud section)
-      expect(excerptEnergy).toBeGreaterThan(0);
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      // Trimmed length should be less than the original
+      expect(postedMessage.length).toBeLessThan(length);
+      // Should be approximately 4 seconds (within a 10ms window tolerance)
+      expect(postedMessage.length).toBeGreaterThanOrEqual(63000);
+    });
+
+    it('trims trailing silence before sending to the worker', async () => {
+      // 5 seconds at 16kHz: 4s signal + 1s silence
+      const length = 80000;
+      const channelData = new Float32Array(length);
+      // Fill samples 0–64000 with audible signal
+      for (let i = 0; i < 64000; i++) {
+        channelData[i] = 0.5 * Math.sin(i * 0.1);
+      }
+      const buffer = {
+        numberOfChannels: 1,
+        length,
+        sampleRate: 16000,
+        duration: length / 16000,
+        getChannelData: () => channelData,
+      } as unknown as AudioBuffer;
+
+      const promise = service.classify('track-trim', buffer);
+      simulateWorkerResult('electricguitar', 0.85);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.length).toBeLessThan(length);
+      expect(postedMessage.length).toBeGreaterThanOrEqual(63000);
+    });
+
+    it('sends full audio when there is no silence to trim', async () => {
+      // 3 seconds at 16kHz filled with signal
+      const length = 48000;
+      const channelData = new Float32Array(length);
+      for (let i = 0; i < length; i++) {
+        channelData[i] = 0.5 * Math.sin(i * 0.1);
+      }
+      const buffer = {
+        numberOfChannels: 1,
+        length,
+        sampleRate: 16000,
+        duration: length / 16000,
+        getChannelData: () => channelData,
+      } as unknown as AudioBuffer;
+
+      const promise = service.classify('track-full', buffer);
+      simulateWorkerResult('electricguitar', 0.85);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.length).toBe(length);
+    });
+
+    it('sends full audio when the entire buffer is silent', async () => {
+      // 3 seconds of silence at 16kHz
+      const buffer = createAudioBuffer(1, 48000, 16000);
+
+      const promise = service.classify('track-silent', buffer);
+      simulateWorkerResult('electricguitar', 0.85);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.length).toBe(48000);
+    });
+
+    it('returns unknown when trimmed audio is too short for classification', async () => {
+      // 3 seconds at 16kHz: 2s silence + 1s signal + leftover silence
+      // After trimming, ~1s remains which is below MIN_AUDIO_DURATION_SECONDS
+      const length = 48000;
+      const channelData = new Float32Array(length);
+      // Only fill a short burst (0.5s) in the middle
+      for (let i = 24000; i < 32000; i++) {
+        channelData[i] = 0.5 * Math.sin(i * 0.1);
+      }
+      const buffer = {
+        numberOfChannels: 1,
+        length,
+        sampleRate: 16000,
+        duration: length / 16000,
+        getChannelData: () => channelData,
+      } as unknown as AudioBuffer;
+
+      const label = await service.classify('track-short-trim', buffer);
+
+      expect(label).toBe('unknown');
+      expect(service.getClassificationState('track-short-trim')).toBe('done');
     });
   });
 

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -122,12 +122,13 @@ async function initializeContext(): Promise<InferenceContext> {
     fetchModel(INSTRUMENT_HEAD_URL, onInstrumentProgress),
   ]);
 
+  console.log('[classification:worker] Creating ONNX inference sessions...');
   const [effnetSession, instrumentSession] = await Promise.all([
     ort.InferenceSession.create(effnetBuffer),
     ort.InferenceSession.create(instrumentBuffer),
   ]);
 
-  console.log('[classification:worker] Models loaded');
+  console.log('[classification:worker] Models loaded and sessions created');
   return { effnetSession, instrumentSession, ort };
 }
 
@@ -140,6 +141,9 @@ async function classify(
   const { effnetSession, instrumentSession, ort } = ctx;
 
   // Compute mel spectrogram patches
+  console.log(
+    `[classification:worker] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
+  );
   const patches = await computeMelSpectrogram(monoAudio);
   console.log(
     `[classification:worker] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
@@ -157,6 +161,9 @@ async function classify(
     inputData.set(patches[i], i * PATCH_FRAMES * MEL_BANDS);
   }
 
+  console.log(
+    `[classification:worker] Running EffNet on ${batchSize} patches (input shape: [${batchSize}, ${PATCH_FRAMES}, ${MEL_BANDS}])...`,
+  );
   const effnetInput = new ort.Tensor('float32', inputData, [
     batchSize,
     PATCH_FRAMES,
@@ -169,6 +176,9 @@ async function classify(
     data: Float32Array;
     dims: number[];
   };
+  console.log(
+    `[classification:worker] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
+  );
 
   // Average embeddings across patches → [1, 1280]
   const embeddingDim = embeddings.dims[1];
@@ -180,6 +190,9 @@ async function classify(
   }
 
   // Run instrument classification head → 40 sigmoid predictions
+  console.log(
+    `[classification:worker] Running instrument head (embedding dim: ${embeddingDim})...`,
+  );
   const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
     1,
     embeddingDim,
@@ -200,6 +213,17 @@ async function classify(
       bestIndex = i;
     }
   }
+
+  // Log top-3 predictions for debugging
+  const scored = Array.from(predictions.data)
+    .map((score, i) => ({ label: JAMENDO_CLASSES[i], score }))
+    .sort((a, b) => b.score - a.score);
+  console.log(
+    `[classification:worker] Top predictions: ${scored
+      .slice(0, 3)
+      .map((p) => `${p.label}=${p.score.toFixed(3)}`)
+      .join(', ')}`,
+  );
 
   return {
     label: JAMENDO_CLASSES[bestIndex],


### PR DESCRIPTION
## Summary
- Replaced the loudest-5-second-excerpt extraction with start/end silence trimming for instrument classification preprocessing. The new approach trims leading and trailing silence using a 10ms RMS window, passing the full non-silent audio to the classifier instead of a fixed-length loudest segment.
- Added comprehensive debug and error logging throughout the classification pipeline (service, worker, and main-thread fallback) — including audio dimensions, trim stats, download progress, EffNet/instrument head steps, and top-3 predictions — to aid debugging on mobile devices without devtools access.
- Updated tests to cover silence trimming behavior: leading silence, trailing silence, no silence, fully silent audio, and too-short-after-trim cases.

## Test plan
- [x] All 38 existing + new unit tests pass
- [x] ESLint passes
- [ ] Manual test: upload an audio file with leading/trailing silence and verify classification still works
- [ ] Manual test: check browser console for detailed `[classification]` log messages through the full pipeline

https://claude.ai/code/session_01T1AaRs4JdVR6gQzamDRR5c