### PR TITLE
Replace console logging with in-app LogOverlay for mobile debugging

### DIFF
--- a/src/components/AudioStartup.tsx
+++ b/src/components/AudioStartup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import AudioService from '../services/AudioService';
+import LogService from '../services/LogService';
 import useMessage from './message';
 
 const AudioStartup = () => {
@@ -11,7 +12,7 @@ const AudioStartup = () => {
     startedRef.current = true;
 
     AudioService.startAudio()
-      .then(() => console.log('audio is ready'))
+      .then(() => LogService.log('audio is ready'))
       .catch(() => {
         message('failed to start audio', {
           type: 'error',

--- a/src/components/LogOverlay.css
+++ b/src/components/LogOverlay.css
@@ -1,0 +1,111 @@
+.log-overlay-toggle {
+  position: fixed;
+  bottom: 8px;
+  right: 8px;
+  z-index: 9999;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: monospace;
+  background: #1f1f1f;
+  color: #d9d9d9;
+  border: 1px solid #434343;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.log-overlay-toggle:active {
+  opacity: 1;
+}
+
+.log-overlay {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  height: 40vh;
+  display: flex;
+  flex-direction: column;
+  background: #141414;
+  border-top: 1px solid #434343;
+  font-family: monospace;
+  font-size: 11px;
+}
+
+.log-overlay-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  background: #1f1f1f;
+  color: #d9d9d9;
+  border-bottom: 1px solid #434343;
+  flex-shrink: 0;
+}
+
+.log-overlay-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.log-overlay-actions button {
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: monospace;
+  background: #2a2a2a;
+  color: #d9d9d9;
+  border: 1px solid #434343;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.log-overlay-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.log-entry {
+  display: flex;
+  gap: 6px;
+  padding: 1px 8px;
+  color: #d9d9d9;
+  word-break: break-all;
+}
+
+.log-entry-level {
+  flex-shrink: 0;
+  width: 28px;
+  color: #8c8c8c;
+}
+
+.log-entry-time {
+  flex-shrink: 0;
+  color: #595959;
+}
+
+.log-entry-message {
+  white-space: pre-wrap;
+}
+
+.log-entry-warn {
+  color: #faad14;
+}
+
+.log-entry-warn .log-entry-level {
+  color: #faad14;
+}
+
+.log-entry-error {
+  color: #ff4d4f;
+}
+
+.log-entry-error .log-entry-level {
+  color: #ff4d4f;
+}
+
+.log-entry-debug {
+  color: #8c8c8c;
+}

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import useLogService from '../hooks/useLogService';
+import type { LogLevel } from '../services/LogService';
+import './LogOverlay.css';
+
+const LEVEL_LABELS: Record<LogLevel, string> = {
+  log: 'LOG',
+  warn: 'WRN',
+  error: 'ERR',
+  debug: 'DBG',
+};
+
+const LogOverlay = () => {
+  const { entries, clear } = useLogService();
+  const [isOpen, setIsOpen] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when new entries arrive
+  useEffect(() => {
+    if (isOpen && listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [entries, isOpen]);
+
+  const badge = entries.length > 0 ? ` (${entries.length})` : '';
+
+  if (!isOpen) {
+    return (
+      <button className="log-overlay-toggle" onClick={() => setIsOpen(true)}>
+        Logs{badge}
+      </button>
+    );
+  }
+
+  return (
+    <div className="log-overlay">
+      <div className="log-overlay-header">
+        <span>Logs ({entries.length})</span>
+        <div className="log-overlay-actions">
+          <button onClick={clear}>Clear</button>
+          <button onClick={() => setIsOpen(false)}>Close</button>
+        </div>
+      </div>
+      <div className="log-overlay-list" ref={listRef}>
+        {entries.map((entry) => (
+          <div key={entry.id} className={`log-entry log-entry-${entry.level}`}>
+            <span className="log-entry-level">{LEVEL_LABELS[entry.level]}</span>
+            <span className="log-entry-time">
+              {formatTime(entry.timestamp)}
+            </span>
+            <span className="log-entry-message">{entry.message}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  const h = String(date.getHours()).padStart(2, '0');
+  const m = String(date.getMinutes()).padStart(2, '0');
+  const s = String(date.getSeconds()).padStart(2, '0');
+  const ms = String(date.getMilliseconds()).padStart(3, '0');
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+export default LogOverlay;

--- a/src/hooks/useLogService.ts
+++ b/src/hooks/useLogService.ts
@@ -1,0 +1,25 @@
+// Bridge hook: LogService signals → React components.
+//
+// Calls useSignals() to subscribe to LogService's entries signal,
+// then returns plain values and action callbacks for components.
+
+import { useSignals } from '@preact/signals-react/runtime';
+import LogService, { type LogEntry } from '../services/LogService';
+
+type LogServiceHook = {
+  entries: readonly LogEntry[];
+  clear: () => void;
+};
+
+const useLogService = (): LogServiceHook => {
+  useSignals();
+
+  return {
+    get entries() {
+      return LogService.signals.entries.value;
+    },
+    clear: LogService.clear,
+  };
+};
+
+export default useLogService;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { BrowserSupportProvider } from './browserSupport';
 import App from './components/App';
 import AudioStartup from './components/AudioStartup';
+import LogOverlay from './components/LogOverlay';
 import './index.css';
 
 const root = createRoot(document.getElementById('root')!);
@@ -25,6 +26,7 @@ root.render(
             <App />
           </BrowserRouter>
         </BrowserSupportProvider>
+        <LogOverlay />
       </AntApp>
     </ConfigProvider>
   </StyleProvider>,

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -19,6 +19,7 @@ import {
   mapToInstrumentLabel,
   type InstrumentLabel,
 } from './instrumentLabels';
+import LogService from './LogService';
 import { computeMelSpectrogram } from './melSpectrogram';
 import { fetchModel } from './ModelCache';
 
@@ -138,7 +139,7 @@ class InstrumentClassificationService {
     if (this.cache.has(trackId)) {
       const cached = this.cache.get(trackId)!;
       if (cached.state === 'done' && cached.result) {
-        console.debug(
+        LogService.debug(
           `[classification] Track ${trackId} already classified as "${cached.result.label}" (cached)`,
         );
         return cached.result.label;
@@ -146,12 +147,12 @@ class InstrumentClassificationService {
     }
 
     const durationSeconds = audioBuffer.length / audioBuffer.sampleRate;
-    console.debug(
+    LogService.debug(
       `[classification] Track ${trackId}: ${audioBuffer.numberOfChannels}ch, ${audioBuffer.length} samples, ${audioBuffer.sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
     );
 
     if (durationSeconds < MIN_AUDIO_DURATION_SECONDS) {
-      console.log(
+      LogService.log(
         `[classification] Track ${trackId} too short (${durationSeconds.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
       );
       const result: ClassificationResult = {
@@ -164,12 +165,12 @@ class InstrumentClassificationService {
 
     const excerpt = trimSilence(audioBuffer);
     const trimmedDuration = excerpt.length / excerpt.sampleRate;
-    console.debug(
+    LogService.debug(
       `[classification] Track ${trackId} after silence trim: ${excerpt.length} samples, ${trimmedDuration.toFixed(2)}s (removed ${(durationSeconds - trimmedDuration).toFixed(2)}s of silence)`,
     );
 
     if (trimmedDuration < MIN_AUDIO_DURATION_SECONDS) {
-      console.log(
+      LogService.log(
         `[classification] Track ${trackId} too short after trimming (${trimmedDuration.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
       );
       const result: ClassificationResult = {
@@ -181,14 +182,14 @@ class InstrumentClassificationService {
     }
 
     this.setEntry(trackId, { state: 'classifying' });
-    console.log(`[classification] Classifying track ${trackId}`);
+    LogService.log(`[classification] Classifying track ${trackId}`);
 
     try {
       const rawResult = await this.runInference(excerpt);
       return this.applyResult(trackId, rawResult);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      console.error(
+      LogService.error(
         `[classification] Classification failed for track ${trackId}: ${detail}`,
       );
       this.setEntry(trackId, { state: 'error' });
@@ -203,12 +204,12 @@ class InstrumentClassificationService {
   ): Promise<RawClassificationResult> {
     const excerptDuration = (excerpt.length / excerpt.sampleRate).toFixed(2);
     if (this.workerFailed) {
-      console.debug(
+      LogService.debug(
         `[classification] Using main-thread inference (worker previously failed): ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
       );
       return this.classifyOnMainThread(excerpt);
     }
-    console.debug(
+    LogService.debug(
       `[classification] Sending to worker: ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
     );
     try {
@@ -219,7 +220,7 @@ class InstrumentClassificationService {
         workerError instanceof Error
           ? workerError.message
           : String(workerError);
-      console.warn(
+      LogService.warn(
         `[classification] Worker failed, falling back to main thread: ${errorDetail}`,
       );
       return this.classifyOnMainThread(excerpt);
@@ -235,7 +236,7 @@ class InstrumentClassificationService {
       score: rawResult.score,
     };
     this.setEntry(trackId, { state: 'done', result });
-    console.log(
+    LogService.log(
       `[classification] Track ${trackId} classified as "${result.label}" (raw: "${rawResult.label}", score: ${result.score.toFixed(3)})`,
     );
     return result.label;
@@ -281,10 +282,17 @@ class InstrumentClassificationService {
       this.worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
         const { type } = event.data;
 
+        // Forward worker log messages to LogService
+        if (type === 'log') {
+          const { level, message } = event.data;
+          LogService[level](message);
+          return;
+        }
+
         // Handle download progress updates (service-level, not per-request)
         if (type === 'download-progress') {
           this._downloadProgress.value = event.data.progress;
-          console.debug(
+          LogService.debug(
             `[classification] Model download progress: ${event.data.progress}%`,
           );
           return;
@@ -293,7 +301,7 @@ class InstrumentClassificationService {
         const response = event.data as ClassifyResponse;
         const pending = this.pendingRequests.get(response.id);
         if (!pending) {
-          console.warn(
+          LogService.warn(
             `[classification] Received worker response for unknown request id=${response.id}`,
           );
           return;
@@ -304,12 +312,12 @@ class InstrumentClassificationService {
         this._downloadProgress.value = null;
 
         if (response.type === 'error') {
-          console.error(
+          LogService.error(
             `[classification] Worker returned error for request id=${response.id}: ${response.message}`,
           );
           pending.reject(new Error(response.message));
         } else {
-          console.debug(
+          LogService.debug(
             `[classification] Worker result for request id=${response.id}: "${response.label}" (score: ${response.score.toFixed(3)})`,
           );
           pending.resolve({
@@ -319,7 +327,7 @@ class InstrumentClassificationService {
         }
       };
       this.worker.onerror = (event) => {
-        console.error('[classification] Worker crashed (onerror):', event);
+        LogService.error('[classification] Worker crashed (onerror):', event);
         this._downloadProgress.value = null;
         this.rejectAllPending(
           new Error(
@@ -343,12 +351,12 @@ class InstrumentClassificationService {
   private async classifyOnMainThread(
     excerpt: AudioExcerpt,
   ): Promise<{ label: string; score: number }> {
-    console.debug(
+    LogService.debug(
       '[classification] Loading classifier for main-thread inference...',
     );
     const classify = await this.loadClassifier();
     const monoSamples = downmixExcerptToMono(excerpt, MODEL_SAMPLE_RATE);
-    console.debug(
+    LogService.debug(
       `[classification] Main-thread mono audio: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
     );
     return classify(monoSamples);
@@ -365,7 +373,7 @@ class InstrumentClassificationService {
   }
 
   private async initializeClassifier(): Promise<Classifier> {
-    console.log('[classification] Loading ONNX models on main thread...');
+    LogService.log('[classification] Loading ONNX models on main thread...');
     const ort = await import('onnxruntime-web');
     ort.env.wasm.numThreads = 1;
 
@@ -379,14 +387,14 @@ class InstrumentClassificationService {
       ort.InferenceSession.create(instrumentBuffer),
     ]);
 
-    console.log('[classification] Models loaded on main thread');
+    LogService.log('[classification] Models loaded on main thread');
 
     return async (monoAudio: Float32Array) => {
-      console.debug(
+      LogService.debug(
         `[classification] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
       );
       const patches = await computeMelSpectrogram(monoAudio);
-      console.log(
+      LogService.log(
         `[classification] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
       );
       if (patches.length === 0) {
@@ -402,7 +410,7 @@ class InstrumentClassificationService {
         inputData.set(patches[i], i * PATCH_FRAMES * MEL_BANDS);
       }
 
-      console.debug(
+      LogService.debug(
         `[classification] Running EffNet on ${batchSize} patches...`,
       );
       const effnetInput = new ort.Tensor('float32', inputData, [
@@ -417,7 +425,7 @@ class InstrumentClassificationService {
         data: Float32Array;
         dims: readonly number[];
       };
-      console.debug(
+      LogService.debug(
         `[classification] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
       );
 
@@ -431,7 +439,7 @@ class InstrumentClassificationService {
       }
 
       // Run instrument classification head
-      console.debug(
+      LogService.debug(
         `[classification] Running instrument head (embedding dim: ${embeddingDim})...`,
       );
       const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
@@ -459,7 +467,7 @@ class InstrumentClassificationService {
       const scored = Array.from(predictions.data)
         .map((score, i) => ({ label: JAMENDO_CLASSES[i], score }))
         .sort((a, b) => b.score - a.score);
-      console.log(
+      LogService.log(
         `[classification] Top predictions: ${scored
           .slice(0, 3)
           .map((p) => `${p.label}=${p.score.toFixed(3)}`)
@@ -547,7 +555,7 @@ function trimSilence(audioBuffer: AudioBuffer): AudioExcerpt {
 
   // If the entire audio is silent, return the full buffer untrimmed
   if (trimStart >= trimEnd) {
-    console.debug(
+    LogService.debug(
       `[classification] Entire audio appears silent (threshold=${SILENCE_THRESHOLD}), using full buffer`,
     );
     const channelData: Float32Array[] = [];

--- a/src/services/LogService.ts
+++ b/src/services/LogService.ts
@@ -1,0 +1,85 @@
+// LogService — captures log messages for display in the UI.
+//
+// Replaces console.log/warn/error calls throughout the app so that log
+// output is visible on devices without devtools (e.g. mobile browsers).
+//
+// Signal ownership: LogService owns the `entries` signal. Only LogService
+// writes to it. Consumers read via the `signals` accessor (bridge hooks)
+// or the plain `entries` getter (tests, workflows).
+
+import { signal, type ReadonlySignal } from '@preact/signals-react';
+
+export type LogLevel = 'log' | 'warn' | 'error' | 'debug';
+
+export type LogEntry = {
+  id: number;
+  level: LogLevel;
+  message: string;
+  timestamp: number;
+};
+
+const MAX_ENTRIES = 200;
+
+let nextId = 0;
+
+const _entries = signal<readonly LogEntry[]>([]);
+
+// --- Narrow channel for reactive consumers (hooks) ---
+
+const signals: {
+  readonly entries: ReadonlySignal<readonly LogEntry[]>;
+} = {
+  entries: _entries,
+};
+
+// --- Plain getter for non-reactive consumers (tests, workflows) ---
+
+function getEntries(): readonly LogEntry[] {
+  return _entries.value;
+}
+
+// --- Mutation functions ---
+
+function append(level: LogLevel, args: unknown[]): void {
+  const message = args
+    .map((arg) =>
+      typeof arg === 'string' ? arg : JSON.stringify(arg, null, 2),
+    )
+    .join(' ');
+
+  const entry: LogEntry = {
+    id: nextId++,
+    level,
+    message,
+    timestamp: Date.now(),
+  };
+
+  const current = _entries.value;
+  const updated =
+    current.length >= MAX_ENTRIES
+      ? [...current.slice(current.length - MAX_ENTRIES + 1), entry]
+      : [...current, entry];
+  _entries.value = updated;
+}
+
+function log(...args: unknown[]): void {
+  append('log', args);
+}
+
+function warn(...args: unknown[]): void {
+  append('warn', args);
+}
+
+function error(...args: unknown[]): void {
+  append('error', args);
+}
+
+function debug(...args: unknown[]): void {
+  append('debug', args);
+}
+
+function clear(): void {
+  _entries.value = [];
+}
+
+export default { signals, getEntries, log, warn, error, debug, clear };

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -43,7 +43,16 @@ export type DownloadProgressMessage = {
   progress: number;
 };
 
-export type WorkerMessage = ClassifyResponse | DownloadProgressMessage;
+export type WorkerLogMessage = {
+  type: 'log';
+  level: 'log' | 'warn' | 'error' | 'debug';
+  message: string;
+};
+
+export type WorkerMessage =
+  | ClassifyResponse
+  | DownloadProgressMessage
+  | WorkerLogMessage;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OnnxSession = any;
@@ -90,7 +99,7 @@ function reportProgress(url: string, loaded: number, total: number): void {
 }
 
 async function initializeContext(): Promise<InferenceContext> {
-  console.log('[classification:worker] Loading ONNX models...');
+  workerLog('log', '[classification:worker] Loading ONNX models...');
   const ort = await import('onnxruntime-web');
 
   // Disable multithreading to avoid SharedArrayBuffer requirement
@@ -103,9 +112,15 @@ async function initializeContext(): Promise<InferenceContext> {
   const allCached = effnetCached && instrumentCached;
 
   if (allCached) {
-    console.log('[classification:worker] Models found in cache, loading...');
+    workerLog(
+      'log',
+      '[classification:worker] Models found in cache, loading...',
+    );
   } else {
-    console.log('[classification:worker] Downloading models from network...');
+    workerLog(
+      'log',
+      '[classification:worker] Downloading models from network...',
+    );
   }
 
   const onEffnetProgress = allCached
@@ -122,13 +137,19 @@ async function initializeContext(): Promise<InferenceContext> {
     fetchModel(INSTRUMENT_HEAD_URL, onInstrumentProgress),
   ]);
 
-  console.log('[classification:worker] Creating ONNX inference sessions...');
+  workerLog(
+    'log',
+    '[classification:worker] Creating ONNX inference sessions...',
+  );
   const [effnetSession, instrumentSession] = await Promise.all([
     ort.InferenceSession.create(effnetBuffer),
     ort.InferenceSession.create(instrumentBuffer),
   ]);
 
-  console.log('[classification:worker] Models loaded and sessions created');
+  workerLog(
+    'log',
+    '[classification:worker] Models loaded and sessions created',
+  );
   return { effnetSession, instrumentSession, ort };
 }
 
@@ -141,11 +162,13 @@ async function classify(
   const { effnetSession, instrumentSession, ort } = ctx;
 
   // Compute mel spectrogram patches
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
   );
   const patches = await computeMelSpectrogram(monoAudio);
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
   );
   if (patches.length === 0) {
@@ -161,7 +184,8 @@ async function classify(
     inputData.set(patches[i], i * PATCH_FRAMES * MEL_BANDS);
   }
 
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Running EffNet on ${batchSize} patches (input shape: [${batchSize}, ${PATCH_FRAMES}, ${MEL_BANDS}])...`,
   );
   const effnetInput = new ort.Tensor('float32', inputData, [
@@ -176,7 +200,8 @@ async function classify(
     data: Float32Array;
     dims: number[];
   };
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
   );
 
@@ -190,7 +215,8 @@ async function classify(
   }
 
   // Run instrument classification head → 40 sigmoid predictions
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Running instrument head (embedding dim: ${embeddingDim})...`,
   );
   const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
@@ -218,7 +244,8 @@ async function classify(
   const scored = Array.from(predictions.data)
     .map((score, i) => ({ label: JAMENDO_CLASSES[i], score }))
     .sort((a, b) => b.score - a.score);
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Top predictions: ${scored
       .slice(0, 3)
       .map((p) => `${p.label}=${p.score.toFixed(3)}`)
@@ -282,13 +309,25 @@ type WorkerSelf = {
 
 const workerSelf = self as unknown as WorkerSelf;
 
+// Forward log messages to the main thread for display in the UI overlay.
+// Workers don't have access to LogService, so we post messages that the
+// main thread handler picks up and routes to LogService.
+function workerLog(level: WorkerLogMessage['level'], message: string): void {
+  workerSelf.postMessage({
+    type: 'log',
+    level,
+    message,
+  } satisfies WorkerLogMessage);
+}
+
 workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
   const { id, channelData, sampleRate, length } = event.data;
 
   const channels = channelData.length;
   const firstChannelLength = channelData[0]?.length ?? 0;
   const durationSeconds = length / sampleRate;
-  console.log(
+  workerLog(
+    'log',
     `[classification:worker] Received audio: ${channels}ch, ${length} samples (actual first channel: ${firstChannelLength}), ${sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
   );
 
@@ -306,7 +345,8 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
     const ctx = await loadContext();
     const monoSamples = downmixToMono(channelData, sampleRate, length);
 
-    console.log(
+    workerLog(
+      'log',
       `[classification:worker] Mono audio after downmix: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
     );
 
@@ -321,7 +361,10 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
     workerSelf.postMessage(response);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`[classification:worker] Classification failed: ${message}`);
+    workerLog(
+      'error',
+      `[classification:worker] Classification failed: ${message}`,
+    );
     const response: ClassifyResponse = { id, type: 'error', message };
     workerSelf.postMessage(response);
   }


### PR DESCRIPTION
## Summary

- Added `LogService` (signal-based) that stores log entries with level, message, and timestamp
- Added `useLogService` bridge hook for reactive access from React components
- Added `LogOverlay` component — a collapsible panel at the bottom of the screen that displays all log output with color-coded levels and timestamps
- Replaced all `console.log/warn/error/debug` calls in `AudioStartup.tsx` and `InstrumentClassificationService.ts` with `LogService` calls
- Worker logs (`classification.worker.ts`) are forwarded to the main thread via a new `log` message type, then routed to `LogService`

## Test plan

- [ ] Open the app on a mobile device — tap "Logs" button in the bottom-right corner to expand the log panel
- [ ] Upload an audio file and verify classification log messages appear in the overlay
- [ ] Verify log levels are color-coded: white for log, yellow for warn, red for error, grey for debug
- [ ] Tap "Clear" to clear all entries, "Close" to collapse the panel
- [ ] Confirm all 795 existing tests still pass (`npm test -- --run`)
- [ ] Confirm lint passes (`npm run lint`)
- [ ] Confirm production build succeeds (`npm run build`)

https://claude.ai/code/session_01GWKEgDFxhbkG9b76YZ1iUZ