### PR TITLE
Enhance piano roll notes with 3D effect and playhead glow

### DIFF
--- a/src/components/workstation/spectrogram/PianoRollRenderer.ts
+++ b/src/components/workstation/spectrogram/PianoRollRenderer.ts
@@ -3,6 +3,9 @@
  * as semi-transparent rectangular blocks aligned to the CQT spectrogram's
  * log-frequency axis.
  *
+ * Notes have a 3D appearance with gradient fills and distinct borders.
+ * Notes currently intersecting the playhead receive a bright glow effect.
+ *
  * The CQT spectrogram uses 24 bins/octave starting at C1 (32.7 Hz).
  * MIDI note numbers map to the same log scale:
  *   binIndex = 24 × log2(freq / 32.7)
@@ -31,13 +34,28 @@ const NOTE_HEIGHT_BINS = 2;
 const NOTE_FILL_OPACITY = 0.6;
 
 /** Note block border opacity (0–1). */
-const NOTE_BORDER_OPACITY = 0.8;
+const NOTE_BORDER_OPACITY = 0.85;
 
 /** Note block corner radius in pixels. */
 const CORNER_RADIUS = 2;
 
 /** Note block border width in pixels. */
-const BORDER_WIDTH = 1;
+const BORDER_WIDTH = 1.5;
+
+/** Opacity boost for notes intersecting the playhead (0–1). */
+const ACTIVE_FILL_OPACITY = 0.9;
+
+/** Glow blur radius in pixels for active notes. */
+const ACTIVE_GLOW_BLUR = 8;
+
+/** Glow opacity for active notes (0–1). */
+const ACTIVE_GLOW_OPACITY = 0.5;
+
+/** Top highlight opacity multiplier for 3D gradient (relative to fill). */
+const HIGHLIGHT_LIGHTNESS_BOOST = 40;
+
+/** Bottom shadow darkening factor (0–1, lower = darker). */
+const SHADOW_DARKENING_FACTOR = 0.55;
 
 // ---------------------------------------------------------------------------
 // Coordinate mapping
@@ -68,10 +86,15 @@ export type PianoRollViewport = {
   canvasHeight: number;
   /** Total number of CQT frequency bins (determines y-axis scale). */
   frequencyBinCount: number;
+  /** Current playhead time in seconds (-1 or undefined = no glow effect). */
+  playheadTime?: number;
 };
 
 /**
  * Draws melody notes as semi-transparent blocks onto a 2D canvas context.
+ *
+ * Notes have a gradient fill for a 3D appearance and a distinct border.
+ * Notes intersecting the playhead receive a bright glow effect.
  *
  * Only notes within the visible viewport are rendered (horizontal culling).
  * Vertical positions are mapped from MIDI note → CQT bin → canvas pixel.
@@ -88,6 +111,7 @@ export function drawPianoRoll(
     viewportWidth,
     canvasHeight,
     frequencyBinCount,
+    playheadTime,
   } = viewport;
 
   if (notes.length === 0 || frequencyBinCount === 0) return;
@@ -97,12 +121,8 @@ export function drawPianoRoll(
   const viewEndTime = (contentOffset + viewportWidth) / pixelsPerSecond;
 
   const { r, g, b } = color;
-  const fillStyle = `rgba(${r}, ${g}, ${b}, ${NOTE_FILL_OPACITY})`;
-  const strokeStyle = `rgba(${(r * 0.7) | 0}, ${(g * 0.7) | 0}, ${(b * 0.7) | 0}, ${NOTE_BORDER_OPACITY})`;
-
-  ctx.fillStyle = fillStyle;
-  ctx.strokeStyle = strokeStyle;
-  ctx.lineWidth = BORDER_WIDTH;
+  const hasPlayhead =
+    playheadTime !== undefined && playheadTime !== null && playheadTime >= 0;
 
   for (let i = 0; i < notes.length; i++) {
     const note = notes[i];
@@ -127,16 +147,93 @@ export function drawPianoRoll(
 
     if (height < 1) continue;
 
-    drawRoundedRect(ctx, x, y, width, height, CORNER_RADIUS);
+    const isActive =
+      hasPlayhead &&
+      playheadTime >= note.startTime &&
+      playheadTime < note.endTime;
+
+    drawNote(ctx, x, y, width, height, r, g, b, isActive);
   }
 }
 
 /**
- * Draws a filled and stroked rounded rectangle.
- * Uses the canvas roundRect API if available, otherwise falls back to
- * a simple rect (no rounded corners).
+ * Draws a single note block with gradient fill, border, and optional glow.
  */
-function drawRoundedRect(
+function drawNote(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+  isActive: boolean,
+): void {
+  const fillOpacity = isActive ? ACTIVE_FILL_OPACITY : NOTE_FILL_OPACITY;
+
+  // Active notes: draw glow behind the note
+  if (isActive) {
+    ctx.save();
+    ctx.shadowColor = `rgba(${r}, ${g}, ${b}, ${ACTIVE_GLOW_OPACITY})`;
+    ctx.shadowBlur = ACTIVE_GLOW_BLUR;
+    ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${fillOpacity})`;
+    drawRoundedPath(ctx, x, y, width, height, CORNER_RADIUS);
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // 3D gradient fill: lighter at top, darker at bottom
+  const gradient = ctx.createLinearGradient(x, y, x, y + height);
+  const rTop = Math.min(255, r + HIGHLIGHT_LIGHTNESS_BOOST);
+  const gTop = Math.min(255, g + HIGHLIGHT_LIGHTNESS_BOOST);
+  const bTop = Math.min(255, b + HIGHLIGHT_LIGHTNESS_BOOST);
+  const rBot = (r * SHADOW_DARKENING_FACTOR) | 0;
+  const gBot = (g * SHADOW_DARKENING_FACTOR) | 0;
+  const bBot = (b * SHADOW_DARKENING_FACTOR) | 0;
+
+  gradient.addColorStop(0, `rgba(${rTop}, ${gTop}, ${bTop}, ${fillOpacity})`);
+  gradient.addColorStop(1, `rgba(${rBot}, ${gBot}, ${bBot}, ${fillOpacity})`);
+
+  ctx.fillStyle = gradient;
+  ctx.strokeStyle = `rgba(${(r * 0.6) | 0}, ${(g * 0.6) | 0}, ${(b * 0.6) | 0}, ${NOTE_BORDER_OPACITY})`;
+  ctx.lineWidth = BORDER_WIDTH;
+
+  drawRoundedPath(ctx, x, y, width, height, CORNER_RADIUS);
+  ctx.fill();
+  ctx.stroke();
+
+  // Inner top highlight line for extra depth
+  drawTopHighlight(ctx, x, y, width, r, g, b, fillOpacity);
+}
+
+/**
+ * Draws a thin highlight line along the top edge of a note for a 3D bevel.
+ */
+function drawTopHighlight(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  r: number,
+  g: number,
+  b: number,
+  baseOpacity: number,
+): void {
+  const highlightOpacity = Math.min(1, baseOpacity * 0.5);
+  ctx.strokeStyle = `rgba(${Math.min(255, r + 80)}, ${Math.min(255, g + 80)}, ${Math.min(255, b + 80)}, ${highlightOpacity})`;
+  ctx.lineWidth = 0.5;
+  ctx.beginPath();
+  ctx.moveTo(x + CORNER_RADIUS, y + 0.5);
+  ctx.lineTo(x + width - CORNER_RADIUS, y + 0.5);
+  ctx.stroke();
+}
+
+/**
+ * Creates a rounded-rectangle path without filling or stroking.
+ * Uses the canvas roundRect API if available, otherwise falls back to rect.
+ */
+function drawRoundedPath(
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
@@ -150,6 +247,4 @@ function drawRoundedRect(
   } else {
     ctx.rect(x, y, width, height);
   }
-  ctx.fill();
-  ctx.stroke();
 }

--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -135,6 +135,9 @@ const Spectrogram = ({
         color,
         frequencyBinCount,
         duration,
+        startTime,
+        playback.getEngineTime(),
+        playback.isPlaying,
         lastDrawnOverlayRef,
       );
     }
@@ -330,6 +333,9 @@ function drawMelodyOverlay(
   color: TrackColor,
   frequencyBinCount: number,
   duration: number,
+  startTime: number,
+  playheadTime: number,
+  isPlaying: boolean,
   lastDrawnOverlayRef: React.MutableRefObject<{
     offset: number;
     pps: number;
@@ -356,8 +362,11 @@ function drawMelodyOverlay(
   const needsResize =
     canvas.width !== viewportWidth || canvas.height !== height;
 
+  // During playback, always redraw to update the playhead glow effect.
+  // When stopped, use memoization to skip unchanged frames.
   const last = lastDrawnOverlayRef.current;
   if (
+    !isPlaying &&
     !needsResize &&
     contentOffset === last.offset &&
     pixelsPerSecond === last.pps &&
@@ -378,12 +387,16 @@ function drawMelodyOverlay(
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+  // Playhead time relative to this track's start time
+  const trackPlayheadTime = playheadTime - startTime;
+
   const viewport: PianoRollViewport = {
     pixelsPerSecond,
     contentOffset,
     viewportWidth,
     canvasHeight: height,
     frequencyBinCount,
+    playheadTime: trackPlayheadTime,
   };
 
   drawPianoRoll(ctx, notes, color, viewport);

--- a/src/components/workstation/spectrogram/__tests__/PianoRollRenderer.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/PianoRollRenderer.test.ts
@@ -41,17 +41,30 @@ describe('midiNoteToBin', () => {
 describe('drawPianoRoll', () => {
   const color = { r: 100, g: 200, b: 150 };
 
+  function createMockGradient() {
+    return {
+      addColorStop: vi.fn(),
+    };
+  }
+
   function createMockCtx() {
     return {
       fillStyle: '',
       strokeStyle: '',
       lineWidth: 0,
+      shadowColor: '',
+      shadowBlur: 0,
       clearRect: vi.fn(),
       beginPath: vi.fn(),
       fill: vi.fn(),
       stroke: vi.fn(),
       rect: vi.fn(),
       roundRect: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      createLinearGradient: vi.fn(() => createMockGradient()),
     } as unknown as CanvasRenderingContext2D;
   }
 
@@ -97,9 +110,10 @@ describe('drawPianoRoll', () => {
 
     drawPianoRoll(ctx, [note], color, makeViewport());
 
-    expect(ctx.beginPath).toHaveBeenCalledTimes(1);
-    expect(ctx.fill).toHaveBeenCalledTimes(1);
-    expect(ctx.stroke).toHaveBeenCalledTimes(1);
+    // Each note: beginPath for body + fill + stroke, then beginPath for highlight + stroke
+    expect(ctx.fill).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.createLinearGradient).toHaveBeenCalled();
   });
 
   it('culls notes entirely before the viewport', () => {
@@ -144,7 +158,7 @@ describe('drawPianoRoll', () => {
     // Viewport covers 0–4 seconds; note starts at 3.5 and extends past 4
     drawPianoRoll(ctx, [note], color, makeViewport());
 
-    expect(ctx.beginPath).toHaveBeenCalledTimes(1);
+    expect(ctx.fill).toHaveBeenCalled();
   });
 
   it('draws multiple visible notes', () => {
@@ -157,12 +171,40 @@ describe('drawPianoRoll', () => {
 
     drawPianoRoll(ctx, notes, color, makeViewport());
 
-    expect(ctx.beginPath).toHaveBeenCalledTimes(3);
-    expect(ctx.fill).toHaveBeenCalledTimes(3);
-    expect(ctx.stroke).toHaveBeenCalledTimes(3);
+    // Each note creates a gradient
+    expect(ctx.createLinearGradient).toHaveBeenCalledTimes(3);
   });
 
-  it('sets fill style with track color and opacity', () => {
+  it('creates gradient fill with track color for 3D effect', () => {
+    const ctx = createMockCtx();
+    const gradient = createMockGradient();
+    (ctx.createLinearGradient as ReturnType<typeof vi.fn>).mockReturnValue(
+      gradient,
+    );
+
+    const note: MelodyNote = {
+      startTime: 0,
+      endTime: 1,
+      midiNote: 60,
+      confidence: 0.9,
+    };
+
+    drawPianoRoll(ctx, [note], color, makeViewport());
+
+    expect(ctx.createLinearGradient).toHaveBeenCalled();
+    // Gradient has two stops: lighter top and darker bottom
+    expect(gradient.addColorStop).toHaveBeenCalledTimes(2);
+    expect(gradient.addColorStop).toHaveBeenCalledWith(
+      0,
+      expect.stringContaining('rgba('),
+    );
+    expect(gradient.addColorStop).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('rgba('),
+    );
+  });
+
+  it('draws top highlight line for 3D bevel', () => {
     const ctx = createMockCtx();
     const note: MelodyNote = {
       startTime: 0,
@@ -173,9 +215,9 @@ describe('drawPianoRoll', () => {
 
     drawPianoRoll(ctx, [note], color, makeViewport());
 
-    expect(ctx.fillStyle).toContain('100');
-    expect(ctx.fillStyle).toContain('200');
-    expect(ctx.fillStyle).toContain('150');
+    // Top highlight uses moveTo/lineTo
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
   });
 
   it('uses roundRect when available', () => {
@@ -189,7 +231,7 @@ describe('drawPianoRoll', () => {
 
     drawPianoRoll(ctx, [note], color, makeViewport());
 
-    expect(ctx.roundRect).toHaveBeenCalledTimes(1);
+    expect(ctx.roundRect).toHaveBeenCalled();
     expect(ctx.rect).not.toHaveBeenCalled();
   });
 
@@ -207,6 +249,77 @@ describe('drawPianoRoll', () => {
 
     drawPianoRoll(ctx, [note], color, makeViewport());
 
-    expect(ctx.rect).toHaveBeenCalledTimes(1);
+    expect(ctx.rect).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Playhead glow effect
+  // ---------------------------------------------------------------------------
+
+  describe('playhead glow', () => {
+    it('applies glow effect to notes intersecting the playhead', () => {
+      const ctx = createMockCtx();
+      const note: MelodyNote = {
+        startTime: 1.0,
+        endTime: 2.0,
+        midiNote: 60,
+        confidence: 0.9,
+      };
+
+      drawPianoRoll(ctx, [note], color, makeViewport({ playheadTime: 1.5 }));
+
+      // Active notes use save/restore for glow shadow
+      expect(ctx.save).toHaveBeenCalled();
+      expect(ctx.restore).toHaveBeenCalled();
+    });
+
+    it('does not apply glow when playhead is outside note range', () => {
+      const ctx = createMockCtx();
+      const note: MelodyNote = {
+        startTime: 1.0,
+        endTime: 2.0,
+        midiNote: 60,
+        confidence: 0.9,
+      };
+
+      drawPianoRoll(ctx, [note], color, makeViewport({ playheadTime: 0.5 }));
+
+      // No save/restore means no glow was applied
+      expect(ctx.save).not.toHaveBeenCalled();
+    });
+
+    it('does not apply glow when playheadTime is undefined', () => {
+      const ctx = createMockCtx();
+      const note: MelodyNote = {
+        startTime: 0,
+        endTime: 1,
+        midiNote: 60,
+        confidence: 0.9,
+      };
+
+      drawPianoRoll(
+        ctx,
+        [note],
+        color,
+        makeViewport({ playheadTime: undefined }),
+      );
+
+      expect(ctx.save).not.toHaveBeenCalled();
+    });
+
+    it('applies glow only to the note under the playhead', () => {
+      const ctx = createMockCtx();
+      const notes: MelodyNote[] = [
+        { startTime: 0, endTime: 1, midiNote: 60, confidence: 0.9 },
+        { startTime: 1, endTime: 2, midiNote: 64, confidence: 0.8 },
+        { startTime: 2, endTime: 3, midiNote: 67, confidence: 0.7 },
+      ];
+
+      drawPianoRoll(ctx, notes, color, makeViewport({ playheadTime: 1.5 }));
+
+      // Only the second note (1.0–2.0) intersects playhead at 1.5
+      expect(ctx.save).toHaveBeenCalledTimes(1);
+      expect(ctx.restore).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -230,6 +230,7 @@ it('draws piano roll notes on the overlay canvas when melody data exists', () =>
   mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
   mockGetEntry.mockReturnValue(cachedEntry);
 
+  const mockGradient = { addColorStop: vi.fn() };
   const mockCtx = {
     clearRect: vi.fn(),
     drawImage: vi.fn(),
@@ -237,13 +238,18 @@ it('draws piano roll notes on the overlay canvas when melody data exists', () =>
     fillStyle: '' as string,
     strokeStyle: '' as string,
     lineWidth: 0,
+    shadowColor: '' as string,
+    shadowBlur: 0,
     beginPath: vi.fn(),
     fill: vi.fn(),
     stroke: vi.fn(),
     rect: vi.fn(),
     roundRect: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
     save: vi.fn(),
     restore: vi.fn(),
+    createLinearGradient: vi.fn(() => mockGradient),
     globalCompositeOperation: 'source-over' as string,
     canvas: { width: VIEWPORT_WIDTH, height: 128 },
   };
@@ -274,10 +280,13 @@ it('draws piano roll notes on the overlay canvas when melody data exists', () =>
   const callback = calls[calls.length - 1]?.[0];
   callback?.();
 
-  // drawPianoRoll should call beginPath once per visible note (2 notes)
-  expect(mockCtx.beginPath).toHaveBeenCalledTimes(2);
+  // drawPianoRoll draws each note with a gradient body + top highlight line
+  // Each note: beginPath (body) + beginPath (highlight) = 2 per note
+  expect(mockCtx.beginPath).toHaveBeenCalledTimes(4);
+  // Each note: fill (body) + stroke (body) + stroke (highlight)
   expect(mockCtx.fill).toHaveBeenCalledTimes(2);
-  expect(mockCtx.stroke).toHaveBeenCalledTimes(2);
+  expect(mockCtx.stroke).toHaveBeenCalledTimes(4);
+  expect(mockCtx.createLinearGradient).toHaveBeenCalledTimes(2);
 
   vi.restoreAllMocks();
 });


### PR DESCRIPTION
## Summary

- Add gradient fill (lighter top, darker bottom) to piano roll notes for a 3D appearance
- Add distinct contrasting border and subtle inner top highlight line for depth
- Add bright glow effect on notes as they pass through the playhead during playback
- Pass engine time and playback state from Spectrogram to the renderer for real-time glow animation

## Test plan

- [x] Unit tests for gradient fill creation (createLinearGradient called per note)
- [x] Unit tests for top highlight line rendering (moveTo/lineTo)
- [x] Unit tests for playhead glow: active notes use save/restore for shadow
- [x] Unit tests for glow not applied when playhead is outside note range or undefined
- [x] Unit tests for glow applied only to note under playhead (not all notes)
- [x] Component test updated with gradient mock, verifies draw calls per note
- [x] All 877 existing tests pass
- [x] ESLint passes
- [x] Production build succeeds

https://claude.ai/code/session_01QQYYR9TCDmQz6HvHjNuiMG