### PR TITLE
Migrate Layout from Ant Design to semantic HTML + CSS

### DIFF
--- a/src/components/layout/PageLayout.css
+++ b/src/components/layout/PageLayout.css
@@ -1,14 +1,17 @@
 .page {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
 }
 
 .page__header {
-  height: auto;
+  background-color: var(--surface);
   padding: 0;
 }
 
 .page__content {
   display: flex;
   flex-direction: column;
+  flex: auto;
 }

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,23 +1,20 @@
-import { Layout } from 'antd';
 import React from 'react';
 import './PageLayout.css';
-
-const { Header, Content } = Layout;
 
 type PageLayoutProps = React.PropsWithChildren;
 
 export const PageLayout = ({ children }: PageLayoutProps) => {
-  return <Layout className="page">{children}</Layout>;
+  return <div className="page">{children}</div>;
 };
 
 type PageHeaderProps = React.PropsWithChildren;
 
 export const PageHeader = ({ children }: PageHeaderProps) => {
-  return <Header className="page__header">{children}</Header>;
+  return <header className="page__header">{children}</header>;
 };
 
 type PageContentProps = React.PropsWithChildren;
 
 export const PageContent = ({ children }: PageContentProps) => {
-  return <Content className="page__content">{children}</Content>;
+  return <main className="page__content">{children}</main>;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,9 +17,6 @@ root.render(
     <ConfigProvider
       theme={{
         algorithm: theme.darkAlgorithm,
-        // antd v5 Layout.Header defaults to #001529 even in dark mode;
-        // override to match colorBgContainer (#141414) used in antd v4 dark theme
-        components: { Layout: { headerBg: '#141414' } },
       }}
     >
       <AntApp>


### PR DESCRIPTION
## Summary
- Replaced Ant Design `Layout`, `Layout.Header`, and `Layout.Content` with semantic HTML elements (`<div>`, `<header>`, `<main>`) styled with plain CSS
- Updated `PageLayout.css` to replicate Ant Design's flex column layout behavior with explicit styles
- Removed the `Layout.headerBg` theme override from `ConfigProvider` in `index.tsx` — the header background is now set via the `--surface` CSS variable in `PageLayout.css`

Closes #290

## Test plan
- [x] All 877 existing tests pass
- [x] Production build succeeds
- [x] ESLint passes
- [ ] Visual check: page layout renders identically (full-height, dark header background)
- [ ] Verify no remaining `Layout` imports from `antd`

https://claude.ai/code/session_01Nz6yCrx9RyDeoGpUYJsDWp