### PR TITLE
Extract melody with PredominantPitchMelodia in worker (#298)

### DIFF
--- a/src/services/MelodyExtractor.ts
+++ b/src/services/MelodyExtractor.ts
@@ -1,0 +1,206 @@
+/**
+ * Melody extraction using essentia.js PredominantPitchMelodia (MELODIA).
+ *
+ * Runs the MELODIA algorithm on a mono audio buffer, then converts the
+ * raw pitch contour into discrete note events (MelodyNote[]).
+ *
+ * Pipeline:
+ * 1. EqualLoudness filter (perceptual pre-processing)
+ * 2. PredominantPitchMelodia (pitch + confidence per frame)
+ * 3. Filter unvoiced / low-confidence frames
+ * 4. Quantize Hz → MIDI note number
+ * 5. Group consecutive same-note frames into note events
+ * 6. Discard notes shorter than minimum duration
+ */
+
+import { getEssentia } from './essentiaLoader';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MelodyNote = {
+  startTime: number;
+  endTime: number;
+  midiNote: number;
+  confidence: number;
+};
+
+export type MelodyData = {
+  notes: MelodyNote[];
+  timeResolution: number;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** MELODIA default hop size in samples. */
+const MELODIA_HOP_SIZE = 128;
+
+/** Minimum confidence to accept a pitch frame. */
+const CONFIDENCE_THRESHOLD = 0.25;
+
+/** Minimum note duration in seconds (~50ms ≈ 2 MELODIA hops at 44.1 kHz). */
+const MIN_NOTE_DURATION = 0.05;
+
+/** Frequency range for melody extraction. */
+const MIN_FREQUENCY = 55;
+const MAX_FREQUENCY = 1760;
+
+// ---------------------------------------------------------------------------
+// Pure conversion functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a frequency in Hz to the nearest MIDI note number.
+ * Returns a rounded integer (0–127 clamped).
+ *
+ * Formula: round(12 × log2(hz / 440) + 69)
+ */
+export function hzToMidi(hz: number): number {
+  if (hz <= 0) return 0;
+  const midi = Math.round(12 * Math.log2(hz / 440) + 69);
+  return Math.max(0, Math.min(127, midi));
+}
+
+/**
+ * Converts a MELODIA pitch contour into discrete MelodyNote events.
+ *
+ * Steps:
+ * 1. Filter frames where pitch = 0 (unvoiced) or confidence < threshold
+ * 2. Quantize remaining Hz values to MIDI note numbers
+ * 3. Group consecutive frames with the same MIDI note
+ * 4. Discard notes shorter than MIN_NOTE_DURATION
+ */
+export function pitchContourToNotes(
+  pitchValues: Float32Array,
+  confidenceValues: Float32Array,
+  sampleRate: number,
+  hopSize: number,
+): MelodyNote[] {
+  const frameTime = hopSize / sampleRate;
+  const frameCount = Math.min(pitchValues.length, confidenceValues.length);
+
+  const grouped: MelodyNote[] = [];
+  let currentNote: MelodyNote | null = null;
+  let confidenceSum = 0;
+  let confidenceCount = 0;
+
+  for (let i = 0; i < frameCount; i++) {
+    const pitch = pitchValues[i];
+    const confidence = confidenceValues[i];
+
+    if (pitch <= 0 || confidence < CONFIDENCE_THRESHOLD) {
+      // Unvoiced or low-confidence frame — close current note
+      if (currentNote) {
+        currentNote.endTime = i * frameTime;
+        currentNote.confidence = confidenceSum / confidenceCount;
+        grouped.push(currentNote);
+        currentNote = null;
+        confidenceSum = 0;
+        confidenceCount = 0;
+      }
+      continue;
+    }
+
+    const midi = hzToMidi(pitch);
+
+    if (currentNote && currentNote.midiNote === midi) {
+      // Same note continues — accumulate confidence
+      confidenceSum += confidence;
+      confidenceCount += 1;
+    } else {
+      // Different note — close previous and start new
+      if (currentNote) {
+        currentNote.endTime = i * frameTime;
+        currentNote.confidence = confidenceSum / confidenceCount;
+        grouped.push(currentNote);
+      }
+      currentNote = {
+        startTime: i * frameTime,
+        endTime: 0,
+        midiNote: midi,
+        confidence: 0,
+      };
+      confidenceSum = confidence;
+      confidenceCount = 1;
+    }
+  }
+
+  // Close final note
+  if (currentNote) {
+    currentNote.endTime = frameCount * frameTime;
+    currentNote.confidence = confidenceSum / confidenceCount;
+    grouped.push(currentNote);
+  }
+
+  // Filter notes shorter than minimum duration
+  return grouped.filter(
+    (note) => note.endTime - note.startTime >= MIN_NOTE_DURATION,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main extraction function
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts melody from a mono audio signal using MELODIA.
+ *
+ * Requires essentia.js WASM to be available (loaded lazily via getEssentia).
+ * Pre-processes the signal with EqualLoudness for best results.
+ */
+export async function extractMelody(
+  monoSignal: Float32Array,
+  sampleRate: number,
+): Promise<MelodyData> {
+  const essentia = await getEssentia();
+
+  const inputVector = essentia.arrayToVector(monoSignal);
+
+  // Pre-process with EqualLoudness filter for perceptual weighting
+  const filtered = essentia.EqualLoudness(inputVector, sampleRate);
+  const filteredSignal = filtered.signal;
+
+  // Run MELODIA with recommended defaults, adjusted frequency range
+  const result = essentia.PredominantPitchMelodia(
+    filteredSignal,
+    /* binResolution */ 10,
+    /* filterIterations */ 3,
+    /* frameSize */ 2048,
+    /* guessUnvoiced */ false,
+    /* harmonicWeight */ 0.8,
+    /* hopSize */ MELODIA_HOP_SIZE,
+    /* magnitudeCompression */ 1,
+    /* magnitudeThreshold */ 40,
+    /* maxFrequency */ MAX_FREQUENCY,
+    /* minDuration */ 100,
+    /* minFrequency */ MIN_FREQUENCY,
+  );
+
+  const pitchValues: Float32Array = essentia.vectorToArray(result.pitch);
+  const confidenceValues: Float32Array = essentia.vectorToArray(
+    result.pitchConfidence,
+  );
+
+  const notes = pitchContourToNotes(
+    pitchValues,
+    confidenceValues,
+    sampleRate,
+    MELODIA_HOP_SIZE,
+  );
+
+  const timeResolution = MELODIA_HOP_SIZE / sampleRate;
+
+  return { notes, timeResolution };
+}
+
+// Exported for testing
+export {
+  MELODIA_HOP_SIZE,
+  CONFIDENCE_THRESHOLD,
+  MIN_NOTE_DURATION,
+  MIN_FREQUENCY as MELODY_MIN_FREQUENCY,
+  MAX_FREQUENCY as MELODY_MAX_FREQUENCY,
+};

--- a/src/services/SpectrogramCache.ts
+++ b/src/services/SpectrogramCache.ts
@@ -1,17 +1,29 @@
 import { type TrackColor } from '../types/track';
+import { type MelodyData } from './MelodyExtractor';
 import OfflineAnalyser, { type SpectrogramData } from './OfflineAnalyser';
 import { renderTiles } from './SpectrogramTileRenderer';
-import { type AnalyseResponse } from './spectrogram.worker';
+import { type WorkerResponse } from './spectrogram.worker';
 
 export type TrackSpectrogramEntry = {
   data: SpectrogramData;
   tiles: ImageBitmap[];
 };
 
-type PendingRequest = {
-  resolve: (result: { data: SpectrogramData; tiles: ImageBitmap[] }) => void;
+type SpectrogramResult = { data: SpectrogramData; tiles: ImageBitmap[] };
+
+type PendingSpectrogramRequest = {
+  kind: 'spectrogram';
+  resolve: (result: SpectrogramResult) => void;
   reject: (error: Error) => void;
 };
+
+type PendingMelodyRequest = {
+  kind: 'melody';
+  resolve: (result: MelodyData) => void;
+  reject: (error: Error) => void;
+};
+
+type PendingRequest = PendingSpectrogramRequest | PendingMelodyRequest;
 
 class SpectrogramCache {
   private entries = new Map<string, TrackSpectrogramEntry>();
@@ -25,7 +37,7 @@ class SpectrogramCache {
     audioBuffer: AudioBuffer,
     color: TrackColor,
   ): Promise<void> {
-    let result: { data: SpectrogramData; tiles: ImageBitmap[] };
+    let result: SpectrogramResult;
     if (this.workerFailed) {
       result = await this.analyseOnMainThread(audioBuffer, color);
     } else {
@@ -64,13 +76,40 @@ class SpectrogramCache {
     this.entries.clear();
   }
 
+  extractMelodyInWorker(audioBuffer: AudioBuffer): Promise<MelodyData> {
+    const worker = this.getWorker();
+    const id = this.nextMessageId++;
+
+    const channelData: Float32Array[] = [];
+    const transferables: Transferable[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      const copy = new Float32Array(audioBuffer.getChannelData(ch));
+      channelData.push(copy);
+      transferables.push(copy.buffer);
+    }
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { kind: 'melody', resolve, reject });
+      worker.postMessage(
+        {
+          id,
+          kind: 'melody',
+          channelData,
+          sampleRate: audioBuffer.sampleRate,
+          length: audioBuffer.length,
+        },
+        transferables,
+      );
+    });
+  }
+
   private getWorker(): Worker {
     if (!this.worker) {
       this.worker = new Worker(
         new URL('./spectrogram.worker.ts', import.meta.url),
         { type: 'module' },
       );
-      this.worker.onmessage = (event: MessageEvent<AnalyseResponse>) => {
+      this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
         const { id, type } = event.data;
         const pending = this.pendingRequests.get(id);
         if (!pending) return;
@@ -78,7 +117,9 @@ class SpectrogramCache {
 
         if (type === 'error') {
           pending.reject(new Error(event.data.message));
-        } else {
+        } else if (type === 'melody-result' && pending.kind === 'melody') {
+          pending.resolve(event.data.data);
+        } else if (type === 'result' && pending.kind === 'spectrogram') {
           pending.resolve({ data: event.data.data, tiles: event.data.tiles });
         }
       };
@@ -102,7 +143,7 @@ class SpectrogramCache {
   private analyseInWorker(
     audioBuffer: AudioBuffer,
     color: TrackColor,
-  ): Promise<{ data: SpectrogramData; tiles: ImageBitmap[] }> {
+  ): Promise<SpectrogramResult> {
     const worker = this.getWorker();
     const id = this.nextMessageId++;
 
@@ -115,10 +156,11 @@ class SpectrogramCache {
     }
 
     return new Promise((resolve, reject) => {
-      this.pendingRequests.set(id, { resolve, reject });
+      this.pendingRequests.set(id, { kind: 'spectrogram', resolve, reject });
       worker.postMessage(
         {
           id,
+          kind: 'spectrogram',
           channelData,
           sampleRate: audioBuffer.sampleRate,
           length: audioBuffer.length,
@@ -132,7 +174,7 @@ class SpectrogramCache {
   private async analyseOnMainThread(
     audioBuffer: AudioBuffer,
     color: TrackColor,
-  ): Promise<{ data: SpectrogramData; tiles: ImageBitmap[] }> {
+  ): Promise<SpectrogramResult> {
     const analyser = new OfflineAnalyser(audioBuffer);
     const data = await analyser.analyseToFrames();
     const tiles = renderTiles(data, color);

--- a/src/services/__tests__/MelodyExtractor.test.ts
+++ b/src/services/__tests__/MelodyExtractor.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockPitch = new Float32Array(100).fill(440);
+const mockConfidence = new Float32Array(100).fill(0.9);
+
+const mockEssentia = vi.hoisted(() => ({
+  arrayToVector: vi.fn().mockReturnValue('vector'),
+  EqualLoudness: vi.fn().mockReturnValue({ signal: 'filtered' }),
+  PredominantPitchMelodia: vi.fn().mockReturnValue({
+    pitch: 'pitchVector',
+    pitchConfidence: 'confVector',
+  }),
+  vectorToArray: vi.fn(),
+}));
+
+vi.mock('../essentiaLoader', () => ({
+  getEssentia: vi.fn().mockResolvedValue(mockEssentia),
+}));
+
+import {
+  CONFIDENCE_THRESHOLD,
+  extractMelody,
+  hzToMidi,
+  MELODIA_HOP_SIZE,
+  pitchContourToNotes,
+} from '../MelodyExtractor';
+
+describe('hzToMidi', () => {
+  it('converts A4 (440 Hz) to MIDI 69', () => {
+    expect(hzToMidi(440)).toBe(69);
+  });
+
+  it('converts C4 (261.63 Hz) to MIDI 60', () => {
+    expect(hzToMidi(261.63)).toBe(60);
+  });
+
+  it('converts A3 (220 Hz) to MIDI 57', () => {
+    expect(hzToMidi(220)).toBe(57);
+  });
+
+  it('converts C1 (32.7 Hz) to MIDI 24', () => {
+    expect(hzToMidi(32.7)).toBe(24);
+  });
+
+  it('returns 0 for zero Hz', () => {
+    expect(hzToMidi(0)).toBe(0);
+  });
+
+  it('returns 0 for negative Hz', () => {
+    expect(hzToMidi(-100)).toBe(0);
+  });
+
+  it('clamps to 127 for very high frequencies', () => {
+    expect(hzToMidi(100000)).toBe(127);
+  });
+
+  it('converts E4 (329.63 Hz) to MIDI 64', () => {
+    expect(hzToMidi(329.63)).toBe(64);
+  });
+});
+
+describe('pitchContourToNotes', () => {
+  const sampleRate = 44100;
+  const hopSize = MELODIA_HOP_SIZE;
+  const frameTime = hopSize / sampleRate;
+
+  /**
+   * Helper: creates a contour with a steady pitch for N frames.
+   * Returns pitch and confidence arrays.
+   */
+  function steadyContour(
+    hz: number,
+    confidence: number,
+    frames: number,
+  ): { pitch: Float32Array; confidence: Float32Array } {
+    return {
+      pitch: new Float32Array(frames).fill(hz),
+      confidence: new Float32Array(frames).fill(confidence),
+    };
+  }
+
+  it('groups consecutive same-pitch frames into a single note', () => {
+    const frames = 100;
+    const { pitch, confidence } = steadyContour(440, 0.9, frames);
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].midiNote).toBe(69); // A4
+    expect(notes[0].startTime).toBeCloseTo(0);
+    expect(notes[0].endTime).toBeCloseTo(frames * frameTime, 4);
+    expect(notes[0].confidence).toBeCloseTo(0.9, 4);
+  });
+
+  it('splits notes when pitch changes', () => {
+    const framesPerNote = 50;
+    const totalFrames = framesPerNote * 2;
+    const pitch = new Float32Array(totalFrames);
+    const confidence = new Float32Array(totalFrames).fill(0.8);
+
+    // First half: A4 (440 Hz), second half: E4 (329.63 Hz)
+    for (let i = 0; i < framesPerNote; i++) pitch[i] = 440;
+    for (let i = framesPerNote; i < totalFrames; i++) pitch[i] = 329.63;
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(2);
+    expect(notes[0].midiNote).toBe(69); // A4
+    expect(notes[1].midiNote).toBe(64); // E4
+    expect(notes[0].endTime).toBeCloseTo(notes[1].startTime, 4);
+  });
+
+  it('filters unvoiced frames (pitch = 0)', () => {
+    const frames = 100;
+    const pitch = new Float32Array(frames);
+    const confidence = new Float32Array(frames).fill(0.9);
+
+    // First 50 frames: A4, rest: unvoiced
+    for (let i = 0; i < 50; i++) pitch[i] = 440;
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].midiNote).toBe(69);
+    expect(notes[0].endTime).toBeCloseTo(50 * frameTime, 4);
+  });
+
+  it('filters low-confidence frames', () => {
+    const frames = 100;
+    const pitch = new Float32Array(frames).fill(440);
+    const confidence = new Float32Array(frames);
+
+    // First 50 frames: high confidence, rest: below threshold
+    for (let i = 0; i < 50; i++) confidence[i] = 0.9;
+    for (let i = 50; i < frames; i++)
+      confidence[i] = CONFIDENCE_THRESHOLD - 0.01;
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].endTime).toBeCloseTo(50 * frameTime, 4);
+  });
+
+  it('discards notes shorter than minimum duration', () => {
+    // At 44100 Hz with hop 128, each frame is ~2.9 ms.
+    // MIN_NOTE_DURATION is 50 ms ≈ ~17 frames.
+    const shortFrames = 5; // ~14.5 ms — below threshold
+    const longFrames = 50; // ~145 ms — above threshold
+    const gapFrames = 10;
+    const totalFrames = shortFrames + gapFrames + longFrames;
+
+    const pitch = new Float32Array(totalFrames);
+    const confidence = new Float32Array(totalFrames);
+
+    // Short note (should be filtered)
+    for (let i = 0; i < shortFrames; i++) {
+      pitch[i] = 440;
+      confidence[i] = 0.9;
+    }
+    // Gap (unvoiced)
+    // Long note (should be kept)
+    for (let i = shortFrames + gapFrames; i < totalFrames; i++) {
+      pitch[i] = 330;
+      confidence[i] = 0.9;
+    }
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].midiNote).toBe(64); // E4
+  });
+
+  it('returns empty array for all-unvoiced input', () => {
+    const pitch = new Float32Array(100); // all zeros
+    const confidence = new Float32Array(100).fill(0.9);
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(0);
+  });
+
+  it('averages confidence across grouped frames', () => {
+    const frames = 40;
+    const pitch = new Float32Array(frames).fill(440);
+    const confidence = new Float32Array(frames);
+
+    // Ramp confidence from 0.5 to 0.9
+    for (let i = 0; i < frames; i++) {
+      confidence[i] = 0.5 + (0.4 * i) / (frames - 1);
+    }
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(1);
+    // Average of a linear ramp from 0.5 to 0.9 is 0.7
+    expect(notes[0].confidence).toBeCloseTo(0.7, 1);
+  });
+
+  it('handles gap between two notes', () => {
+    const frames = 120;
+    const pitch = new Float32Array(frames);
+    const confidence = new Float32Array(frames);
+
+    // Note 1: frames 0–39 (A4)
+    for (let i = 0; i < 40; i++) {
+      pitch[i] = 440;
+      confidence[i] = 0.8;
+    }
+    // Gap: frames 40–79 (unvoiced)
+    // Note 2: frames 80–119 (C5 = 523.25 Hz)
+    for (let i = 80; i < 120; i++) {
+      pitch[i] = 523.25;
+      confidence[i] = 0.7;
+    }
+
+    const notes = pitchContourToNotes(pitch, confidence, sampleRate, hopSize);
+
+    expect(notes).toHaveLength(2);
+    expect(notes[0].midiNote).toBe(69); // A4
+    expect(notes[1].midiNote).toBe(72); // C5
+    expect(notes[1].startTime).toBeCloseTo(80 * frameTime, 4);
+  });
+});
+
+describe('extractMelody', () => {
+  it('calls essentia MELODIA and returns MelodyData', async () => {
+    mockEssentia.vectorToArray
+      .mockReturnValueOnce(mockPitch)
+      .mockReturnValueOnce(mockConfidence);
+
+    const signal = new Float32Array(44100); // 1 second
+    const result = await extractMelody(signal, 44100);
+
+    expect(mockEssentia.arrayToVector).toHaveBeenCalledWith(signal);
+    expect(mockEssentia.EqualLoudness).toHaveBeenCalledWith('vector', 44100);
+    expect(mockEssentia.PredominantPitchMelodia).toHaveBeenCalled();
+    expect(result.notes.length).toBeGreaterThan(0);
+    expect(result.timeResolution).toBeCloseTo(MELODIA_HOP_SIZE / 44100, 6);
+  });
+});

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -1,20 +1,47 @@
 import { type TrackColor } from '../types/track';
 import { analyseCQT } from './CQTAnalyser';
 import { getEssentia } from './essentiaLoader';
+import { type MelodyData, extractMelody } from './MelodyExtractor';
+import { mixToMono } from './CQTAnalyser';
 import { type SpectrogramData } from './OfflineAnalyser';
 import { renderTiles } from './SpectrogramTileRenderer';
 
+// ---------------------------------------------------------------------------
+// Message protocol
+// ---------------------------------------------------------------------------
+
 export type AnalyseRequest = {
   id: number;
+  kind: 'spectrogram';
   channelData: Float32Array[];
   sampleRate: number;
   length: number;
   color: TrackColor;
 };
 
+export type MelodyRequest = {
+  id: number;
+  kind: 'melody';
+  channelData: Float32Array[];
+  sampleRate: number;
+  length: number;
+};
+
+export type WorkerRequest = AnalyseRequest | MelodyRequest;
+
 export type AnalyseResponse =
   | { id: number; type: 'result'; data: SpectrogramData; tiles: ImageBitmap[] }
   | { id: number; type: 'error'; message: string };
+
+export type MelodyResponse =
+  | { id: number; type: 'melody-result'; data: MelodyData }
+  | { id: number; type: 'error'; message: string };
+
+export type WorkerResponse = AnalyseResponse | MelodyResponse;
+
+// ---------------------------------------------------------------------------
+// Worker implementation
+// ---------------------------------------------------------------------------
 
 // TypeScript sees `self` as Window (DOM lib), but in a worker it is
 // DedicatedWorkerGlobalScope with a different postMessage signature.
@@ -38,8 +65,8 @@ function preWarmEssentia(): void {
 
 let essentiaPreWarmed = false;
 
-workerSelf.onmessage = async (event: MessageEvent<AnalyseRequest>) => {
-  const { id, channelData, sampleRate, length, color } = event.data;
+async function handleSpectrogram(request: AnalyseRequest): Promise<void> {
+  const { id, channelData, sampleRate, length, color } = request;
 
   try {
     const data = analyseCQT(channelData, sampleRate, length);
@@ -55,5 +82,33 @@ workerSelf.onmessage = async (event: MessageEvent<AnalyseRequest>) => {
     const message = error instanceof Error ? error.message : String(error);
     const response: AnalyseResponse = { id, type: 'error', message };
     workerSelf.postMessage(response);
+  }
+}
+
+async function handleMelody(request: MelodyRequest): Promise<void> {
+  const { id, channelData, sampleRate, length } = request;
+
+  try {
+    const mono = mixToMono(channelData, length);
+    const data = await extractMelody(mono, sampleRate);
+    const response: MelodyResponse = { id, type: 'melody-result', data };
+    workerSelf.postMessage(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const response: MelodyResponse = { id, type: 'error', message };
+    workerSelf.postMessage(response);
+  }
+}
+
+workerSelf.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const request = event.data;
+
+  // Backwards compatibility: messages without `kind` are spectrogram requests
+  const kind = request.kind ?? 'spectrogram';
+
+  if (kind === 'melody') {
+    await handleMelody(request as MelodyRequest);
+  } else {
+    await handleSpectrogram(request as AnalyseRequest);
   }
 };

--- a/src/types/essentia.d.ts
+++ b/src/types/essentia.d.ts
@@ -3,12 +3,43 @@ declare module 'essentia.js/dist/essentia-wasm.es.js' {
 }
 
 declare module 'essentia.js/dist/essentia.js-core.es.js' {
+  type VectorFloat = unknown;
+
   class Essentia {
     constructor(wasmModule: unknown, isDebug?: boolean);
     version: string;
     algorithmNames: string;
     shutdown(): void;
     reinstate(): void;
+    arrayToVector(inputArray: Float32Array): VectorFloat;
+    vectorToArray(inputVector: VectorFloat): Float32Array;
+    EqualLoudness(
+      signal: VectorFloat,
+      sampleRate?: number,
+    ): { signal: VectorFloat };
+    PredominantPitchMelodia(
+      signal: VectorFloat,
+      binResolution?: number,
+      filterIterations?: number,
+      frameSize?: number,
+      guessUnvoiced?: boolean,
+      harmonicWeight?: number,
+      hopSize?: number,
+      magnitudeCompression?: number,
+      magnitudeThreshold?: number,
+      maxFrequency?: number,
+      minDuration?: number,
+      minFrequency?: number,
+      numberHarmonics?: number,
+      peakDistributionThreshold?: number,
+      peakFrameThreshold?: number,
+      pitchContinuity?: number,
+      referenceFrequency?: number,
+      sampleRate?: number,
+      timeContinuity?: number,
+      voiceVibrato?: boolean,
+      voicingTolerance?: number,
+    ): { pitch: VectorFloat; pitchConfidence: VectorFloat };
   }
   export default Essentia;
 }


### PR DESCRIPTION
## Summary

- Add `MelodyExtractor` service that runs essentia's MELODIA algorithm on audio buffers and converts the raw pitch contour into discrete `MelodyNote[]` events
- Extend the spectrogram worker message protocol with a `'melody'` request type for off-main-thread extraction
- Add `extractMelodyInWorker()` to `SpectrogramCache` for main-thread callers
- Update essentia type declarations with `arrayToVector`, `vectorToArray`, `EqualLoudness`, and `PredominantPitchMelodia` signatures

### Pitch-to-note pipeline

1. **EqualLoudness** filter (perceptual pre-processing)
2. **PredominantPitchMelodia** (pitch + confidence per frame, hop=128 samples)
3. **Filter** unvoiced (pitch=0) and low-confidence (<0.25) frames
4. **Quantize** Hz → MIDI note number via `round(12 × log2(hz / 440) + 69)`
5. **Group** consecutive same-note frames into note events with averaged confidence
6. **Discard** notes shorter than 50ms

Closes #298

## Test plan

- [x] 17 unit tests covering Hz→MIDI conversion, note grouping, confidence averaging, minimum duration filtering, gap handling, and extractMelody integration with mocked essentia
- [x] All 824 existing tests pass
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)

https://claude.ai/code/session_01HMnHWzwcMfGLdyb5tiCfgS