### PR TITLE
Fix mel spectrogram returning 0 patches for valid audio

### DIFF
--- a/src/services/__tests__/melSpectrogram.test.ts
+++ b/src/services/__tests__/melSpectrogram.test.ts
@@ -22,17 +22,23 @@ beforeEach(() => {
   mockComputeFrameWise.mockReset();
 });
 
+// Builds a mock return value matching the real essentia.js computeFrameWise
+// output: melSpectrum is an array of arrays (one array of MEL_BANDS values per
+// frame), NOT a flat Float32Array.
+function mockMelSpectrum(totalFrames: number, fillValue = 0.001) {
+  const melSpectrum: Float32Array[] = [];
+  for (let i = 0; i < totalFrames; i++) {
+    const frame = new Float32Array(MEL_BANDS);
+    frame.fill(fillValue);
+    melSpectrum.push(frame);
+  }
+  return { melSpectrum, melBandsSize: MEL_BANDS, patchSize: 187 };
+}
+
 describe('computeMelSpectrogram', () => {
   it('returns patches of 128 frames x 96 mel bands', async () => {
     const totalFrames = PATCH_SIZE * 2;
-    const melSpectrum = new Float32Array(totalFrames * MEL_BANDS);
-    melSpectrum.fill(0.001);
-
-    mockComputeFrameWise.mockReturnValue({
-      melSpectrum,
-      melBandsSize: MEL_BANDS,
-      patchSize: 187,
-    });
+    mockComputeFrameWise.mockReturnValue(mockMelSpectrum(totalFrames));
 
     const patches = await computeMelSpectrogram(new Float32Array(16000));
 
@@ -44,14 +50,7 @@ describe('computeMelSpectrogram', () => {
   it('discards leftover frames that do not fill a complete patch', async () => {
     // 128 + 64 = 192 frames — only 1 full patch
     const totalFrames = PATCH_SIZE + 64;
-    const melSpectrum = new Float32Array(totalFrames * MEL_BANDS);
-    melSpectrum.fill(0.001);
-
-    mockComputeFrameWise.mockReturnValue({
-      melSpectrum,
-      melBandsSize: MEL_BANDS,
-      patchSize: 187,
-    });
+    mockComputeFrameWise.mockReturnValue(mockMelSpectrum(totalFrames));
 
     const patches = await computeMelSpectrogram(new Float32Array(16000));
 
@@ -59,14 +58,7 @@ describe('computeMelSpectrogram', () => {
   });
 
   it('returns empty array when audio is too short for one patch', async () => {
-    const totalFrames = 64;
-    const melSpectrum = new Float32Array(totalFrames * MEL_BANDS);
-
-    mockComputeFrameWise.mockReturnValue({
-      melSpectrum,
-      melBandsSize: MEL_BANDS,
-      patchSize: 187,
-    });
+    mockComputeFrameWise.mockReturnValue(mockMelSpectrum(64));
 
     const patches = await computeMelSpectrogram(new Float32Array(1000));
 
@@ -74,16 +66,10 @@ describe('computeMelSpectrogram', () => {
   });
 
   it('applies log compression: log10(1 + 10000 * x)', async () => {
-    const totalFrames = PATCH_SIZE;
-    const melSpectrum = new Float32Array(totalFrames * MEL_BANDS);
     const testValue = 0.05;
-    melSpectrum.fill(testValue);
-
-    mockComputeFrameWise.mockReturnValue({
-      melSpectrum,
-      melBandsSize: MEL_BANDS,
-      patchSize: 187,
-    });
+    mockComputeFrameWise.mockReturnValue(
+      mockMelSpectrum(PATCH_SIZE, testValue),
+    );
 
     const patches = await computeMelSpectrogram(new Float32Array(16000));
     const expected = Math.log10(1 + 10000 * testValue);
@@ -94,13 +80,7 @@ describe('computeMelSpectrogram', () => {
 
   it('passes audio to the extractor', async () => {
     const audio = new Float32Array([0.1, 0.2, 0.3]);
-    const melSpectrum = new Float32Array(0);
-
-    mockComputeFrameWise.mockReturnValue({
-      melSpectrum,
-      melBandsSize: MEL_BANDS,
-      patchSize: 187,
-    });
+    mockComputeFrameWise.mockReturnValue(mockMelSpectrum(0));
 
     await computeMelSpectrogram(audio);
 

--- a/src/services/melSpectrogram.ts
+++ b/src/services/melSpectrogram.ts
@@ -57,11 +57,11 @@ export async function computeMelSpectrogram(
 ): Promise<Float32Array[]> {
   const extractor = await getExtractor();
 
-  // computeFrameWise returns { melSpectrum, melBandsSize, patchSize, ... }
-  // melSpectrum is a flat Float32Array: totalFrames × melBandsSize
+  // computeFrameWise returns { melSpectrum, ... } where melSpectrum is an
+  // array of per-frame arrays (each of length MEL_BANDS), NOT a flat buffer.
   const features = extractor.computeFrameWise(monoAudio, HOP_SIZE);
-  const melSpectrum: Float32Array = features.melSpectrum;
-  const totalFrames = melSpectrum.length / MEL_BANDS;
+  const melFrames: ArrayLike<number>[] = features.melSpectrum;
+  const totalFrames = melFrames.length;
   const patchCount = Math.floor(totalFrames / PATCH_SIZE);
 
   const patches: Float32Array[] = [];
@@ -70,11 +70,11 @@ export async function computeMelSpectrogram(
     const startFrame = p * PATCH_SIZE;
 
     for (let f = 0; f < PATCH_SIZE; f++) {
+      const frame = melFrames[startFrame + f];
       for (let b = 0; b < MEL_BANDS; b++) {
-        const rawValue = melSpectrum[(startFrame + f) * MEL_BANDS + b];
         // Log compression: log10(1 + 10000 * x)
         patch[f * MEL_BANDS + b] = Math.log10(
-          1 + LOG_COMPRESSION_FACTOR * rawValue,
+          1 + LOG_COMPRESSION_FACTOR * frame[b],
         );
       }
     }


### PR DESCRIPTION
## Summary
- **Root cause**: `computeMelSpectrogram` assumed essentia.js `computeFrameWise` returns `melSpectrum` as a flat `Float32Array`, but it actually returns an **array of per-frame arrays** (each of length 96 mel bands). The code divided `.length` (frame count) by `MEL_BANDS` (96), producing ~24 frames instead of ~2328 — giving 0 patches for any audio under ~54 minutes.
- **Fix**: Treat `melSpectrum` as a 2D array and index frames directly instead of computing flat offsets.
- **Tests**: Updated mock return values to match the real essentia.js API, confirming the previous mocks masked the bug.

## Test plan
- [x] Failing test written first, confirming the bug with correct mock format
- [x] Fix applied, all 5 mel spectrogram tests pass
- [x] Full test suite passes (795 tests, 60 files)
- [ ] Manual verification: upload a 37s+ audio file and confirm classification completes without "Audio too short" error

https://claude.ai/code/session_01RdtLtF6iXK2wU7xxVgHt8e