### PR TITLE
Render piano roll overlay canvas on Spectrogram (#300)

### DIFF
--- a/src/components/workstation/spectrogram/PianoRollRenderer.ts
+++ b/src/components/workstation/spectrogram/PianoRollRenderer.ts
@@ -1,0 +1,155 @@
+/**
+ * Renders a piano roll overlay on a canvas, drawing detected melody notes
+ * as semi-transparent rectangular blocks aligned to the CQT spectrogram's
+ * log-frequency axis.
+ *
+ * The CQT spectrogram uses 24 bins/octave starting at C1 (32.7 Hz).
+ * MIDI note numbers map to the same log scale:
+ *   binIndex = 24 × log2(freq / 32.7)
+ *
+ * Each semitone spans 2 CQT bins (24 bins/octave ÷ 12 semitones).
+ * Bin 0 is at the bottom of the canvas, matching the spectrogram orientation.
+ */
+
+import { type MelodyNote } from '../../../services/MelodyExtractor';
+import { type TrackColor } from '../../../types/track';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** CQT base frequency — C1. */
+const CQT_BASE_FREQUENCY = 32.7;
+
+/** CQT bins per octave. */
+const BINS_PER_OCTAVE = 24;
+
+/** Height of a note block in CQT bins (1 semitone = 2 bins). */
+const NOTE_HEIGHT_BINS = 2;
+
+/** Note block fill opacity (0–1). */
+const NOTE_FILL_OPACITY = 0.6;
+
+/** Note block border opacity (0–1). */
+const NOTE_BORDER_OPACITY = 0.8;
+
+/** Note block corner radius in pixels. */
+const CORNER_RADIUS = 2;
+
+/** Note block border width in pixels. */
+const BORDER_WIDTH = 1;
+
+// ---------------------------------------------------------------------------
+// Coordinate mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a MIDI note number to a CQT bin index.
+ * MIDI → frequency: freq = 440 × 2^((midi - 69) / 12)
+ * Frequency → bin:   bin  = 24 × log2(freq / 32.7)
+ */
+export function midiNoteToBin(midiNote: number): number {
+  const freq = 440 * 2 ** ((midiNote - 69) / 12);
+  return BINS_PER_OCTAVE * Math.log2(freq / CQT_BASE_FREQUENCY);
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+export type PianoRollViewport = {
+  /** Pixels per second (zoom level). */
+  pixelsPerSecond: number;
+  /** Horizontal scroll offset in content pixels. */
+  contentOffset: number;
+  /** Canvas / viewport width in pixels. */
+  viewportWidth: number;
+  /** Canvas height in pixels. */
+  canvasHeight: number;
+  /** Total number of CQT frequency bins (determines y-axis scale). */
+  frequencyBinCount: number;
+};
+
+/**
+ * Draws melody notes as semi-transparent blocks onto a 2D canvas context.
+ *
+ * Only notes within the visible viewport are rendered (horizontal culling).
+ * Vertical positions are mapped from MIDI note → CQT bin → canvas pixel.
+ */
+export function drawPianoRoll(
+  ctx: CanvasRenderingContext2D,
+  notes: MelodyNote[],
+  color: TrackColor,
+  viewport: PianoRollViewport,
+): void {
+  const {
+    pixelsPerSecond,
+    contentOffset,
+    viewportWidth,
+    canvasHeight,
+    frequencyBinCount,
+  } = viewport;
+
+  if (notes.length === 0 || frequencyBinCount === 0) return;
+
+  const pixelsPerBin = canvasHeight / frequencyBinCount;
+  const viewStartTime = contentOffset / pixelsPerSecond;
+  const viewEndTime = (contentOffset + viewportWidth) / pixelsPerSecond;
+
+  const { r, g, b } = color;
+  const fillStyle = `rgba(${r}, ${g}, ${b}, ${NOTE_FILL_OPACITY})`;
+  const strokeStyle = `rgba(${(r * 0.7) | 0}, ${(g * 0.7) | 0}, ${(b * 0.7) | 0}, ${NOTE_BORDER_OPACITY})`;
+
+  ctx.fillStyle = fillStyle;
+  ctx.strokeStyle = strokeStyle;
+  ctx.lineWidth = BORDER_WIDTH;
+
+  for (let i = 0; i < notes.length; i++) {
+    const note = notes[i];
+
+    // Viewport culling — skip notes entirely outside the visible range
+    if (note.endTime <= viewStartTime || note.startTime >= viewEndTime) {
+      continue;
+    }
+
+    const x = note.startTime * pixelsPerSecond - contentOffset;
+    const width = (note.endTime - note.startTime) * pixelsPerSecond;
+
+    // Map MIDI note to CQT bin, then to canvas y-coordinate.
+    // Bin 0 is at the bottom of the canvas (row = canvasHeight - 1).
+    const binIndex = midiNoteToBin(note.midiNote);
+    const noteTopBin = binIndex + NOTE_HEIGHT_BINS / 2;
+    const noteBottomBin = binIndex - NOTE_HEIGHT_BINS / 2;
+
+    // Canvas y: top of canvas = highest bin, bottom = bin 0
+    const y = canvasHeight - noteTopBin * pixelsPerBin;
+    const height = (noteTopBin - noteBottomBin) * pixelsPerBin;
+
+    if (height < 1) continue;
+
+    drawRoundedRect(ctx, x, y, width, height, CORNER_RADIUS);
+  }
+}
+
+/**
+ * Draws a filled and stroked rounded rectangle.
+ * Uses the canvas roundRect API if available, otherwise falls back to
+ * a simple rect (no rounded corners).
+ */
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  ctx.beginPath();
+  if (ctx.roundRect) {
+    ctx.roundRect(x, y, width, height, radius);
+  } else {
+    ctx.rect(x, y, width, height);
+  }
+  ctx.fill();
+  ctx.stroke();
+}

--- a/src/components/workstation/spectrogram/Spectrogram.css
+++ b/src/components/workstation/spectrogram/Spectrogram.css
@@ -7,3 +7,11 @@
   left: 0;
   display: block;
 }
+
+.spectrogram__overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  pointer-events: none;
+}

--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -5,7 +5,10 @@ import { useRecordingService } from '../../../hooks/useRecordingService';
 import { useTrackService } from '../../../hooks/useTrackService';
 import { useTrackVolume } from '../../../hooks/useTrackVolume';
 import FrequencyVisualizer from '../../../services/FrequencyVisualizer';
+import { type MelodyNote } from '../../../services/MelodyExtractor';
+import { type TrackColor } from '../../../types/track';
 import { type Track } from '../../../types/track';
+import { drawPianoRoll, type PianoRollViewport } from './PianoRollRenderer';
 import RecordingBuffer from './RecordingBuffer';
 import './Spectrogram.css';
 import { useSpectrogramCache } from './useSpectrogramCache';
@@ -27,8 +30,14 @@ const Spectrogram = ({
   isRecordingTrack = false,
 }: SpectrogramProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const overlayRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const lastDrawnRef = useRef({ offset: -1, pps: -1, tileCount: -1 });
+  const lastDrawnOverlayRef = useRef({
+    offset: -1,
+    pps: -1,
+    noteCount: -1,
+  });
   const recordingBufferRef = useRef<RecordingBuffer | null>(null);
 
   const { trackId, color } = track;
@@ -51,8 +60,10 @@ const Spectrogram = ({
   const timeResolution = entry?.data.timeResolution ?? 0.025;
   const frameDisplayWidth = pixelsPerSecond * timeResolution;
   const tileDisplayWidth = TILE_WIDTH * frameDisplayWidth;
+  const frequencyBinCount = entry?.data.frequencyBinCount ?? 0;
   const totalFrames = entry?.data.frequencyFrames.length ?? 0;
   const tiles = entry?.tiles ?? [];
+  const melodyNotes = entry?.melody?.notes ?? [];
 
   const visualizerRef = useRef<FrequencyVisualizer | null>(null);
 
@@ -78,9 +89,10 @@ const Spectrogram = ({
     // Hook objects reference stable service singletons via getters
   }, [isRecordingTrack, color]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Draw visible tiles on each animation frame
+  // Draw visible tiles and melody overlay on each animation frame
   useAnimationFrame(() => {
     const canvas = canvasRef.current;
+    const overlay = overlayRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
 
@@ -112,6 +124,20 @@ const Spectrogram = ({
       duration,
       lastDrawnRef,
     );
+
+    if (overlay && melodyNotes.length > 0) {
+      drawMelodyOverlay(
+        overlay,
+        container,
+        pixelsPerSecond,
+        height,
+        melodyNotes,
+        color,
+        frequencyBinCount,
+        duration,
+        lastDrawnOverlayRef,
+      );
+    }
   });
 
   const { opacity } = useTrackVolume(trackId);
@@ -133,6 +159,7 @@ const Spectrogram = ({
       }}
     >
       <canvas ref={canvasRef} className="spectrogram__canvas" />
+      <canvas ref={overlayRef} className="spectrogram__overlay" />
     </div>
   );
 };
@@ -292,6 +319,74 @@ function drawTilesFrame(
 
     ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
   }
+}
+
+function drawMelodyOverlay(
+  canvas: HTMLCanvasElement,
+  container: HTMLDivElement,
+  pixelsPerSecond: number,
+  height: number,
+  notes: MelodyNote[],
+  color: TrackColor,
+  frequencyBinCount: number,
+  duration: number,
+  lastDrawnOverlayRef: React.MutableRefObject<{
+    offset: number;
+    pps: number;
+    noteCount: number;
+  }>,
+): void {
+  const containerWidth = duration * pixelsPerSecond;
+
+  const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
+  const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+
+  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const timeline = container.closest('.timeline');
+  const paddingLeft = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+    : 0;
+  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
+  const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
+  const contentOffset = Math.min(
+    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
+    maxContentOffset,
+  );
+
+  const needsResize =
+    canvas.width !== viewportWidth || canvas.height !== height;
+
+  const last = lastDrawnOverlayRef.current;
+  if (
+    !needsResize &&
+    contentOffset === last.offset &&
+    pixelsPerSecond === last.pps &&
+    notes.length === last.noteCount
+  ) {
+    return;
+  }
+  last.offset = contentOffset;
+  last.pps = pixelsPerSecond;
+  last.noteCount = notes.length;
+
+  if (needsResize) {
+    canvas.width = viewportWidth;
+    canvas.height = height;
+  }
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const viewport: PianoRollViewport = {
+    pixelsPerSecond,
+    contentOffset,
+    viewportWidth,
+    canvasHeight: height,
+    frequencyBinCount,
+  };
+
+  drawPianoRoll(ctx, notes, color, viewport);
 }
 
 export default Spectrogram;

--- a/src/components/workstation/spectrogram/__tests__/PianoRollRenderer.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/PianoRollRenderer.test.ts
@@ -1,0 +1,212 @@
+import { type MelodyNote } from '../../../../services/MelodyExtractor';
+import {
+  drawPianoRoll,
+  midiNoteToBin,
+  type PianoRollViewport,
+} from '../PianoRollRenderer';
+
+// ---------------------------------------------------------------------------
+// midiNoteToBin
+// ---------------------------------------------------------------------------
+
+describe('midiNoteToBin', () => {
+  it('maps C1 (MIDI 24) to bin 0', () => {
+    // C1 = 32.7 Hz, bin = 24 × log2(32.7 / 32.7) = 0
+    expect(midiNoteToBin(24)).toBeCloseTo(0, 0);
+  });
+
+  it('maps C2 (MIDI 36) to bin 24', () => {
+    // C2 = 65.4 Hz, one octave above C1 → bin 24
+    expect(midiNoteToBin(36)).toBeCloseTo(24, 0);
+  });
+
+  it('maps A4 (MIDI 69) to the expected bin', () => {
+    // A4 = 440 Hz, bin = 24 × log2(440 / 32.7) ≈ 88.7
+    const bin = midiNoteToBin(69);
+    expect(bin).toBeCloseTo(24 * Math.log2(440 / 32.7), 1);
+  });
+
+  it('increases by 2 bins per semitone', () => {
+    // 24 bins/octave ÷ 12 semitones = 2 bins per semitone
+    const binA = midiNoteToBin(60); // C4
+    const binB = midiNoteToBin(61); // C#4
+    expect(binB - binA).toBeCloseTo(2, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drawPianoRoll
+// ---------------------------------------------------------------------------
+
+describe('drawPianoRoll', () => {
+  const color = { r: 100, g: 200, b: 150 };
+
+  function createMockCtx() {
+    return {
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      clearRect: vi.fn(),
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      rect: vi.fn(),
+      roundRect: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  function makeViewport(
+    overrides: Partial<PianoRollViewport> = {},
+  ): PianoRollViewport {
+    return {
+      pixelsPerSecond: 200,
+      contentOffset: 0,
+      viewportWidth: 800,
+      canvasHeight: 128,
+      frequencyBinCount: 192,
+      ...overrides,
+    };
+  }
+
+  it('does not draw when notes array is empty', () => {
+    const ctx = createMockCtx();
+    drawPianoRoll(ctx, [], color, makeViewport());
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('does not draw when frequencyBinCount is zero', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 1,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+    drawPianoRoll(ctx, [note], color, makeViewport({ frequencyBinCount: 0 }));
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('draws a note block within the viewport', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 0.5,
+      endTime: 1.0,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+    expect(ctx.fill).toHaveBeenCalledTimes(1);
+    expect(ctx.stroke).toHaveBeenCalledTimes(1);
+  });
+
+  it('culls notes entirely before the viewport', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 0.5,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    // Viewport starts at 2 seconds (contentOffset = 400px at 200 pps)
+    drawPianoRoll(ctx, [note], color, makeViewport({ contentOffset: 400 }));
+
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('culls notes entirely after the viewport', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 10,
+      endTime: 11,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    // Viewport covers 0–4 seconds (800px / 200 pps)
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.beginPath).not.toHaveBeenCalled();
+  });
+
+  it('draws notes that partially overlap the viewport', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 3.5,
+      endTime: 5.0,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    // Viewport covers 0–4 seconds; note starts at 3.5 and extends past 4
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('draws multiple visible notes', () => {
+    const ctx = createMockCtx();
+    const notes: MelodyNote[] = [
+      { startTime: 0, endTime: 0.5, midiNote: 60, confidence: 0.9 },
+      { startTime: 1, endTime: 1.5, midiNote: 64, confidence: 0.8 },
+      { startTime: 2, endTime: 2.5, midiNote: 67, confidence: 0.7 },
+    ];
+
+    drawPianoRoll(ctx, notes, color, makeViewport());
+
+    expect(ctx.beginPath).toHaveBeenCalledTimes(3);
+    expect(ctx.fill).toHaveBeenCalledTimes(3);
+    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+  });
+
+  it('sets fill style with track color and opacity', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 1,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.fillStyle).toContain('100');
+    expect(ctx.fillStyle).toContain('200');
+    expect(ctx.fillStyle).toContain('150');
+  });
+
+  it('uses roundRect when available', () => {
+    const ctx = createMockCtx();
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 1,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.roundRect).toHaveBeenCalledTimes(1);
+    expect(ctx.rect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to rect when roundRect is unavailable', () => {
+    const ctx = createMockCtx();
+    // Remove roundRect to simulate older browser
+    (ctx as unknown as Record<string, unknown>).roundRect = undefined;
+
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 1,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.rect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -172,6 +172,23 @@ it('renders a canvas element', () => {
   expect(canvas).toBeInTheDocument();
 });
 
+it('renders an overlay canvas for the piano roll', () => {
+  const { container } = render(<Spectrogram {...defaultProps} />);
+
+  const overlay = container.querySelector('.spectrogram__overlay');
+  expect(overlay).toBeInTheDocument();
+  expect(overlay?.tagName).toBe('CANVAS');
+});
+
+it('overlay canvas has pointer-events none to pass through interactions', () => {
+  const { container } = render(<Spectrogram {...defaultProps} />);
+
+  const overlay = container.querySelector('.spectrogram__overlay');
+  expect(overlay).toBeInTheDocument();
+  // pointer-events: none is set via CSS class, verified by class presence
+  expect(overlay?.classList.contains('spectrogram__overlay')).toBe(true);
+});
+
 it('renders spectrogram container with correct opacity from volume signal', () => {
   trackService.getSignals(TRACK_ID)!.volume.value = 50;
   const { container } = render(<Spectrogram {...defaultProps} />);


### PR DESCRIPTION
## Summary

- Add a `PianoRollRenderer` module that draws detected melody notes as semi-transparent rectangular blocks on a 2D canvas, mapping MIDI notes to the CQT spectrogram's log-frequency axis
- Add a second `<canvas>` element overlaid on the spectrogram canvas with `pointer-events: none` so scrubbing and click interactions pass through
- Integrate the overlay into the `Spectrogram` component's animation frame loop with the same viewport culling and `lastDrawnRef` memoization pattern used by the tile renderer
- Overlay syncs with zoom (`pixelsPerSecond`) and scroll position, reusing the same coordinate calculations as the spectrogram

## Test plan

- [x] Unit tests for `midiNoteToBin` coordinate mapping (C1→bin 0, C2→bin 24, 2 bins/semitone)
- [x] Unit tests for `drawPianoRoll` viewport culling (before, after, partially overlapping)
- [x] Unit tests for `drawPianoRoll` visual rendering (fill/stroke called, color applied, roundRect fallback)
- [x] Component tests for overlay canvas presence and CSS class
- [x] All 868 existing tests pass
- [x] ESLint passes
- [x] Production build succeeds

Closes #300

https://claude.ai/code/session_01KibTutBxhRdGJVVYz3yJWt