### PR TITLE
Cache melody extraction results alongside spectrogram data (#299)

### DIFF
--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -62,6 +62,8 @@ const { mockRetrieveAudioBuffer, mockRetrieveStartTime } = vi.hoisted(() => ({
 vi.mock('../../../../services/ProjectStorageService', () => ({
   loadSpectrogramData: vi.fn().mockResolvedValue(null),
   saveSpectrogramData: vi.fn().mockResolvedValue(undefined),
+  loadMelodyData: vi.fn().mockResolvedValue(null),
+  saveMelodyData: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../../../hooks/useAudioService', () => ({
@@ -70,6 +72,11 @@ vi.mock('../../../../hooks/useAudioService', () => ({
       analyse: mockAnalyse,
       getEntry: mockGetEntry,
       restore: vi.fn(),
+      getMelody: vi.fn(),
+      setMelody: vi.fn(),
+      extractMelodyInWorker: vi
+        .fn()
+        .mockResolvedValue({ notes: [], timeResolution: 0.0029 }),
     },
   }),
 }));

--- a/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
@@ -2,17 +2,23 @@ import 'fake-indexeddb/auto';
 import { IDBFactory } from 'fake-indexeddb';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MelodyData } from '../../../../services/MelodyExtractor';
 import type { SpectrogramData } from '../../../../services/OfflineAnalyser';
 import {
+  loadMelodyData,
   loadSpectrogramData,
   resetDB,
+  saveMelodyData,
   saveSpectrogramData,
+  type MelodyStoreData,
   type SpectrogramStoreData,
 } from '../../../../services/ProjectStorageService';
 import type { TrackSpectrogramEntry } from '../../../../services/SpectrogramCache';
 import { type TrackColor } from '../../../../types/track';
 import {
+  fromMelodyStoreData,
   fromSpectrogramStoreData,
+  toMelodyStoreData,
   toSpectrogramStoreData,
   useSpectrogramCache,
 } from '../useSpectrogramCache';
@@ -27,14 +33,28 @@ const MOCK_DATA: SpectrogramData = {
   duration: 0.05,
 };
 
+const MOCK_MELODY: MelodyData = {
+  notes: [{ startTime: 0.1, endTime: 0.5, midiNote: 60, confidence: 0.9 }],
+  timeResolution: 0.0029,
+};
+
 const MOCK_ENTRY: TrackSpectrogramEntry = {
   data: MOCK_DATA,
   tiles: [],
 };
 
+const MOCK_ENTRY_WITH_MELODY: TrackSpectrogramEntry = {
+  data: MOCK_DATA,
+  tiles: [],
+  melody: MOCK_MELODY,
+};
+
 const mockGetEntry = vi.fn();
 const mockAnalyse = vi.fn();
 const mockRestore = vi.fn();
+const mockGetMelody = vi.fn();
+const mockSetMelody = vi.fn();
+const mockExtractMelodyInWorker = vi.fn();
 
 vi.mock('../../../../hooks/useAudioService', () => ({
   useAudioService: () => ({
@@ -42,6 +62,9 @@ vi.mock('../../../../hooks/useAudioService', () => ({
       getEntry: mockGetEntry,
       analyse: mockAnalyse,
       restore: mockRestore,
+      getMelody: mockGetMelody,
+      setMelody: mockSetMelody,
+      extractMelodyInWorker: mockExtractMelodyInWorker,
     },
   }),
 }));
@@ -137,6 +160,39 @@ describe('fromSpectrogramStoreData', () => {
   });
 });
 
+describe('toMelodyStoreData', () => {
+  it('converts MelodyData to MelodyStoreData', () => {
+    const result = toMelodyStoreData('track-1', MOCK_MELODY);
+
+    expect(result.trackId).toBe('track-1');
+    expect(result.notes).toEqual(MOCK_MELODY.notes);
+    expect(result.timeResolution).toBe(0.0029);
+  });
+});
+
+describe('fromMelodyStoreData', () => {
+  it('converts MelodyStoreData back to MelodyData', () => {
+    const stored: MelodyStoreData = {
+      trackId: 'track-1',
+      notes: [{ startTime: 0.1, endTime: 0.5, midiNote: 60, confidence: 0.9 }],
+      timeResolution: 0.0029,
+    };
+
+    const result = fromMelodyStoreData(stored);
+
+    expect(result.notes).toEqual(stored.notes);
+    expect(result.timeResolution).toBe(0.0029);
+  });
+
+  it('round-trips through to/from without data loss', () => {
+    const stored = toMelodyStoreData('track-1', MOCK_MELODY);
+    const restored = fromMelodyStoreData(stored);
+
+    expect(restored.notes).toEqual(MOCK_MELODY.notes);
+    expect(restored.timeResolution).toBe(MOCK_MELODY.timeResolution);
+  });
+});
+
 describe('useSpectrogramCache', () => {
   it('returns undefined when audioBuffer is not available', () => {
     const { result } = renderHook(() =>
@@ -193,6 +249,7 @@ describe('useSpectrogramCache', () => {
       .mockReturnValue(MOCK_ENTRY); // after analyse
 
     mockAnalyse.mockResolvedValue(undefined);
+    mockExtractMelodyInWorker.mockResolvedValue(MOCK_MELODY);
 
     const buffer = mockAudioBuffer();
     const { result } = renderHook(() =>
@@ -210,5 +267,79 @@ describe('useSpectrogramCache', () => {
     expect(stored).not.toBeNull();
     expect(stored!.trackId).toBe('track-1');
     expect(stored!.timeResolution).toBe(0.025);
+  });
+
+  it('restores melody from IndexedDB alongside spectrogram', async () => {
+    mockGetEntry
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue(MOCK_ENTRY_WITH_MELODY);
+
+    const storeData = toSpectrogramStoreData('track-1', MOCK_DATA);
+    await saveSpectrogramData(storeData);
+    const melodyStore = toMelodyStoreData('track-1', MOCK_MELODY);
+    await saveMelodyData(melodyStore);
+
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', mockAudioBuffer(), COLOR),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(MOCK_ENTRY_WITH_MELODY);
+    });
+
+    expect(mockSetMelody).toHaveBeenCalledWith(
+      'track-1',
+      expect.objectContaining({
+        timeResolution: 0.0029,
+        notes: expect.arrayContaining([
+          expect.objectContaining({ midiNote: 60 }),
+        ]),
+      }),
+    );
+  });
+
+  it('runs melody extraction after spectrogram analysis', async () => {
+    mockGetEntry.mockReturnValueOnce(undefined).mockReturnValue(MOCK_ENTRY);
+
+    mockAnalyse.mockResolvedValue(undefined);
+    mockExtractMelodyInWorker.mockResolvedValue(MOCK_MELODY);
+
+    const buffer = mockAudioBuffer();
+    renderHook(() => useSpectrogramCache('track-1', buffer, COLOR));
+
+    await waitFor(() => {
+      expect(mockExtractMelodyInWorker).toHaveBeenCalledWith(buffer);
+    });
+
+    await waitFor(() => {
+      expect(mockSetMelody).toHaveBeenCalledWith('track-1', MOCK_MELODY);
+    });
+
+    // Verify melody data was saved to IndexedDB
+    const stored = await loadMelodyData('track-1');
+    expect(stored).not.toBeNull();
+    expect(stored!.trackId).toBe('track-1');
+    expect(stored!.timeResolution).toBe(0.0029);
+  });
+
+  it('does not fail when melody extraction errors', async () => {
+    mockGetEntry.mockReturnValueOnce(undefined).mockReturnValue(MOCK_ENTRY);
+
+    mockAnalyse.mockResolvedValue(undefined);
+    mockExtractMelodyInWorker.mockRejectedValue(
+      new Error('essentia.js unavailable'),
+    );
+
+    const buffer = mockAudioBuffer();
+    const { result } = renderHook(() =>
+      useSpectrogramCache('track-1', buffer, COLOR),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(MOCK_ENTRY);
+    });
+
+    // Melody extraction failed but spectrogram still works
+    expect(mockSetMelody).not.toHaveBeenCalled();
   });
 });

--- a/src/components/workstation/spectrogram/useSpectrogramCache.ts
+++ b/src/components/workstation/spectrogram/useSpectrogramCache.ts
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useAudioService } from '../../../hooks/useAudioService';
+import { type MelodyData } from '../../../services/MelodyExtractor';
 import { type SpectrogramData } from '../../../services/OfflineAnalyser';
 import {
+  loadMelodyData,
   loadSpectrogramData,
+  saveMelodyData,
   saveSpectrogramData,
+  type MelodyStoreData,
   type SpectrogramStoreData,
 } from '../../../services/ProjectStorageService';
 import { type TrackSpectrogramEntry } from '../../../services/SpectrogramCache';
@@ -39,6 +43,24 @@ export function fromSpectrogramStoreData(
   };
 }
 
+export function toMelodyStoreData(
+  trackId: string,
+  melody: MelodyData,
+): MelodyStoreData {
+  return {
+    trackId,
+    notes: melody.notes,
+    timeResolution: melody.timeResolution,
+  };
+}
+
+export function fromMelodyStoreData(stored: MelodyStoreData): MelodyData {
+  return {
+    notes: stored.notes,
+    timeResolution: stored.timeResolution,
+  };
+}
+
 export function useSpectrogramCache(
   trackId: string,
   audioBuffer: AudioBuffer | undefined,
@@ -60,18 +82,27 @@ export function useSpectrogramCache(
 
     const loadOrAnalyse = async () => {
       // Check IndexedDB for previously stored spectrogram data
-      const stored = await loadSpectrogramData(trackId);
+      const [storedSpectrogram, storedMelody] = await Promise.all([
+        loadSpectrogramData(trackId),
+        loadMelodyData(trackId),
+      ]);
 
       if (cancelled) return;
 
-      if (stored) {
-        const data = fromSpectrogramStoreData(stored);
+      if (storedSpectrogram) {
+        const data = fromSpectrogramStoreData(storedSpectrogram);
         audioService.spectrogramCache.restore(trackId, data, color);
+
+        if (storedMelody) {
+          const melody = fromMelodyStoreData(storedMelody);
+          audioService.spectrogramCache.setMelody(trackId, melody);
+        }
+
         setEntry(audioService.spectrogramCache.getEntry(trackId));
         return;
       }
 
-      // No cached data — run full analysis
+      // No cached data — run full spectrogram analysis
       await audioService.spectrogramCache.analyse(trackId, audioBuffer, color);
 
       if (cancelled) return;
@@ -79,11 +110,20 @@ export function useSpectrogramCache(
       const analysedEntry = audioService.spectrogramCache.getEntry(trackId);
       setEntry(analysedEntry);
 
-      // Persist for future loads
+      // Persist spectrogram for future loads
       if (analysedEntry) {
         const storeData = toSpectrogramStoreData(trackId, analysedEntry.data);
         saveSpectrogramData(storeData);
       }
+
+      // Run melody extraction in the background
+      extractAndCacheMelody(audioService, trackId, audioBuffer, () => {
+        if (cancelled) return;
+        const updated = audioService.spectrogramCache.getEntry(trackId);
+        if (updated) {
+          setEntry({ ...updated });
+        }
+      });
     };
 
     loadOrAnalyse();
@@ -94,4 +134,22 @@ export function useSpectrogramCache(
   }, [trackId, audioBuffer, color, audioService]);
 
   return entry;
+}
+
+function extractAndCacheMelody(
+  audioService: ReturnType<typeof useAudioService>,
+  trackId: string,
+  audioBuffer: AudioBuffer,
+  onComplete: () => void,
+): void {
+  audioService.spectrogramCache
+    .extractMelodyInWorker(audioBuffer)
+    .then((melody) => {
+      audioService.spectrogramCache.setMelody(trackId, melody);
+      saveMelodyData(toMelodyStoreData(trackId, melody));
+      onComplete();
+    })
+    .catch(() => {
+      // Melody extraction is non-critical; silently ignore failures
+    });
 }

--- a/src/services/ProjectStorageService.ts
+++ b/src/services/ProjectStorageService.ts
@@ -1,8 +1,9 @@
 import { type DBSchema, type IDBPDatabase, openDB } from 'idb';
+import { type MelodyNote } from './MelodyExtractor';
 import { type Track } from '../types/track';
 
 const DB_NAME = 'mawimbi-db';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 export type StoredProject = {
   id: string;
@@ -23,6 +24,12 @@ export type SpectrogramStoreData = {
   duration: number;
 };
 
+export type MelodyStoreData = {
+  trackId: string;
+  notes: MelodyNote[];
+  timeResolution: number;
+};
+
 interface MawimbiDB extends DBSchema {
   projects: {
     key: string;
@@ -37,6 +44,10 @@ interface MawimbiDB extends DBSchema {
     key: string;
     value: SpectrogramStoreData;
   };
+  melodies: {
+    key: string;
+    value: MelodyStoreData;
+  };
 }
 
 let dbPromise: Promise<IDBPDatabase<MawimbiDB>> | null = null;
@@ -44,14 +55,19 @@ let dbPromise: Promise<IDBPDatabase<MawimbiDB>> | null = null;
 function getDB(): Promise<IDBPDatabase<MawimbiDB>> {
   if (!dbPromise) {
     dbPromise = openDB<MawimbiDB>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        const projectStore = db.createObjectStore('projects', {
-          keyPath: 'id',
-        });
-        projectStore.createIndex('by-updatedAt', 'updatedAt');
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          const projectStore = db.createObjectStore('projects', {
+            keyPath: 'id',
+          });
+          projectStore.createIndex('by-updatedAt', 'updatedAt');
 
-        db.createObjectStore('audioData', { keyPath: 'trackId' });
-        db.createObjectStore('spectrograms', { keyPath: 'trackId' });
+          db.createObjectStore('audioData', { keyPath: 'trackId' });
+          db.createObjectStore('spectrograms', { keyPath: 'trackId' });
+        }
+        if (oldVersion < 2) {
+          db.createObjectStore('melodies', { keyPath: 'trackId' });
+        }
       },
     });
   }
@@ -81,13 +97,14 @@ export async function deleteProject(id: string): Promise<void> {
   if (project) {
     const trackIds = project.tracks.map((t) => t.trackId);
     const tx = db.transaction(
-      ['projects', 'audioData', 'spectrograms'],
+      ['projects', 'audioData', 'spectrograms', 'melodies'],
       'readwrite',
     );
     tx.objectStore('projects').delete(id);
     for (const trackId of trackIds) {
       tx.objectStore('audioData').delete(trackId);
       tx.objectStore('spectrograms').delete(trackId);
+      tx.objectStore('melodies').delete(trackId);
     }
     await tx.done;
   }
@@ -132,6 +149,24 @@ export async function loadSpectrogramData(
 export async function deleteSpectrogramData(trackId: string): Promise<void> {
   const db = await getDB();
   await db.delete('spectrograms', trackId);
+}
+
+export async function saveMelodyData(data: MelodyStoreData): Promise<void> {
+  const db = await getDB();
+  await db.put('melodies', data);
+}
+
+export async function loadMelodyData(
+  trackId: string,
+): Promise<MelodyStoreData | null> {
+  const db = await getDB();
+  const entry = await db.get('melodies', trackId);
+  return entry ?? null;
+}
+
+export async function deleteMelodyData(trackId: string): Promise<void> {
+  const db = await getDB();
+  await db.delete('melodies', trackId);
 }
 
 export async function getStorageEstimate(): Promise<StorageEstimate> {

--- a/src/services/SpectrogramCache.ts
+++ b/src/services/SpectrogramCache.ts
@@ -7,6 +7,7 @@ import { type WorkerResponse } from './spectrogram.worker';
 export type TrackSpectrogramEntry = {
   data: SpectrogramData;
   tiles: ImageBitmap[];
+  melody?: MelodyData;
 };
 
 type SpectrogramResult = { data: SpectrogramData; tiles: ImageBitmap[] };
@@ -59,6 +60,17 @@ class SpectrogramCache {
 
   getEntry(trackId: string): TrackSpectrogramEntry | undefined {
     return this.entries.get(trackId);
+  }
+
+  getMelody(trackId: string): MelodyData | undefined {
+    return this.entries.get(trackId)?.melody;
+  }
+
+  setMelody(trackId: string, melody: MelodyData): void {
+    const entry = this.entries.get(trackId);
+    if (entry) {
+      entry.melody = melody;
+    }
   }
 
   invalidate(trackId: string): void {

--- a/src/services/__tests__/ProjectStorageService.test.ts
+++ b/src/services/__tests__/ProjectStorageService.test.ts
@@ -11,10 +11,14 @@ import {
   saveSpectrogramData,
   loadSpectrogramData,
   deleteSpectrogramData,
+  saveMelodyData,
+  loadMelodyData,
+  deleteMelodyData,
   getStorageEstimate,
   resetDB,
   type StoredProject,
   type SpectrogramStoreData,
+  type MelodyStoreData,
 } from '../ProjectStorageService';
 
 function createProject(overrides: Partial<StoredProject> = {}): StoredProject {
@@ -38,6 +42,17 @@ function createSpectrogramData(trackId: string): SpectrogramStoreData {
     frequencyBinCount: 128,
     sampleRate: 44100,
     duration: 2.5,
+  };
+}
+
+function createMelodyData(trackId: string): MelodyStoreData {
+  return {
+    trackId,
+    notes: [
+      { startTime: 0.1, endTime: 0.5, midiNote: 60, confidence: 0.9 },
+      { startTime: 0.6, endTime: 1.0, midiNote: 64, confidence: 0.85 },
+    ],
+    timeResolution: 0.0029,
   };
 }
 
@@ -122,7 +137,7 @@ describe('ProjectStorageService', () => {
   });
 
   describe('deleteProject cleans up related data', () => {
-    it('deletes associated audio and spectrogram data', async () => {
+    it('deletes associated audio, spectrogram, and melody data', async () => {
       const project = createProject({
         tracks: [
           {
@@ -144,6 +159,8 @@ describe('ProjectStorageService', () => {
       await saveAudioData('track-2', new ArrayBuffer(200));
       await saveSpectrogramData(createSpectrogramData('track-1'));
       await saveSpectrogramData(createSpectrogramData('track-2'));
+      await saveMelodyData(createMelodyData('track-1'));
+      await saveMelodyData(createMelodyData('track-2'));
 
       await deleteProject('project-1');
 
@@ -151,6 +168,8 @@ describe('ProjectStorageService', () => {
       expect(await loadAudioData('track-2')).toBeNull();
       expect(await loadSpectrogramData('track-1')).toBeNull();
       expect(await loadSpectrogramData('track-2')).toBeNull();
+      expect(await loadMelodyData('track-1')).toBeNull();
+      expect(await loadMelodyData('track-2')).toBeNull();
     });
   });
 
@@ -233,6 +252,51 @@ describe('ProjectStorageService', () => {
       await expect(
         deleteSpectrogramData('does-not-exist'),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('melody data CRUD', () => {
+    it('saves and loads melody data', async () => {
+      const data = createMelodyData('track-1');
+      await saveMelodyData(data);
+
+      const loaded = await loadMelodyData('track-1');
+      expect(loaded?.trackId).toBe('track-1');
+      expect(loaded?.timeResolution).toBe(0.0029);
+      expect(loaded?.notes).toHaveLength(2);
+      expect(loaded?.notes[0]).toEqual({
+        startTime: 0.1,
+        endTime: 0.5,
+        midiNote: 60,
+        confidence: 0.9,
+      });
+    });
+
+    it('returns null for non-existent melody data', async () => {
+      const loaded = await loadMelodyData('does-not-exist');
+      expect(loaded).toBeNull();
+    });
+
+    it('overwrites existing melody data', async () => {
+      await saveMelodyData(createMelodyData('track-1'));
+      const updated = createMelodyData('track-1');
+      updated.timeResolution = 0.005;
+      await saveMelodyData(updated);
+
+      const loaded = await loadMelodyData('track-1');
+      expect(loaded?.timeResolution).toBe(0.005);
+    });
+
+    it('deletes melody data', async () => {
+      await saveMelodyData(createMelodyData('track-1'));
+      await deleteMelodyData('track-1');
+
+      const loaded = await loadMelodyData('track-1');
+      expect(loaded).toBeNull();
+    });
+
+    it('deleting non-existent melody data does not throw', async () => {
+      await expect(deleteMelodyData('does-not-exist')).resolves.toBeUndefined();
     });
   });
 

--- a/src/services/__tests__/SpectrogramCache.test.ts
+++ b/src/services/__tests__/SpectrogramCache.test.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { type TrackColor } from '../../types/track';
+import { type MelodyData } from '../MelodyExtractor';
 import type { SpectrogramData } from '../OfflineAnalyser';
 import SpectrogramCache from '../SpectrogramCache';
 
@@ -74,6 +75,20 @@ function simulateWorkerError(message: string, id = 0) {
     data: { id, type: 'error', message },
   } as MessageEvent);
 }
+
+function simulateWorkerMelodyResult(data: MelodyData, id = 0) {
+  mockWorker.onmessage!({
+    data: { id, type: 'melody-result', data },
+  } as MessageEvent);
+}
+
+const MOCK_MELODY_DATA: MelodyData = {
+  notes: [
+    { startTime: 0.1, endTime: 0.5, midiNote: 60, confidence: 0.9 },
+    { startTime: 0.6, endTime: 1.0, midiNote: 64, confidence: 0.85 },
+  ],
+  timeResolution: 0.0029,
+};
 
 let cache: SpectrogramCache;
 
@@ -375,5 +390,109 @@ describe('invalidateAll', () => {
 
   it('does nothing when cache is empty', () => {
     expect(() => cache.invalidateAll()).not.toThrow();
+  });
+});
+
+describe('getMelody', () => {
+  it('returns undefined when no melody is set', async () => {
+    const promise = cache.analyse('track-1', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [mockTileBitmap]);
+    await promise;
+
+    expect(cache.getMelody('track-1')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown track', () => {
+    expect(cache.getMelody('nonexistent')).toBeUndefined();
+  });
+});
+
+describe('setMelody', () => {
+  it('stores melody data on an existing entry', async () => {
+    const promise = cache.analyse('track-1', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [mockTileBitmap]);
+    await promise;
+
+    cache.setMelody('track-1', MOCK_MELODY_DATA);
+
+    expect(cache.getMelody('track-1')).toBe(MOCK_MELODY_DATA);
+  });
+
+  it('does nothing when track does not exist', () => {
+    expect(() =>
+      cache.setMelody('nonexistent', MOCK_MELODY_DATA),
+    ).not.toThrow();
+    expect(cache.getMelody('nonexistent')).toBeUndefined();
+  });
+
+  it('makes melody available through getEntry', async () => {
+    const promise = cache.analyse('track-1', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [mockTileBitmap]);
+    await promise;
+
+    cache.setMelody('track-1', MOCK_MELODY_DATA);
+
+    const entry = cache.getEntry('track-1');
+    expect(entry?.melody).toBe(MOCK_MELODY_DATA);
+  });
+
+  it('invalidate removes melody data along with the entry', async () => {
+    const promise = cache.analyse('track-1', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [mockTileBitmap]);
+    await promise;
+
+    cache.setMelody('track-1', MOCK_MELODY_DATA);
+    cache.invalidate('track-1');
+
+    expect(cache.getMelody('track-1')).toBeUndefined();
+  });
+
+  it('invalidateAll removes melody data for all tracks', async () => {
+    const promise1 = cache.analyse('track-1', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [mockTileBitmap], 0);
+    await promise1;
+
+    const tile2 = { close: vi.fn() } as unknown as ImageBitmap;
+    const promise2 = cache.analyse('track-2', mockAudioBuffer(), COLOR);
+    simulateWorkerResult(MOCK_SPECTROGRAM_DATA, [tile2], 1);
+    await promise2;
+
+    cache.setMelody('track-1', MOCK_MELODY_DATA);
+    cache.setMelody('track-2', MOCK_MELODY_DATA);
+    cache.invalidateAll();
+
+    expect(cache.getMelody('track-1')).toBeUndefined();
+    expect(cache.getMelody('track-2')).toBeUndefined();
+  });
+});
+
+describe('extractMelodyInWorker', () => {
+  it('posts melody request to worker with correct message format', () => {
+    cache.extractMelodyInWorker(mockAudioBuffer());
+
+    expect(mockWorker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 0,
+        kind: 'melody',
+        sampleRate: 44100,
+        length: 3,
+      }),
+      expect.any(Array),
+    );
+  });
+
+  it('resolves with MelodyData from worker response', async () => {
+    const promise = cache.extractMelodyInWorker(mockAudioBuffer());
+    simulateWorkerMelodyResult(MOCK_MELODY_DATA);
+
+    const result = await promise;
+    expect(result).toBe(MOCK_MELODY_DATA);
+  });
+
+  it('rejects when worker responds with error', async () => {
+    const promise = cache.extractMelodyInWorker(mockAudioBuffer());
+    simulateWorkerError('essentia.js failed');
+
+    await expect(promise).rejects.toThrow('essentia.js failed');
   });
 });


### PR DESCRIPTION
## Summary
- Add in-memory melody caching to `SpectrogramCache` via optional `melody` field on `TrackSpectrogramEntry`, with `getMelody()`/`setMelody()` accessors
- Add IndexedDB persistence for melody data: new `melodies` object store (DB version 2), `MelodyStoreData` type, and `saveMelodyData`/`loadMelodyData`/`deleteMelodyData` functions
- Extend `useSpectrogramCache` hook to automatically extract melody after spectrogram analysis, persist results, and restore from IndexedDB on reload
- Update `deleteProject` to clean up melody data alongside audio and spectrogram data

## Test plan
- [x] `SpectrogramCache` melody tests: getMelody/setMelody, invalidation clears melody, extractMelodyInWorker message protocol
- [x] `ProjectStorageService` melody tests: CRUD operations, deleteProject cleanup includes melody data
- [x] `useSpectrogramCache` melody tests: restores from IndexedDB, runs extraction after analysis, handles extraction failures gracefully
- [x] Melody store data round-trip conversion tests (toMelodyStoreData/fromMelodyStoreData)
- [x] All 849 existing tests pass, no regressions
- [x] Build and lint pass

Closes #299

https://claude.ai/code/session_01KrrCf4mk5Xi1afb3JFADPo