### PR TITLE
Refactor logging: intercept console methods, move View Logs to overflow menu

### DIFF
--- a/src/components/AudioStartup.tsx
+++ b/src/components/AudioStartup.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import AudioService from '../services/AudioService';
-import LogService from '../services/LogService';
 import useMessage from './message';
 
 const AudioStartup = () => {
@@ -12,7 +11,7 @@ const AudioStartup = () => {
     startedRef.current = true;
 
     AudioService.startAudio()
-      .then(() => LogService.log('audio is ready'))
+      .then(() => console.log('audio is ready'))
       .catch(() => {
         message('failed to start audio', {
           type: 'error',

--- a/src/components/LogOverlay.css
+++ b/src/components/LogOverlay.css
@@ -1,23 +1,3 @@
-.log-overlay-toggle {
-  position: fixed;
-  bottom: 8px;
-  right: 8px;
-  z-index: 9999;
-  padding: 4px 10px;
-  font-size: 12px;
-  font-family: monospace;
-  background: #1f1f1f;
-  color: #d9d9d9;
-  border: 1px solid #434343;
-  border-radius: 4px;
-  cursor: pointer;
-  opacity: 0.7;
-}
-
-.log-overlay-toggle:active {
-  opacity: 1;
-}
-
 .log-overlay {
   position: fixed;
   bottom: 0;

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import useLogService from '../hooks/useLogService';
 import type { LogLevel } from '../services/LogService';
 import './LogOverlay.css';
@@ -10,9 +10,14 @@ const LEVEL_LABELS: Record<LogLevel, string> = {
   debug: 'DBG',
 };
 
-const LogOverlay = () => {
+type LogOverlayProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const LogOverlay = (props: LogOverlayProps) => {
+  const { isOpen, onClose } = props;
   const { entries, clear } = useLogService();
-  const [isOpen, setIsOpen] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to bottom when new entries arrive
@@ -22,14 +27,8 @@ const LogOverlay = () => {
     }
   }, [entries, isOpen]);
 
-  const badge = entries.length > 0 ? ` (${entries.length})` : '';
-
   if (!isOpen) {
-    return (
-      <button className="log-overlay-toggle" onClick={() => setIsOpen(true)}>
-        Logs{badge}
-      </button>
-    );
+    return null;
   }
 
   return (
@@ -38,7 +37,7 @@ const LogOverlay = () => {
         <span>Logs ({entries.length})</span>
         <div className="log-overlay-actions">
           <button onClick={clear}>Clear</button>
-          <button onClick={() => setIsOpen(false)}>Close</button>
+          <button onClick={onClose}>Close</button>
         </div>
       </div>
       <div className="log-overlay-list" ref={listRef}>

--- a/src/components/project/ProjectPage.tsx
+++ b/src/components/project/ProjectPage.tsx
@@ -1,6 +1,8 @@
+import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Fullscreen from '../fullscreen/Fullscreen';
 import { PageContent, PageHeader, PageLayout } from '../layout/PageLayout';
+import LogOverlay from '../LogOverlay';
 import Workstation from '../workstation/Workstation';
 import './ProjectPage.css';
 import {
@@ -38,6 +40,7 @@ type ProjectPageContentProps = {
 
 const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
   const [state, dispatch, undoControls] = useProjectReducer(initialState);
+  const [isLogOverlayOpen, setIsLogOverlayOpen] = useState(false);
 
   const uploadFile = useUploadFile(dispatch);
   const [fullScreenHandle, toggleFullscreen] = useFullscreen();
@@ -45,6 +48,11 @@ const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
   useTrackSideEffects(state.tracks);
   useDeleteTrackAudio(state.tracks);
   useAutoSave(state);
+
+  const toggleLogOverlay = useCallback(
+    () => setIsLogOverlayOpen((prev) => !prev),
+    [],
+  );
 
   const recordingColor = COLOR_PALETTE[state.nextColorId];
 
@@ -62,6 +70,8 @@ const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
               uploadFile={uploadFile}
               isFullscreen={fullScreenHandle.active}
               toggleFullscreen={toggleFullscreen}
+              isLogOverlayOpen={isLogOverlayOpen}
+              toggleLogOverlay={toggleLogOverlay}
               undo={undoControls.undo}
               redo={undoControls.redo}
               canUndo={undoControls.canUndo}
@@ -77,6 +87,7 @@ const ProjectPageContent = ({ initialState }: ProjectPageContentProps) => {
             />
           </PageContent>
         </PageLayout>
+        <LogOverlay isOpen={isLogOverlayOpen} onClose={toggleLogOverlay} />
       </Fullscreen>
     </ProjectDispatch.Provider>
   );

--- a/src/components/project/ProjectPageHeader.tsx
+++ b/src/components/project/ProjectPageHeader.tsx
@@ -16,6 +16,8 @@ type ProjectPageHeaderProps = {
   uploadFile: (file: File) => void;
   isFullscreen: boolean;
   toggleFullscreen: (state?: boolean) => void;
+  isLogOverlayOpen: boolean;
+  toggleLogOverlay: () => void;
   undo: () => void;
   redo: () => void;
   canUndo: boolean;
@@ -98,6 +100,8 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
         <OverflowMenu
           isFullscreen={props.isFullscreen}
           toggleFullscreen={props.toggleFullscreen}
+          isLogOverlayOpen={props.isLogOverlayOpen}
+          toggleLogOverlay={props.toggleLogOverlay}
           getPopupContainer={() => containerRef.current!}
         />
       </div>
@@ -135,17 +139,30 @@ const UploadButton = (props: UploadButtonProps) => {
 type OverflowMenuProps = {
   isFullscreen: boolean;
   toggleFullscreen: (state?: boolean) => void;
+  isLogOverlayOpen: boolean;
+  toggleLogOverlay: () => void;
   getPopupContainer: () => HTMLElement;
 };
 
 const OverflowMenu = (props: OverflowMenuProps) => {
-  const { isFullscreen, toggleFullscreen, getPopupContainer } = props;
+  const {
+    isFullscreen,
+    toggleFullscreen,
+    isLogOverlayOpen,
+    toggleLogOverlay,
+    getPopupContainer,
+  } = props;
 
   const items: MenuProps['items'] = [
     {
       key: 'fullscreen',
       label: isFullscreen ? 'Exit Full Screen' : 'Enter Full Screen',
       onClick: () => toggleFullscreen(),
+    },
+    {
+      key: 'logs',
+      label: isLogOverlayOpen ? 'Hide Logs' : 'View Logs',
+      onClick: toggleLogOverlay,
     },
   ];
 

--- a/src/components/project/__tests__/ProjectPageHeader.test.tsx
+++ b/src/components/project/__tests__/ProjectPageHeader.test.tsx
@@ -14,6 +14,8 @@ const defaultProps = {
   uploadFile: mockUploadFile,
   isFullscreen: false,
   toggleFullscreen: vi.fn(),
+  isLogOverlayOpen: false,
+  toggleLogOverlay: vi.fn(),
   undo: mockUndo,
   redo: mockRedo,
   canUndo: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,11 @@ import { BrowserRouter } from 'react-router-dom';
 import { BrowserSupportProvider } from './browserSupport';
 import App from './components/App';
 import AudioStartup from './components/AudioStartup';
-import LogOverlay from './components/LogOverlay';
+import LogService from './services/LogService';
 import './index.css';
+
+// Intercept console methods before any logging occurs
+LogService.install();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(
@@ -26,7 +29,6 @@ root.render(
             <App />
           </BrowserRouter>
         </BrowserSupportProvider>
-        <LogOverlay />
       </AntApp>
     </ConfigProvider>
   </StyleProvider>,

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -19,7 +19,6 @@ import {
   mapToInstrumentLabel,
   type InstrumentLabel,
 } from './instrumentLabels';
-import LogService from './LogService';
 import { computeMelSpectrogram } from './melSpectrogram';
 import { fetchModel } from './ModelCache';
 
@@ -139,7 +138,7 @@ class InstrumentClassificationService {
     if (this.cache.has(trackId)) {
       const cached = this.cache.get(trackId)!;
       if (cached.state === 'done' && cached.result) {
-        LogService.debug(
+        console.debug(
           `[classification] Track ${trackId} already classified as "${cached.result.label}" (cached)`,
         );
         return cached.result.label;
@@ -147,12 +146,12 @@ class InstrumentClassificationService {
     }
 
     const durationSeconds = audioBuffer.length / audioBuffer.sampleRate;
-    LogService.debug(
+    console.debug(
       `[classification] Track ${trackId}: ${audioBuffer.numberOfChannels}ch, ${audioBuffer.length} samples, ${audioBuffer.sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
     );
 
     if (durationSeconds < MIN_AUDIO_DURATION_SECONDS) {
-      LogService.log(
+      console.log(
         `[classification] Track ${trackId} too short (${durationSeconds.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
       );
       const result: ClassificationResult = {
@@ -165,12 +164,12 @@ class InstrumentClassificationService {
 
     const excerpt = trimSilence(audioBuffer);
     const trimmedDuration = excerpt.length / excerpt.sampleRate;
-    LogService.debug(
+    console.debug(
       `[classification] Track ${trackId} after silence trim: ${excerpt.length} samples, ${trimmedDuration.toFixed(2)}s (removed ${(durationSeconds - trimmedDuration).toFixed(2)}s of silence)`,
     );
 
     if (trimmedDuration < MIN_AUDIO_DURATION_SECONDS) {
-      LogService.log(
+      console.log(
         `[classification] Track ${trackId} too short after trimming (${trimmedDuration.toFixed(1)}s < ${MIN_AUDIO_DURATION_SECONDS}s) — skipping`,
       );
       const result: ClassificationResult = {
@@ -182,14 +181,14 @@ class InstrumentClassificationService {
     }
 
     this.setEntry(trackId, { state: 'classifying' });
-    LogService.log(`[classification] Classifying track ${trackId}`);
+    console.log(`[classification] Classifying track ${trackId}`);
 
     try {
       const rawResult = await this.runInference(excerpt);
       return this.applyResult(trackId, rawResult);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      LogService.error(
+      console.error(
         `[classification] Classification failed for track ${trackId}: ${detail}`,
       );
       this.setEntry(trackId, { state: 'error' });
@@ -204,12 +203,12 @@ class InstrumentClassificationService {
   ): Promise<RawClassificationResult> {
     const excerptDuration = (excerpt.length / excerpt.sampleRate).toFixed(2);
     if (this.workerFailed) {
-      LogService.debug(
+      console.debug(
         `[classification] Using main-thread inference (worker previously failed): ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
       );
       return this.classifyOnMainThread(excerpt);
     }
-    LogService.debug(
+    console.debug(
       `[classification] Sending to worker: ${excerpt.channelData.length}ch, ${excerpt.length} samples, ${excerpt.sampleRate} Hz, ${excerptDuration}s`,
     );
     try {
@@ -220,7 +219,7 @@ class InstrumentClassificationService {
         workerError instanceof Error
           ? workerError.message
           : String(workerError);
-      LogService.warn(
+      console.warn(
         `[classification] Worker failed, falling back to main thread: ${errorDetail}`,
       );
       return this.classifyOnMainThread(excerpt);
@@ -236,7 +235,7 @@ class InstrumentClassificationService {
       score: rawResult.score,
     };
     this.setEntry(trackId, { state: 'done', result });
-    LogService.log(
+    console.log(
       `[classification] Track ${trackId} classified as "${result.label}" (raw: "${rawResult.label}", score: ${result.score.toFixed(3)})`,
     );
     return result.label;
@@ -282,17 +281,17 @@ class InstrumentClassificationService {
       this.worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
         const { type } = event.data;
 
-        // Forward worker log messages to LogService
+        // Forward worker log messages to console
         if (type === 'log') {
           const { level, message } = event.data;
-          LogService[level](message);
+          console[level](message);
           return;
         }
 
         // Handle download progress updates (service-level, not per-request)
         if (type === 'download-progress') {
           this._downloadProgress.value = event.data.progress;
-          LogService.debug(
+          console.debug(
             `[classification] Model download progress: ${event.data.progress}%`,
           );
           return;
@@ -301,7 +300,7 @@ class InstrumentClassificationService {
         const response = event.data as ClassifyResponse;
         const pending = this.pendingRequests.get(response.id);
         if (!pending) {
-          LogService.warn(
+          console.warn(
             `[classification] Received worker response for unknown request id=${response.id}`,
           );
           return;
@@ -312,12 +311,12 @@ class InstrumentClassificationService {
         this._downloadProgress.value = null;
 
         if (response.type === 'error') {
-          LogService.error(
+          console.error(
             `[classification] Worker returned error for request id=${response.id}: ${response.message}`,
           );
           pending.reject(new Error(response.message));
         } else {
-          LogService.debug(
+          console.debug(
             `[classification] Worker result for request id=${response.id}: "${response.label}" (score: ${response.score.toFixed(3)})`,
           );
           pending.resolve({
@@ -327,7 +326,7 @@ class InstrumentClassificationService {
         }
       };
       this.worker.onerror = (event) => {
-        LogService.error('[classification] Worker crashed (onerror):', event);
+        console.error('[classification] Worker crashed (onerror):', event);
         this._downloadProgress.value = null;
         this.rejectAllPending(
           new Error(
@@ -351,12 +350,12 @@ class InstrumentClassificationService {
   private async classifyOnMainThread(
     excerpt: AudioExcerpt,
   ): Promise<{ label: string; score: number }> {
-    LogService.debug(
+    console.debug(
       '[classification] Loading classifier for main-thread inference...',
     );
     const classify = await this.loadClassifier();
     const monoSamples = downmixExcerptToMono(excerpt, MODEL_SAMPLE_RATE);
-    LogService.debug(
+    console.debug(
       `[classification] Main-thread mono audio: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
     );
     return classify(monoSamples);
@@ -373,7 +372,7 @@ class InstrumentClassificationService {
   }
 
   private async initializeClassifier(): Promise<Classifier> {
-    LogService.log('[classification] Loading ONNX models on main thread...');
+    console.log('[classification] Loading ONNX models on main thread...');
     const ort = await import('onnxruntime-web');
     ort.env.wasm.numThreads = 1;
 
@@ -387,14 +386,14 @@ class InstrumentClassificationService {
       ort.InferenceSession.create(instrumentBuffer),
     ]);
 
-    LogService.log('[classification] Models loaded on main thread');
+    console.log('[classification] Models loaded on main thread');
 
     return async (monoAudio: Float32Array) => {
-      LogService.debug(
+      console.debug(
         `[classification] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
       );
       const patches = await computeMelSpectrogram(monoAudio);
-      LogService.log(
+      console.log(
         `[classification] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
       );
       if (patches.length === 0) {
@@ -410,7 +409,7 @@ class InstrumentClassificationService {
         inputData.set(patches[i], i * PATCH_FRAMES * MEL_BANDS);
       }
 
-      LogService.debug(
+      console.debug(
         `[classification] Running EffNet on ${batchSize} patches...`,
       );
       const effnetInput = new ort.Tensor('float32', inputData, [
@@ -425,7 +424,7 @@ class InstrumentClassificationService {
         data: Float32Array;
         dims: readonly number[];
       };
-      LogService.debug(
+      console.debug(
         `[classification] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
       );
 
@@ -439,7 +438,7 @@ class InstrumentClassificationService {
       }
 
       // Run instrument classification head
-      LogService.debug(
+      console.debug(
         `[classification] Running instrument head (embedding dim: ${embeddingDim})...`,
       );
       const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
@@ -467,7 +466,7 @@ class InstrumentClassificationService {
       const scored = Array.from(predictions.data)
         .map((score, i) => ({ label: JAMENDO_CLASSES[i], score }))
         .sort((a, b) => b.score - a.score);
-      LogService.log(
+      console.log(
         `[classification] Top predictions: ${scored
           .slice(0, 3)
           .map((p) => `${p.label}=${p.score.toFixed(3)}`)
@@ -555,7 +554,7 @@ function trimSilence(audioBuffer: AudioBuffer): AudioExcerpt {
 
   // If the entire audio is silent, return the full buffer untrimmed
   if (trimStart >= trimEnd) {
-    LogService.debug(
+    console.debug(
       `[classification] Entire audio appears silent (threshold=${SILENCE_THRESHOLD}), using full buffer`,
     );
     const channelData: Float32Array[] = [];

--- a/src/services/LogService.ts
+++ b/src/services/LogService.ts
@@ -1,7 +1,11 @@
-// LogService — captures log messages for display in the UI.
+// LogService — intercepts console.log/warn/error/debug and captures entries
+// for display in the UI overlay.
 //
-// Replaces console.log/warn/error calls throughout the app so that log
-// output is visible on devices without devtools (e.g. mobile browsers).
+// On install(), replaces native console methods with wrappers that:
+// 1. Forward to the original console method (so devtools still work)
+// 2. Append the message to the entries signal (so the UI overlay can show it)
+//
+// Callers throughout the app just use console.log/warn/error/debug as normal.
 //
 // Signal ownership: LogService owns the `entries` signal. Only LogService
 // writes to it. Consumers read via the `signals` accessor (bridge hooks)
@@ -62,24 +66,32 @@ function append(level: LogLevel, args: unknown[]): void {
   _entries.value = updated;
 }
 
-function log(...args: unknown[]): void {
-  append('log', args);
-}
-
-function warn(...args: unknown[]): void {
-  append('warn', args);
-}
-
-function error(...args: unknown[]): void {
-  append('error', args);
-}
-
-function debug(...args: unknown[]): void {
-  append('debug', args);
-}
-
 function clear(): void {
   _entries.value = [];
 }
 
-export default { signals, getEntries, log, warn, error, debug, clear };
+// --- Console interception ---
+
+const originalConsole = {
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  debug: console.debug.bind(console),
+};
+
+let installed = false;
+
+function install(): void {
+  if (installed) return;
+  installed = true;
+
+  const LEVELS: LogLevel[] = ['log', 'warn', 'error', 'debug'];
+  for (const level of LEVELS) {
+    console[level] = (...args: unknown[]) => {
+      originalConsole[level](...args);
+      append(level, args);
+    };
+  }
+}
+
+export default { signals, getEntries, clear, install };

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -138,7 +138,7 @@ async function initializeContext(): Promise<InferenceContext> {
   ]);
 
   workerLog(
-    'log',
+    'debug',
     '[classification:worker] Creating ONNX inference sessions...',
   );
   const [effnetSession, instrumentSession] = await Promise.all([
@@ -163,12 +163,12 @@ async function classify(
 
   // Compute mel spectrogram patches
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] Computing mel spectrogram from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s)...`,
   );
   const patches = await computeMelSpectrogram(monoAudio);
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] Mel spectrogram: ${patches.length} patches from ${monoAudio.length} samples (${(monoAudio.length / MODEL_SAMPLE_RATE).toFixed(2)}s at ${MODEL_SAMPLE_RATE} Hz)`,
   );
   if (patches.length === 0) {
@@ -185,7 +185,7 @@ async function classify(
   }
 
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] Running EffNet on ${batchSize} patches (input shape: [${batchSize}, ${PATCH_FRAMES}, ${MEL_BANDS}])...`,
   );
   const effnetInput = new ort.Tensor('float32', inputData, [
@@ -201,7 +201,7 @@ async function classify(
     dims: number[];
   };
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
   );
 
@@ -216,7 +216,7 @@ async function classify(
 
   // Run instrument classification head → 40 sigmoid predictions
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] Running instrument head (embedding dim: ${embeddingDim})...`,
   );
   const instrumentInput = new ort.Tensor('float32', avgEmbedding, [
@@ -310,8 +310,8 @@ type WorkerSelf = {
 const workerSelf = self as unknown as WorkerSelf;
 
 // Forward log messages to the main thread for display in the UI overlay.
-// Workers don't have access to LogService, so we post messages that the
-// main thread handler picks up and routes to LogService.
+// Workers don't have access to the intercepted console, so we post messages
+// that the main thread handler picks up and routes to console.
 function workerLog(level: WorkerLogMessage['level'], message: string): void {
   workerSelf.postMessage({
     type: 'log',
@@ -327,7 +327,7 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
   const firstChannelLength = channelData[0]?.length ?? 0;
   const durationSeconds = length / sampleRate;
   workerLog(
-    'log',
+    'debug',
     `[classification:worker] Received audio: ${channels}ch, ${length} samples (actual first channel: ${firstChannelLength}), ${sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
   );
 
@@ -346,7 +346,7 @@ workerSelf.onmessage = async (event: MessageEvent<ClassifyRequest>) => {
     const monoSamples = downmixToMono(channelData, sampleRate, length);
 
     workerLog(
-      'log',
+      'debug',
       `[classification:worker] Mono audio after downmix: ${monoSamples.length} samples at ${MODEL_SAMPLE_RATE} Hz (${(monoSamples.length / MODEL_SAMPLE_RATE).toFixed(2)}s)`,
     );
 


### PR DESCRIPTION
## Summary

- **LogService refactored** to intercept `console.log/warn/error/debug` instead of providing custom methods. On `install()`, it replaces native console methods with wrappers that forward to both the original console (devtools still work) and the UI overlay signal.
- **All call sites converted** from `LogService.log(...)` to plain `console.log(...)` (and similarly for warn/error/debug). No more explicit LogService imports needed at call sites.
- **Worker log levels refined**: intermediate classification pipeline steps (mel spectrogram, EffNet inference, embedding dims, audio downmix) downgraded from `log` to `debug`. Milestones (model loading, final predictions) remain `log`.
- **View Logs button moved** from a fixed-position root-level toggle into the project page header overflow menu (ellipsis dropdown), alongside the existing fullscreen toggle.

## Test plan

- [x] All 795 tests pass
- [x] ESLint clean
- [x] Production build succeeds
- [ ] Verify logs overlay opens/closes from the overflow menu in browser
- [ ] Verify console.log messages appear in both devtools and the overlay
- [ ] Verify worker log messages are forwarded correctly

https://claude.ai/code/session_0154GXoyUvmcHZ4gjkCxpcZD