### PR TITLE
Fix ONNX session conflict when running classification heads

### DIFF
--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -463,10 +463,15 @@ class InstrumentClassificationService {
       const instrumentInputName = instrumentSession.inputNames[0];
       const voiceInputName = voiceInstrumentalSession.inputNames[0];
 
-      const [instrumentOutput, voiceOutput] = await Promise.all([
-        instrumentSession.run({ [instrumentInputName]: embeddingTensor }),
-        voiceInstrumentalSession.run({ [voiceInputName]: embeddingTensor }),
-      ]);
+      // Run heads sequentially — ONNX Runtime Web's WASM backend (numThreads=1)
+      // shares a single inference runner across sessions, so concurrent run()
+      // calls fail with "Session already started".
+      const instrumentOutput = await instrumentSession.run({
+        [instrumentInputName]: embeddingTensor,
+      });
+      const voiceOutput = await voiceInstrumentalSession.run({
+        [voiceInputName]: embeddingTensor,
+      });
 
       // --- Voice/instrumental classification ---
       const voicePredictions = Object.values(voiceOutput)[0] as {

--- a/src/services/__tests__/InstrumentClassificationService.test.ts
+++ b/src/services/__tests__/InstrumentClassificationService.test.ts
@@ -820,6 +820,91 @@ describe('InstrumentClassificationService', () => {
     });
   });
 
+  describe('sequential session execution', () => {
+    it('runs classification heads sequentially to avoid ONNX "Session already started" error', async () => {
+      // ONNX Runtime Web's WASM backend (numThreads=1) cannot handle
+      // concurrent run() calls — even across different sessions — because
+      // they share a single WASM inference runner. If two sessions run in
+      // parallel via Promise.all, the second one rejects with
+      // "Session already started". The fix is to run them sequentially.
+      mockInferenceSessionCreate.mockReset();
+      mockFetchModel.mockResolvedValue(new ArrayBuffer(8));
+
+      let activeSessions = 0;
+
+      // Simulate ONNX RT behavior: reject if another session is already running
+      function createConcurrencyGuardedRun(
+        result: Record<string, unknown>,
+      ): ReturnType<typeof vi.fn> {
+        return vi.fn().mockImplementation(() => {
+          activeSessions++;
+          if (activeSessions > 1) {
+            activeSessions--;
+            return Promise.reject(new Error('Session already started'));
+          }
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              activeSessions--;
+              resolve(result);
+            }, 0);
+          });
+        });
+      }
+
+      const mockEffnetSession = {
+        inputNames: ['melspectrogram'],
+        run: createConcurrencyGuardedRun({
+          'PartitionedCall:0': {
+            data: new Float32Array(400).fill(0.1),
+            dims: [1, 400],
+          },
+          'PartitionedCall:1': {
+            data: new Float32Array(1280).fill(0.5),
+            dims: [1, 1280],
+          },
+        }),
+      };
+      const mockInstrumentSession = {
+        inputNames: ['model_output'],
+        run: createConcurrencyGuardedRun({
+          output: (() => {
+            const data = new Float32Array(40).fill(0.1);
+            data[15] = 0.85;
+            return { data };
+          })(),
+        }),
+      };
+      const mockVoiceInstrumentalSession = {
+        inputNames: ['model_output'],
+        run: createConcurrencyGuardedRun({
+          output: {
+            data: new Float32Array([0.85, 0.15]),
+            dims: [1, 2],
+          },
+        }),
+      };
+
+      mockInferenceSessionCreate
+        .mockResolvedValueOnce(mockEffnetSession)
+        .mockResolvedValueOnce(mockInstrumentSession)
+        .mockResolvedValueOnce(mockVoiceInstrumentalSession);
+
+      const patch = new Float32Array(128 * 96).fill(0.5);
+      mockComputeMelSpectrogram.mockResolvedValue([patch]);
+
+      const buffer = createAudioBuffer();
+      const promise = service.classify('track-1', buffer);
+
+      // Force fallback to main thread where we control the mock sessions
+      simulateWorkerError('Worker failed');
+      const label = await promise;
+
+      expect(label).toBe('guitar');
+      expect(mockInstrumentSession.run).toHaveBeenCalledTimes(1);
+      expect(mockVoiceInstrumentalSession.run).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('removeClassification', () => {
     it('removes a classification entry', async () => {
       const buffer = createAudioBuffer();

--- a/src/services/classification.worker.ts
+++ b/src/services/classification.worker.ts
@@ -268,10 +268,15 @@ async function classify(
   const instrumentInputName = instrumentSession.inputNames[0];
   const voiceInputName = voiceInstrumentalSession.inputNames[0];
 
-  const [instrumentOutput, voiceOutput] = await Promise.all([
-    instrumentSession.run({ [instrumentInputName]: embeddingTensor }),
-    voiceInstrumentalSession.run({ [voiceInputName]: embeddingTensor }),
-  ]);
+  // Run heads sequentially — ONNX Runtime Web's WASM backend (numThreads=1)
+  // shares a single inference runner across sessions, so concurrent run()
+  // calls fail with "Session already started".
+  const instrumentOutput = await instrumentSession.run({
+    [instrumentInputName]: embeddingTensor,
+  });
+  const voiceOutput = await voiceInstrumentalSession.run({
+    [voiceInputName]: embeddingTensor,
+  });
 
   // --- Voice/instrumental classification ---
   const voicePredictions = Object.values(voiceOutput)[0] as {


### PR DESCRIPTION
## Summary
- Fix "Session already started" error when classifying audio with the instrument and voice/instrumental ONNX models
- ONNX Runtime Web's WASM backend (`numThreads=1`) shares a single inference runner across sessions — running two `session.run()` calls concurrently via `Promise.all` causes the second to reject
- Changed both the classification worker and the main-thread fallback to run the instrument and voice/instrumental heads sequentially instead of in parallel

## Test plan
- [x] Added failing test that simulates ONNX RT's concurrency guard (rejects with "Session already started" when two sessions overlap)
- [x] Verified the test passes after the fix
- [x] All 870 existing tests pass
- [x] Build and lint pass

https://claude.ai/code/session_01PLeP1eGy3MtS2q5FDehp5v