### PR TITLE
Load essentia.js WASM in spectrogram worker (#297)

### DIFF
--- a/src/services/__tests__/essentiaLoader.test.ts
+++ b/src/services/__tests__/essentiaLoader.test.ts
@@ -1,0 +1,88 @@
+import { vi } from 'vitest';
+
+// Mock essentia.js WASM and core modules before importing the loader.
+// The mock Essentia constructor records the WASM module it receives and
+// exposes a version property for the smoke-test assertion.
+const MOCK_VERSION = '0.1.3';
+const mockShutdown = vi.fn();
+
+vi.mock('essentia.js/dist/essentia-wasm.es.js', () => ({
+  EssentiaWASM: { wasmReady: true },
+}));
+
+vi.mock('essentia.js/dist/essentia.js-core.es.js', () => {
+  class MockEssentia {
+    version = MOCK_VERSION;
+    shutdown = mockShutdown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    wasmModule: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(wasm: any) {
+      this.wasmModule = wasm;
+    }
+  }
+  return { default: MockEssentia };
+});
+
+// Import after mocks are registered
+import { getEssentia, isEssentiaReady, resetEssentia } from '../essentiaLoader';
+
+beforeEach(() => {
+  resetEssentia();
+  mockShutdown.mockClear();
+});
+
+describe('essentiaLoader', () => {
+  it('loads and returns an Essentia instance', async () => {
+    const essentia = await getEssentia();
+
+    expect(essentia).toBeDefined();
+    expect(essentia.version).toBe(MOCK_VERSION);
+  });
+
+  it('passes EssentiaWASM to the Essentia constructor', async () => {
+    const essentia = await getEssentia();
+
+    expect(essentia.wasmModule).toEqual({ wasmReady: true });
+  });
+
+  it('caches the instance across calls', async () => {
+    const first = await getEssentia();
+    const second = await getEssentia();
+
+    expect(first).toBe(second);
+  });
+
+  it('shares the initialization promise for concurrent calls', async () => {
+    const [a, b] = await Promise.all([getEssentia(), getEssentia()]);
+
+    expect(a).toBe(b);
+  });
+
+  it('reports ready state after initialization', async () => {
+    expect(isEssentiaReady()).toBe(false);
+
+    await getEssentia();
+
+    expect(isEssentiaReady()).toBe(true);
+  });
+
+  it('resets to uninitialized state and calls shutdown', async () => {
+    await getEssentia();
+    expect(isEssentiaReady()).toBe(true);
+
+    resetEssentia();
+
+    expect(isEssentiaReady()).toBe(false);
+    expect(mockShutdown).toHaveBeenCalledOnce();
+  });
+
+  it('creates a fresh instance after reset', async () => {
+    const first = await getEssentia();
+    resetEssentia();
+    const second = await getEssentia();
+
+    expect(first).not.toBe(second);
+    expect(second.version).toBe(MOCK_VERSION);
+  });
+});

--- a/src/services/essentiaLoader.ts
+++ b/src/services/essentiaLoader.ts
@@ -1,0 +1,58 @@
+// essentiaLoader — lazy initialization of the essentia.js core WASM module.
+//
+// Loads EssentiaWASM and creates an Essentia instance on first call.
+// Subsequent calls return the cached instance. Intended for use inside
+// the spectrogram worker where PredominantPitchMelodia and other
+// algorithms will run.
+//
+// The WASM binary (~1 MB) is loaded dynamically to avoid blocking
+// worker startup and to keep spectrogram analysis (CQT) functional
+// even if essentia initialization fails.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EssentiaInstance = any;
+
+let instance: EssentiaInstance | null = null;
+let initPromise: Promise<EssentiaInstance> | null = null;
+
+/**
+ * Returns a lazily initialized Essentia instance backed by WASM.
+ *
+ * The first call loads the WASM module and creates the instance.
+ * Concurrent calls during initialization share the same promise.
+ * Subsequent calls return the cached instance immediately.
+ */
+export async function getEssentia(): Promise<EssentiaInstance> {
+  if (instance) return instance;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    const [{ EssentiaWASM }, { default: Essentia }] = await Promise.all([
+      import('essentia.js/dist/essentia-wasm.es.js'),
+      import('essentia.js/dist/essentia.js-core.es.js'),
+    ]);
+
+    return new Essentia(EssentiaWASM);
+  })();
+
+  instance = await initPromise;
+  initPromise = null;
+  return instance;
+}
+
+/** Returns `true` if the WASM module has already been initialized. */
+export function isEssentiaReady(): boolean {
+  return instance !== null;
+}
+
+/**
+ * Resets the cached instance. Intended for testing only — allows
+ * re-initialization after mocks are swapped.
+ */
+export function resetEssentia(): void {
+  if (instance && typeof instance.shutdown === 'function') {
+    instance.shutdown();
+  }
+  instance = null;
+  initPromise = null;
+}

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -1,5 +1,6 @@
 import { type TrackColor } from '../types/track';
 import { analyseCQT } from './CQTAnalyser';
+import { getEssentia } from './essentiaLoader';
 import { type SpectrogramData } from './OfflineAnalyser';
 import { renderTiles } from './SpectrogramTileRenderer';
 
@@ -25,6 +26,18 @@ type WorkerSelf = {
 
 const workerSelf = self as unknown as WorkerSelf;
 
+// Pre-warm essentia WASM after the first CQT analysis completes so the
+// module is ready when melody extraction is requested later. Failure is
+// non-fatal — CQT analysis continues to work regardless.
+function preWarmEssentia(): void {
+  getEssentia().catch(() => {
+    // Silently ignore — essentia is optional for spectrogram rendering.
+    // Melody extraction will retry initialization when invoked.
+  });
+}
+
+let essentiaPreWarmed = false;
+
 workerSelf.onmessage = async (event: MessageEvent<AnalyseRequest>) => {
   const { id, channelData, sampleRate, length, color } = event.data;
 
@@ -33,6 +46,11 @@ workerSelf.onmessage = async (event: MessageEvent<AnalyseRequest>) => {
     const tiles = renderTiles(data, color);
     const response: AnalyseResponse = { id, type: 'result', data, tiles };
     workerSelf.postMessage(response, tiles as unknown as Transferable[]);
+
+    if (!essentiaPreWarmed) {
+      essentiaPreWarmed = true;
+      preWarmEssentia();
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const response: AnalyseResponse = { id, type: 'error', message };

--- a/src/types/essentia.d.ts
+++ b/src/types/essentia.d.ts
@@ -2,6 +2,17 @@ declare module 'essentia.js/dist/essentia-wasm.es.js' {
   export function EssentiaWASM(): Promise<unknown>;
 }
 
+declare module 'essentia.js/dist/essentia.js-core.es.js' {
+  class Essentia {
+    constructor(wasmModule: unknown, isDebug?: boolean);
+    version: string;
+    algorithmNames: string;
+    shutdown(): void;
+    reinstate(): void;
+  }
+  export default Essentia;
+}
+
 declare module 'essentia.js/dist/essentia.js-model.es.js' {
   export class EssentiaTFInputExtractor {
     constructor(wasmModule: unknown, extractorType: string);


### PR DESCRIPTION
## Summary

- Add lazy essentia.js core WASM initialization to the spectrogram worker as the foundation for melody extraction (`PredominantPitchMelodia`)
- WASM module is pre-warmed after the first CQT analysis completes, so it's ready when melody extraction is requested in subsequent issues
- Initialization failure is non-fatal — CQT spectrogram analysis continues to work regardless

### Changes

- **`src/services/essentiaLoader.ts`** — New module with `getEssentia()` (lazy singleton), `isEssentiaReady()`, and `resetEssentia()`. Follows the same lazy-init pattern used in `melSpectrogram.ts`
- **`src/services/spectrogram.worker.ts`** — Pre-warms essentia after first successful CQT analysis
- **`src/types/essentia.d.ts`** — TypeScript declaration for `essentia.js-core.es.js` module
- **`src/services/__tests__/essentiaLoader.test.ts`** — 7 unit tests covering initialization, caching, concurrent calls, ready state, shutdown, and reset

Closes #297

## Test plan

- [x] 7 new unit tests pass for essentiaLoader (init, caching, concurrency, ready state, reset/shutdown)
- [x] Existing spectrogram worker tests pass (6 tests, no regressions)
- [x] Full test suite passes (807 tests)
- [x] Lint passes
- [x] Production build succeeds — essentia core is code-split into its own chunk

https://claude.ai/code/session_01BaNkwYuAriDUPQjpY2fryQ