### PR TITLE
Fix blank homepage when IndexedDB is unavailable

### DIFF
--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -31,13 +31,18 @@ const HomePage = () => {
   }, []);
 
   async function loadData() {
-    const [projectList, estimate] = await Promise.all([
-      listProjects(),
-      getStorageEstimate(),
-    ]);
-    setProjects(projectList);
-    setStorage({ usage: estimate.usage, quota: estimate.quota });
-    setIsLoading(false);
+    try {
+      const [projectList, estimate] = await Promise.all([
+        listProjects(),
+        getStorageEstimate(),
+      ]);
+      setProjects(projectList);
+      setStorage({ usage: estimate.usage, quota: estimate.quota });
+    } catch (error) {
+      console.error('Failed to load projects', error);
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   function handleCreate() {

--- a/src/components/home/__tests__/HomePage.test.tsx
+++ b/src/components/home/__tests__/HomePage.test.tsx
@@ -195,6 +195,20 @@ it('displays storage usage when projects exist', async () => {
   });
 });
 
+it('shows empty state when loading projects fails', async () => {
+  mockListProjects.mockRejectedValue(new Error('IndexedDB unavailable'));
+  mockGetStorageEstimate.mockResolvedValue({
+    usage: undefined,
+    quota: undefined,
+  });
+  render(<HomePage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Mawimbi')).toBeInTheDocument();
+  });
+  expect(screen.getByText('Create Project')).toBeInTheDocument();
+});
+
 it('hides storage usage when no projects exist', async () => {
   setupMocks([], { usage: 0, quota: 2147483648 });
   render(<HomePage />);


### PR DESCRIPTION
## Summary
- `HomePage.loadData()` had no error handling — if `listProjects()` or `getStorageEstimate()` threw (e.g. IndexedDB unavailable in private browsing, database corruption, version upgrade error), the promise rejected silently and `setIsLoading(false)` never ran
- This left the page stuck on the loading state, which renders an empty `<div class="home" />` — a completely blank page
- Wrapped `loadData()` in try/catch/finally so `isLoading` always clears and the empty project state renders even when storage access fails

## Test plan
- [x] Added unit test that mocks `listProjects` to reject — verifies the empty state ("Mawimbi" + "Create Project") still renders
- [x] All 853 existing tests pass
- [ ] Verify on deployed site that homepage loads in private/incognito browsing mode

https://claude.ai/code/session_01Wt3L1sCyrGmUniAvZxeTiU