### PR TITLE
Fix instrument classification ONNX input name mismatch

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -417,8 +417,9 @@ class InstrumentClassificationService {
         PATCH_FRAMES,
         MEL_BANDS,
       ]);
+      const effnetInputName = effnetSession.inputNames[0];
       const effnetOutput = await effnetSession.run({
-        model_input: effnetInput,
+        [effnetInputName]: effnetInput,
       });
       const embeddings = Object.values(effnetOutput)[0] as {
         data: Float32Array;
@@ -445,8 +446,9 @@ class InstrumentClassificationService {
         1,
         embeddingDim,
       ]);
+      const instrumentInputName = instrumentSession.inputNames[0];
       const instrumentOutput = await instrumentSession.run({
-        model_input: instrumentInput,
+        [instrumentInputName]: instrumentInput,
       });
       const predictions = Object.values(instrumentOutput)[0] as {
         data: Float32Array;

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -92,6 +92,7 @@ function setupMainThreadMocks(): void {
   mockFetchModel.mockResolvedValue(new ArrayBuffer(8));
 
   const mockEffnetSession = {
+    inputNames: ['melspectrogram'],
     run: vi.fn().mockResolvedValue({
       output: {
         data: new Float32Array(1280).fill(0.5),
@@ -100,6 +101,7 @@ function setupMainThreadMocks(): void {
     }),
   };
   const mockInstrumentSession = {
+    inputNames: ['model_output'],
     run: vi.fn().mockResolvedValue({
       output: (() => {
         // 40 predictions, electricguitar (index 15) has highest score
@@ -476,6 +478,31 @@ describe('InstrumentClassificationService', () => {
 
       expect(mockFetchModel).toHaveBeenCalledTimes(2);
       expect(mockInferenceSessionCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses session inputNames for ONNX feed keys', async () => {
+      const buffer = createAudioBuffer();
+
+      // Force fallback
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      // Retrieve the sessions that were created
+      const effnetSession =
+        await mockInferenceSessionCreate.mock.results[0].value;
+      const instrumentSession =
+        await mockInferenceSessionCreate.mock.results[1].value;
+
+      // EffNet should use its inputNames[0] ('melspectrogram') as the feed key
+      const effnetFeed = effnetSession.run.mock.calls[0][0];
+      expect(effnetFeed).toHaveProperty('melspectrogram');
+      expect(effnetFeed).not.toHaveProperty('model_input');
+
+      // Instrument head should use its inputNames[0] ('model_output') as the feed key
+      const instrumentFeed = instrumentSession.run.mock.calls[0][0];
+      expect(instrumentFeed).toHaveProperty('model_output');
+      expect(instrumentFeed).not.toHaveProperty('model_input');
     });
 
     it('reuses the pipeline across multiple calls', async () => {

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -193,8 +193,9 @@ async function classify(
     PATCH_FRAMES,
     MEL_BANDS,
   ]);
+  const effnetInputName = effnetSession.inputNames[0];
   const effnetOutput = await effnetSession.run({
-    model_input: effnetInput,
+    [effnetInputName]: effnetInput,
   });
   const embeddings = Object.values(effnetOutput)[0] as {
     data: Float32Array;
@@ -223,8 +224,9 @@ async function classify(
     1,
     embeddingDim,
   ]);
+  const instrumentInputName = instrumentSession.inputNames[0];
   const instrumentOutput = await instrumentSession.run({
-    model_input: instrumentInput,
+    [instrumentInputName]: instrumentInput,
   });
   const predictions = Object.values(instrumentOutput)[0] as {
     data: Float32Array;


### PR DESCRIPTION
## Summary

- Fixed instrument classification failing with `input 'melspectrogram' is missing in 'feeds'` error
- The EffNet ONNX model expects input named `melspectrogram`, but code was hardcoding `model_input` as the feed key
- Changed both the worker (`classification.worker.ts`) and main-thread fallback (`InstrumentClassificationService.ts`) to read input names dynamically from `session.inputNames[0]` instead of hardcoding them
- Added test verifying correct feed keys are used when calling `session.run()`

## Test plan

- [x] New test `uses session inputNames for ONNX feed keys` passes
- [x] All 796 existing tests pass
- [x] Production build succeeds
- [ ] Manual test: upload an audio file and verify instrument classification completes without errors in the log overlay

https://claude.ai/code/session_01HFsZ3cRG3vUEGipkwjrJFf