### PR TITLE
Fix instrument classification selecting wrong EffNet output

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -515,9 +515,8 @@ type TensorLike = { data: Float32Array; dims: readonly number[] };
 // Discogs-EffNet produces two outputs: genre predictions ([n, 400]) and
 // embeddings ([n, 1280]). The instrument classification head needs the
 // embeddings. Select the output with the largest second dimension.
-function selectEmbeddingOutput(
-  outputs: Record<string, TensorLike>,
-): TensorLike {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function selectEmbeddingOutput(outputs: Record<string, any>): TensorLike {
   const candidates = Object.values(outputs) as TensorLike[];
   let best = candidates[0];
   for (let i = 1; i < candidates.length; i++) {

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -421,10 +421,12 @@ class InstrumentClassificationService {
       const effnetOutput = await effnetSession.run({
         [effnetInputName]: effnetInput,
       });
-      const embeddings = Object.values(effnetOutput)[0] as {
-        data: Float32Array;
-        dims: readonly number[];
-      };
+
+      // Discogs-EffNet produces two outputs:
+      //   PartitionedCall:0 → [n, 400]  (genre predictions)
+      //   PartitionedCall:1 → [n, 1280] (embeddings for downstream heads)
+      // Select the embedding output (largest second dimension).
+      const embeddings = selectEmbeddingOutput(effnetOutput);
       console.debug(
         `[classification] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
       );
@@ -504,6 +506,26 @@ class InstrumentClassificationService {
   private publishCache(): void {
     this._classifications.value = new Map(this.cache);
   }
+}
+
+// --- Output selection ---
+
+type TensorLike = { data: Float32Array; dims: readonly number[] };
+
+// Discogs-EffNet produces two outputs: genre predictions ([n, 400]) and
+// embeddings ([n, 1280]). The instrument classification head needs the
+// embeddings. Select the output with the largest second dimension.
+function selectEmbeddingOutput(
+  outputs: Record<string, TensorLike>,
+): TensorLike {
+  const candidates = Object.values(outputs) as TensorLike[];
+  let best = candidates[0];
+  for (let i = 1; i < candidates.length; i++) {
+    if (candidates[i].dims[1] > best.dims[1]) {
+      best = candidates[i];
+    }
+  }
+  return best;
 }
 
 // --- Silence trimming ---

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -10,9 +10,24 @@ vi.mock('../melSpectrogram', () => ({
 
 const mockInferenceSessionCreate = vi.fn();
 
+type MockTensorInstance = {
+  type: string;
+  data: Float32Array;
+  dims: number[];
+};
+
 vi.mock('onnxruntime-web', () => {
   // Tensor must be a real constructor (not arrow function) to support `new`
-  function MockTensor() {}
+  function MockTensor(
+    this: MockTensorInstance,
+    type: string,
+    data: Float32Array,
+    dims: number[],
+  ) {
+    this.type = type;
+    this.data = data;
+    this.dims = dims;
+  }
   return {
     InferenceSession: {
       create: (...args: unknown[]) => mockInferenceSessionCreate(...args),
@@ -87,14 +102,22 @@ function simulateDownloadProgress(progress: number): void {
   } as MessageEvent);
 }
 
-// Set up main-thread fallback mocks — returns 'electricguitar' as top Jamendo class
+// Set up main-thread fallback mocks — returns 'electricguitar' as top Jamendo class.
+// The real Discogs-EffNet model produces TWO outputs:
+//   PartitionedCall:0 → [n, 400] (genre predictions)
+//   PartitionedCall:1 → [n, 1280] (embeddings for downstream heads)
+// The instrument classification head expects the 1280-dim embeddings.
 function setupMainThreadMocks(): void {
   mockFetchModel.mockResolvedValue(new ArrayBuffer(8));
 
   const mockEffnetSession = {
     inputNames: ['melspectrogram'],
     run: vi.fn().mockResolvedValue({
-      output: {
+      'PartitionedCall:0': {
+        data: new Float32Array(400).fill(0.1),
+        dims: [1, 400],
+      },
+      'PartitionedCall:1': {
         data: new Float32Array(1280).fill(0.5),
         dims: [1, 1280],
       },
@@ -478,6 +501,30 @@ describe('InstrumentClassificationService', () => {
 
       expect(mockFetchModel).toHaveBeenCalledTimes(2);
       expect(mockInferenceSessionCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('selects the 1280-dim embedding output, not the 400-dim prediction output', async () => {
+      const buffer = createAudioBuffer();
+
+      // Force fallback to main thread
+      const promise = service.classify('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      // The instrument head should receive 1280-dim embeddings, not 400-dim predictions.
+      // The real Discogs-EffNet model produces two outputs:
+      //   PartitionedCall:0 → [n, 400] (genre predictions)
+      //   PartitionedCall:1 → [n, 1280] (embeddings)
+      // If the code incorrectly picks the first output (400-dim), the instrument
+      // head receives wrong-sized input and OrtRun() fails with:
+      // "Got invalid dimensions for input: embeddings — index: 1 Got: 400 Expected: 1280"
+      const instrumentSession =
+        await mockInferenceSessionCreate.mock.results[1].value;
+      const instrumentFeed = instrumentSession.run.mock.calls[0][0];
+      const inputTensor = Object.values(
+        instrumentFeed,
+      )[0] as MockTensorInstance;
+      expect(inputTensor.dims).toEqual([1, 1280]);
     });
 
     it('uses session inputNames for ONNX feed keys', async () => {

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -153,6 +153,26 @@ async function initializeContext(): Promise<InferenceContext> {
   return { effnetSession, instrumentSession, ort };
 }
 
+// --- Output selection ---
+
+type TensorLike = { data: Float32Array; dims: number[] };
+
+// Discogs-EffNet produces two outputs: genre predictions ([n, 400]) and
+// embeddings ([n, 1280]). The instrument classification head needs the
+// embeddings. Select the output with the largest second dimension.
+function selectEmbeddingOutput(
+  outputs: Record<string, TensorLike>,
+): TensorLike {
+  const candidates = Object.values(outputs) as TensorLike[];
+  let best = candidates[0];
+  for (let i = 1; i < candidates.length; i++) {
+    if (candidates[i].dims[1] > best.dims[1]) {
+      best = candidates[i];
+    }
+  }
+  return best;
+}
+
 // --- Inference ---
 
 async function classify(
@@ -177,7 +197,7 @@ async function classify(
     );
   }
 
-  // Run EffNet on each patch to get 1280-dim embeddings
+  // Run EffNet on each patch to get embeddings
   const batchSize = patches.length;
   const inputData = new Float32Array(batchSize * PATCH_FRAMES * MEL_BANDS);
   for (let i = 0; i < batchSize; i++) {
@@ -197,16 +217,18 @@ async function classify(
   const effnetOutput = await effnetSession.run({
     [effnetInputName]: effnetInput,
   });
-  const embeddings = Object.values(effnetOutput)[0] as {
-    data: Float32Array;
-    dims: number[];
-  };
+
+  // Discogs-EffNet produces two outputs:
+  //   PartitionedCall:0 → [n, 400]  (genre predictions)
+  //   PartitionedCall:1 → [n, 1280] (embeddings for downstream heads)
+  // Select the embedding output (largest second dimension).
+  const embeddings = selectEmbeddingOutput(effnetOutput);
   workerLog(
     'debug',
     `[classification:worker] EffNet embeddings: [${embeddings.dims.join(', ')}]`,
   );
 
-  // Average embeddings across patches → [1, 1280]
+  // Average embeddings across patches
   const embeddingDim = embeddings.dims[1];
   const avgEmbedding = new Float32Array(embeddingDim);
   for (let p = 0; p < batchSize; p++) {


### PR DESCRIPTION
## Summary

- The Discogs-EffNet ONNX model produces two outputs: genre predictions `[n, 400]` and embeddings `[n, 1280]`. The code used `Object.values(output)[0]` which grabbed the 400-dim predictions instead of the 1280-dim embeddings that the MTG-Jamendo instrument classification head expects.
- This caused `OrtRun()` to fail with: *"Got invalid dimensions for input: embeddings — index: 1 Got: 400 Expected: 1280"*
- Fixed by adding a `selectEmbeddingOutput()` helper that selects the output with the largest second dimension, applied in both the worker and main-thread fallback paths.

## Test plan

- [x] Added test that verifies 1280-dim embedding output is selected when EffNet returns both 400-dim and 1280-dim outputs
- [x] Updated mock EffNet session to match real model structure (two outputs instead of one)
- [x] All 800 existing tests pass
- [ ] Manual test: upload an audio file on the deployed app and verify instrument classification completes without the "invalid dimensions" error

https://claude.ai/code/session_01RpwMsUZMCVwDgt6JGciYg4