### PR TITLE
Add TranscriptionService with Web Worker for Whisper speech-to-text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@eslint/js": "^9.0.0",
+        "@huggingface/transformers": "^3.8.1",
         "@preact/signals-react": "^3.9.0",
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.4.6",
@@ -635,6 +636,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -1247,6 +1258,47 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
+      "integrity": "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
+    },
+    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1293,6 +1345,483 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5067,6 +5596,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5233,6 +5769,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/class-variance-authority": {
@@ -5583,6 +6128,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5873,6 +6424,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -6488,6 +7045,35 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -7347,6 +7933,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -7922,6 +8514,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8014,6 +8618,27 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -8246,6 +8871,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
       }
     },
     "node_modules/onnxruntime-web": {
@@ -9654,6 +10302,23 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -9798,6 +10463,27 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
@@ -9848,6 +10534,62 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -10024,6 +10766,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -10334,6 +11082,31 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
@@ -10513,6 +11286,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@eslint/js": "^9.0.0",
+    "@huggingface/transformers": "^3.8.1",
     "@preact/signals-react": "^3.9.0",
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.4.6",

--- a/src/hooks/useTranscriptionService.ts
+++ b/src/hooks/useTranscriptionService.ts
@@ -1,0 +1,46 @@
+// useTranscriptionService — React hook that bridges
+// TranscriptionService signals to components.
+//
+// Provides reactive transcription state and lookup functions
+// for speech-to-text results on each track.
+
+import { useSignals } from '@preact/signals-react/runtime';
+import { useContext } from 'react';
+import { AudioServiceContext } from './useAudioService';
+import type { TranscriptionState } from '../services/TranscriptionService';
+import type { TrackId } from '../types/track';
+
+export function useTranscriptionService() {
+  useSignals();
+  const service = useContext(AudioServiceContext).transcriptionService;
+
+  return {
+    // --- Reactive state (getter → lazy signal subscription via signals accessor) ---
+
+    get transcriptions() {
+      return service.signals.transcriptions.value;
+    },
+
+    get downloadProgress() {
+      return service.signals.downloadProgress.value;
+    },
+
+    // --- Lookups (read from signal so useSignals() tracks the subscription) ---
+
+    getTranscription: (trackId: TrackId) =>
+      service.signals.transcriptions.value.get(trackId)?.result,
+    getTranscriptionState: (trackId: TrackId): TranscriptionState =>
+      service.signals.transcriptions.value.get(trackId)?.state ?? 'idle',
+
+    // --- Actions ---
+
+    transcribe: (trackId: TrackId, audioBuffer: AudioBuffer) =>
+      service.transcribe(trackId, audioBuffer),
+
+    // --- Cleanup ---
+
+    removeTranscription: (trackId: TrackId) =>
+      service.removeTranscription(trackId),
+    reset: () => service.reset(),
+  };
+}

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -10,6 +10,7 @@ import PlaybackService from './PlaybackService';
 import RecordingService from './RecordingService';
 import TrackService from './TrackService';
 import InstrumentClassificationService from './InstrumentClassificationService';
+import TranscriptionService from './TranscriptionService';
 import SpectrogramCache from './SpectrogramCache';
 import WorkletAnalyser from './WorkletAnalyser';
 
@@ -33,6 +34,7 @@ class AudioService {
   readonly recordingService: RecordingService;
   readonly trackService: TrackService;
   readonly classificationService: InstrumentClassificationService;
+  readonly transcriptionService: TranscriptionService;
   readonly spectrogramCache: SpectrogramCache;
 
   private static instance: AudioService;
@@ -45,6 +47,7 @@ class AudioService {
     this.recordingService = new RecordingService(transport, context);
     this.trackService = new TrackService(context);
     this.classificationService = new InstrumentClassificationService();
+    this.transcriptionService = new TranscriptionService();
     this.spectrogramCache = new SpectrogramCache();
 
     // Fire-and-forget classification when a track is created

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -1,0 +1,254 @@
+// TranscriptionService — owns speech-to-text transcription state.
+//
+// Delegates Whisper inference to a Web Worker to keep the main thread
+// responsive. The worker loads the Whisper model via @huggingface/transformers
+// (ONNX-based, WASM backend) and returns word-level and segment-level
+// timestamps.
+//
+// Signal ownership and per-track caching remain on the main thread.
+
+import { signal, type ReadonlySignal } from '@preact/signals-react';
+import type { TrackId } from '../types/track';
+import type {
+  Transcription,
+  TranscriptionSegment,
+} from '../types/transcription';
+import type { WorkerMessage, TranscribeResponse } from './transcription.worker';
+
+export type TranscriptionState = 'idle' | 'transcribing' | 'done' | 'error';
+
+type TranscriptionEntry = {
+  state: TranscriptionState;
+  result?: Transcription;
+};
+
+type PendingRequest = {
+  resolve: (result: {
+    language: string;
+    segments: TranscriptionSegment[];
+  }) => void;
+  reject: (error: Error) => void;
+};
+
+class TranscriptionService {
+  // --- Private signals (only the service writes these) ---
+
+  private readonly _transcriptions = signal<
+    ReadonlyMap<TrackId, TranscriptionEntry>
+  >(new Map());
+
+  private readonly _downloadProgress = signal<number | null>(null);
+
+  // --- Narrow channel for reactive consumers (hooks) ---
+
+  readonly signals: {
+    readonly transcriptions: ReadonlySignal<
+      ReadonlyMap<TrackId, TranscriptionEntry>
+    >;
+    readonly downloadProgress: ReadonlySignal<number | null>;
+  };
+
+  private cache = new Map<TrackId, TranscriptionEntry>();
+  private worker: Worker | null = null;
+  private nextMessageId = 0;
+  private pendingRequests = new Map<number, PendingRequest>();
+
+  constructor() {
+    this.signals = {
+      transcriptions: this._transcriptions,
+      downloadProgress: this._downloadProgress,
+    };
+  }
+
+  // --- Plain getters for non-reactive consumers (tests, workflows) ---
+
+  get transcriptions(): ReadonlyMap<TrackId, TranscriptionEntry> {
+    return this._transcriptions.value;
+  }
+
+  get downloadProgress(): number | null {
+    return this._downloadProgress.value;
+  }
+
+  getTranscription(trackId: TrackId): Transcription | undefined {
+    return this.cache.get(trackId)?.result;
+  }
+
+  getTranscriptionState(trackId: TrackId): TranscriptionState {
+    return this.cache.get(trackId)?.state ?? 'idle';
+  }
+
+  // --- Transcription ---
+
+  async transcribe(
+    trackId: TrackId,
+    audioBuffer: AudioBuffer,
+  ): Promise<Transcription> {
+    const cached = this.cache.get(trackId);
+    if (cached?.state === 'done' && cached.result) {
+      console.debug(
+        `[transcription] Track ${trackId} already transcribed (cached)`,
+      );
+      return cached.result;
+    }
+
+    const durationSeconds = audioBuffer.length / audioBuffer.sampleRate;
+    console.debug(
+      `[transcription] Track ${trackId}: ${audioBuffer.numberOfChannels}ch, ${audioBuffer.length} samples, ${audioBuffer.sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
+    );
+
+    this.setEntry(trackId, { state: 'transcribing' });
+    console.log(`[transcription] Transcribing track ${trackId}`);
+
+    try {
+      const rawResult = await this.transcribeInWorker(trackId, audioBuffer);
+      const transcription: Transcription = {
+        trackId,
+        language: rawResult.language,
+        segments: rawResult.segments,
+      };
+      this.setEntry(trackId, { state: 'done', result: transcription });
+      console.log(
+        `[transcription] Track ${trackId} transcribed: ${transcription.segments.length} segments, language="${transcription.language}"`,
+      );
+      return transcription;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[transcription] Transcription failed for track ${trackId}: ${detail}`,
+      );
+      this.setEntry(trackId, { state: 'error' });
+      throw new Error(`Transcription failed for track ${trackId}: ${detail}`);
+    }
+  }
+
+  // --- Worker-based inference ---
+
+  private transcribeInWorker(
+    trackId: TrackId,
+    audioBuffer: AudioBuffer,
+  ): Promise<{ language: string; segments: TranscriptionSegment[] }> {
+    const worker = this.getWorker();
+    const id = this.nextMessageId++;
+
+    const transferables: Transferable[] = [];
+    const channelData: Float32Array[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+      const copy = new Float32Array(audioBuffer.getChannelData(ch));
+      channelData.push(copy);
+      transferables.push(copy.buffer);
+    }
+
+    console.debug(
+      `[transcription] Sending track ${trackId} to worker (id=${id})`,
+    );
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      worker.postMessage(
+        {
+          id,
+          type: 'transcribe',
+          channelData,
+          sampleRate: audioBuffer.sampleRate,
+          length: audioBuffer.length,
+        },
+        transferables,
+      );
+    });
+  }
+
+  private getWorker(): Worker {
+    if (!this.worker) {
+      this.worker = new Worker(
+        new URL('./transcription.worker.ts', import.meta.url),
+        { type: 'module' },
+      );
+      this.worker.onmessage = (event: MessageEvent<WorkerMessage>) => {
+        const { type } = event.data;
+
+        // Forward worker log messages to console
+        if (type === 'log') {
+          const { level, message } = event.data;
+          console[level](message);
+          return;
+        }
+
+        // Handle download progress updates
+        if (type === 'download-progress') {
+          this._downloadProgress.value = event.data.progress;
+          console.debug(
+            `[transcription] Model download progress: ${event.data.progress}%`,
+          );
+          return;
+        }
+
+        const response = event.data as TranscribeResponse;
+        const pending = this.pendingRequests.get(response.id);
+        if (!pending) {
+          console.warn(
+            `[transcription] Received worker response for unknown request id=${response.id}`,
+          );
+          return;
+        }
+        this.pendingRequests.delete(response.id);
+
+        // Model is loaded — clear download progress
+        this._downloadProgress.value = null;
+
+        if (response.type === 'error') {
+          console.error(
+            `[transcription] Worker returned error for request id=${response.id}: ${response.message}`,
+          );
+          pending.reject(new Error(response.message));
+        } else {
+          console.debug(
+            `[transcription] Worker result for request id=${response.id}: ${response.segments.length} segments`,
+          );
+          pending.resolve({
+            language: response.language,
+            segments: response.segments,
+          });
+        }
+      };
+      this.worker.onerror = (event) => {
+        console.error('[transcription] Worker crashed (onerror):', event);
+        this._downloadProgress.value = null;
+        this.rejectAllPending(new Error('Transcription worker failed'));
+      };
+    }
+    return this.worker;
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(error);
+    }
+    this.pendingRequests.clear();
+  }
+
+  // --- Cleanup ---
+
+  removeTranscription(trackId: TrackId): void {
+    this.cache.delete(trackId);
+    this.publishCache();
+  }
+
+  reset(): void {
+    this.cache.clear();
+    this.publishCache();
+  }
+
+  // --- Internal state management ---
+
+  private setEntry(trackId: TrackId, entry: TranscriptionEntry): void {
+    this.cache.set(trackId, entry);
+    this.publishCache();
+  }
+
+  private publishCache(): void {
+    this._transcriptions.value = new Map(this.cache);
+  }
+}
+
+export default TranscriptionService;

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -12,21 +12,27 @@ import type { TrackId } from '../types/track';
 import type {
   Transcription,
   TranscriptionSegment,
+  TranscriptionWord,
 } from '../types/transcription';
 import type { WorkerMessage, TranscribeResponse } from './transcription.worker';
 
 export type TranscriptionState = 'idle' | 'transcribing' | 'done' | 'error';
+
+// Default Whisper model — matches the worker default.
+const DEFAULT_MODEL_ID = 'onnx-community/whisper-base';
 
 type TranscriptionEntry = {
   state: TranscriptionState;
   result?: Transcription;
 };
 
+type RawTranscriptionResult = {
+  language: string;
+  segments: TranscriptionSegment[];
+};
+
 type PendingRequest = {
-  resolve: (result: {
-    language: string;
-    segments: TranscriptionSegment[];
-  }) => void;
+  resolve: (result: RawTranscriptionResult) => void;
   reject: (error: Error) => void;
 };
 
@@ -50,10 +56,20 @@ class TranscriptionService {
 
   private cache = new Map<TrackId, TranscriptionEntry>();
   private worker: Worker | null = null;
+  private workerFailed = false;
   private nextMessageId = 0;
   private pendingRequests = new Map<number, PendingRequest>();
 
-  constructor() {
+  // Main-thread fallback state
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mainThreadPipeline: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mainThreadPipelinePromise: Promise<any> | null = null;
+
+  readonly modelId: string;
+
+  constructor(modelId: string = DEFAULT_MODEL_ID) {
+    this.modelId = modelId;
     this.signals = {
       transcriptions: this._transcriptions,
       downloadProgress: this._downloadProgress,
@@ -101,17 +117,8 @@ class TranscriptionService {
     console.log(`[transcription] Transcribing track ${trackId}`);
 
     try {
-      const rawResult = await this.transcribeInWorker(trackId, audioBuffer);
-      const transcription: Transcription = {
-        trackId,
-        language: rawResult.language,
-        segments: rawResult.segments,
-      };
-      this.setEntry(trackId, { state: 'done', result: transcription });
-      console.log(
-        `[transcription] Track ${trackId} transcribed: ${transcription.segments.length} segments, language="${transcription.language}"`,
-      );
-      return transcription;
+      const rawResult = await this.runInference(audioBuffer);
+      return this.applyResult(trackId, rawResult);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       console.error(
@@ -122,12 +129,53 @@ class TranscriptionService {
     }
   }
 
+  // --- Inference orchestration ---
+
+  private async runInference(
+    audioBuffer: AudioBuffer,
+  ): Promise<RawTranscriptionResult> {
+    if (this.workerFailed) {
+      console.debug(
+        '[transcription] Using main-thread inference (worker previously failed)',
+      );
+      return this.transcribeOnMainThread(audioBuffer);
+    }
+    try {
+      return await this.transcribeInWorker(audioBuffer);
+    } catch (workerError) {
+      this.workerFailed = true;
+      const errorDetail =
+        workerError instanceof Error
+          ? workerError.message
+          : String(workerError);
+      console.warn(
+        `[transcription] Worker failed, falling back to main thread: ${errorDetail}`,
+      );
+      return this.transcribeOnMainThread(audioBuffer);
+    }
+  }
+
+  private applyResult(
+    trackId: TrackId,
+    rawResult: RawTranscriptionResult,
+  ): Transcription {
+    const transcription: Transcription = {
+      trackId,
+      language: rawResult.language,
+      segments: rawResult.segments,
+    };
+    this.setEntry(trackId, { state: 'done', result: transcription });
+    console.log(
+      `[transcription] Track ${trackId} transcribed: ${transcription.segments.length} segments, language="${transcription.language}"`,
+    );
+    return transcription;
+  }
+
   // --- Worker-based inference ---
 
   private transcribeInWorker(
-    trackId: TrackId,
     audioBuffer: AudioBuffer,
-  ): Promise<{ language: string; segments: TranscriptionSegment[] }> {
+  ): Promise<RawTranscriptionResult> {
     const worker = this.getWorker();
     const id = this.nextMessageId++;
 
@@ -139,9 +187,7 @@ class TranscriptionService {
       transferables.push(copy.buffer);
     }
 
-    console.debug(
-      `[transcription] Sending track ${trackId} to worker (id=${id})`,
-    );
+    console.debug(`[transcription] Sending to worker (id=${id})`);
 
     return new Promise((resolve, reject) => {
       this.pendingRequests.set(id, { resolve, reject });
@@ -152,6 +198,7 @@ class TranscriptionService {
           channelData,
           sampleRate: audioBuffer.sampleRate,
           length: audioBuffer.length,
+          modelId: this.modelId,
         },
         transferables,
       );
@@ -227,6 +274,64 @@ class TranscriptionService {
     this.pendingRequests.clear();
   }
 
+  // --- Main-thread fallback ---
+
+  private async transcribeOnMainThread(
+    audioBuffer: AudioBuffer,
+  ): Promise<RawTranscriptionResult> {
+    console.debug(
+      '[transcription] Loading Whisper pipeline for main-thread inference...',
+    );
+    const transcriber = await this.loadMainThreadPipeline();
+
+    const mono = downmixToMono(audioBuffer);
+    const resampled = resampleToTarget(mono, audioBuffer.sampleRate);
+    console.debug(
+      `[transcription] Main-thread mono audio: ${resampled.length} samples at ${WHISPER_SAMPLE_RATE} Hz`,
+    );
+
+    const result = await transcriber(resampled, {
+      return_timestamps: 'word',
+      language: null,
+    });
+
+    const language: string = result.language ?? 'en';
+    const chunks: { text: string; timestamp: [number, number | null] }[] =
+      result.chunks ?? [];
+
+    return { language, segments: groupWordsIntoSegments(chunks) };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async loadMainThreadPipeline(): Promise<any> {
+    if (this.mainThreadPipeline) return this.mainThreadPipeline;
+    if (this.mainThreadPipelinePromise) return this.mainThreadPipelinePromise;
+
+    this.mainThreadPipelinePromise = this.initializeMainThreadPipeline();
+    this.mainThreadPipeline = await this.mainThreadPipelinePromise;
+    this.mainThreadPipelinePromise = null;
+    return this.mainThreadPipeline;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async initializeMainThreadPipeline(): Promise<any> {
+    console.log(
+      `[transcription] Loading Whisper model "${this.modelId}" on main thread...`,
+    );
+    const { pipeline: createPipeline, env } =
+      await import('@huggingface/transformers');
+    env.allowLocalModels = false;
+
+    const transcriber = await createPipeline(
+      'automatic-speech-recognition',
+      this.modelId,
+      { dtype: 'q8', device: 'wasm' },
+    );
+
+    console.log('[transcription] Whisper model loaded on main thread');
+    return transcriber;
+  }
+
   // --- Cleanup ---
 
   removeTranscription(trackId: TrackId): void {
@@ -249,6 +354,97 @@ class TranscriptionService {
   private publishCache(): void {
     this._transcriptions.value = new Map(this.cache);
   }
+}
+
+// --- Audio utilities (main-thread fallback) ---
+
+// Whisper expects 16 kHz mono audio
+const WHISPER_SAMPLE_RATE = 16_000;
+
+function downmixToMono(audioBuffer: AudioBuffer): Float32Array {
+  const length = audioBuffer.length;
+  const numberOfChannels = audioBuffer.numberOfChannels;
+  const mono = new Float32Array(length);
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    const data = audioBuffer.getChannelData(ch);
+    for (let i = 0; i < length; i++) {
+      mono[i] += data[i] / numberOfChannels;
+    }
+  }
+  return mono;
+}
+
+function resampleToTarget(input: Float32Array, fromRate: number): Float32Array {
+  if (fromRate === WHISPER_SAMPLE_RATE) return input;
+
+  const ratio = fromRate / WHISPER_SAMPLE_RATE;
+  const outputLength = Math.round(input.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const low = Math.floor(srcIndex);
+    const high = Math.min(low + 1, input.length - 1);
+    const frac = srcIndex - low;
+    output[i] = input[low] * (1 - frac) + input[high] * frac;
+  }
+
+  return output;
+}
+
+// Groups word-level chunks into segments by detecting pauses.
+// A new segment starts when the gap between consecutive words exceeds the threshold.
+const SEGMENT_GAP_THRESHOLD_SECONDS = 1.0;
+
+type WhisperChunk = {
+  text: string;
+  timestamp: [number, number | null];
+};
+
+function groupWordsIntoSegments(
+  chunks: WhisperChunk[],
+): TranscriptionSegment[] {
+  if (chunks.length === 0) return [];
+
+  const segments: TranscriptionSegment[] = [];
+  let currentWords: TranscriptionWord[] = [];
+
+  for (const chunk of chunks) {
+    const word: TranscriptionWord = {
+      text: chunk.text.trim(),
+      start: chunk.timestamp[0],
+      end: chunk.timestamp[1] ?? chunk.timestamp[0],
+    };
+
+    if (word.text === '') continue;
+
+    if (currentWords.length > 0) {
+      const lastWord = currentWords[currentWords.length - 1];
+      const gap = word.start - lastWord.end;
+
+      if (gap >= SEGMENT_GAP_THRESHOLD_SECONDS) {
+        segments.push(buildSegment(currentWords));
+        currentWords = [];
+      }
+    }
+
+    currentWords.push(word);
+  }
+
+  if (currentWords.length > 0) {
+    segments.push(buildSegment(currentWords));
+  }
+
+  return segments;
+}
+
+function buildSegment(words: TranscriptionWord[]): TranscriptionSegment {
+  return {
+    text: words.map((w) => w.text).join(' '),
+    start: words[0].start,
+    end: words[words.length - 1].end,
+    words,
+  };
 }
 
 export default TranscriptionService;

--- a/src/services/__tests__/TranscriptionService.test.ts
+++ b/src/services/__tests__/TranscriptionService.test.ts
@@ -2,6 +2,16 @@ import { vi } from 'vitest';
 import TranscriptionService from '../TranscriptionService';
 import type { TranscriptionSegment } from '../../types/transcription';
 
+// Mock @huggingface/transformers for main-thread fallback tests
+const mockTranscriberFn = vi.fn();
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: vi
+    .fn()
+    .mockImplementation(() => Promise.resolve(mockTranscriberFn)),
+  env: { allowLocalModels: true },
+}));
+
 type MockWorker = {
   postMessage: ReturnType<typeof vi.fn>;
   onmessage: ((event: MessageEvent) => void) | null;
@@ -77,10 +87,23 @@ function simulateDownloadProgress(progress: number): void {
   } as MessageEvent);
 }
 
+// Set up main-thread fallback mock — returns sample transcription result
+function setupMainThreadMocks(): void {
+  mockTranscriberFn.mockResolvedValue({
+    language: 'en',
+    chunks: [
+      { text: ' Hello', timestamp: [0.0, 0.7] },
+      { text: ' world', timestamp: [0.8, 1.5] },
+    ],
+  });
+}
+
 let service: TranscriptionService;
 
 beforeEach(() => {
   service = new TranscriptionService();
+  mockTranscriberFn.mockReset();
+  setupMainThreadMocks();
 });
 
 describe('TranscriptionService', () => {
@@ -99,6 +122,15 @@ describe('TranscriptionService', () => {
 
     it('starts with null download progress', () => {
       expect(service.downloadProgress).toBeNull();
+    });
+
+    it('uses default model ID when not specified', () => {
+      expect(service.modelId).toBe('onnx-community/whisper-base');
+    });
+
+    it('accepts a custom model ID', () => {
+      const custom = new TranscriptionService('onnx-community/whisper-small');
+      expect(custom.modelId).toBe('onnx-community/whisper-small');
     });
   });
 
@@ -129,7 +161,7 @@ describe('TranscriptionService', () => {
       expect(Worker).toHaveBeenCalledTimes(1);
     });
 
-    it('posts channel data, sampleRate, and length to the worker', async () => {
+    it('posts channel data, sampleRate, length, and modelId to the worker', async () => {
       const buffer = createAudioBuffer();
       const promise = service.transcribe('track-1', buffer);
 
@@ -142,6 +174,7 @@ describe('TranscriptionService', () => {
           type: 'transcribe',
           sampleRate: 16000,
           length: 48000,
+          modelId: 'onnx-community/whisper-base',
         }),
         expect.any(Array),
       );
@@ -149,6 +182,18 @@ describe('TranscriptionService', () => {
       const postedMessage = mockWorker.postMessage.mock.calls[0][0];
       expect(postedMessage.channelData).toHaveLength(1);
       expect(postedMessage.channelData[0]).toBeInstanceOf(Float32Array);
+    });
+
+    it('sends custom model ID to the worker', async () => {
+      const custom = new TranscriptionService('onnx-community/whisper-small');
+      const buffer = createAudioBuffer();
+      const promise = custom.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.modelId).toBe('onnx-community/whisper-small');
     });
 
     it('transfers channel data ArrayBuffers to avoid copying', async () => {
@@ -317,31 +362,47 @@ describe('TranscriptionService', () => {
 
       simulateDownloadProgress(50);
 
+      // Trigger onerror (catastrophic worker failure) — rejects all pending
+      // requests and falls back to main-thread inference.
       mockWorker.onerror!({} as ErrorEvent);
+      await promise;
 
-      await expect(promise).rejects.toThrow();
       expect(service.downloadProgress).toBeNull();
     });
   });
 
-  describe('worker error handling', () => {
-    it('sets state to error when the worker responds with an error', async () => {
+  describe('worker error handling with main-thread fallback', () => {
+    it('falls back to main thread when the worker responds with an error', async () => {
       const buffer = createAudioBuffer();
       const promise = service.transcribe('track-1', buffer);
 
       simulateWorkerError('Whisper pipeline failed');
+      await promise;
 
-      await expect(promise).rejects.toThrow(
-        'Transcription failed for track track-1',
-      );
-      expect(service.getTranscriptionState('track-1')).toBe('error');
+      // Should have fallen back to main-thread pipeline
+      expect(mockTranscriberFn).toHaveBeenCalled();
+      expect(service.getTranscriptionState('track-1')).toBe('done');
+      expect(service.getTranscription('track-1')?.segments).toHaveLength(1);
     });
 
-    it('sets state to error when the worker crashes', async () => {
+    it('falls back to main thread when the worker crashes (onerror)', async () => {
       const buffer = createAudioBuffer();
       const promise = service.transcribe('track-1', buffer);
 
       mockWorker.onerror!({} as ErrorEvent);
+      await promise;
+
+      expect(mockTranscriberFn).toHaveBeenCalled();
+      expect(service.getTranscriptionState('track-1')).toBe('done');
+    });
+
+    it('sets state to error when both worker and main thread fail', async () => {
+      mockTranscriberFn.mockRejectedValue(new Error('model load error'));
+
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerError('Worker failed');
 
       await expect(promise).rejects.toThrow(
         'Transcription failed for track track-1',
@@ -349,15 +410,87 @@ describe('TranscriptionService', () => {
       expect(service.getTranscriptionState('track-1')).toBe('error');
     });
 
-    it('rejects all pending requests when the worker crashes', async () => {
+    it('uses main thread directly after worker has failed once', async () => {
       const buffer = createAudioBuffer();
+
+      // First call — worker error triggers fallback
       const promise1 = service.transcribe('track-1', buffer);
-      const promise2 = service.transcribe('track-2', buffer);
+      simulateWorkerError('Worker failed');
+      await promise1;
 
-      mockWorker.onerror!({} as ErrorEvent);
+      // Second call — should go directly to main thread (no worker message)
+      const postMessageCallCount = mockWorker.postMessage.mock.calls.length;
 
-      await expect(promise1).rejects.toThrow();
-      await expect(promise2).rejects.toThrow();
+      mockTranscriberFn.mockResolvedValueOnce({
+        language: 'en',
+        chunks: [{ text: ' test', timestamp: [0.0, 0.5] }],
+      });
+      await service.transcribe('track-2', buffer);
+
+      expect(mockWorker.postMessage.mock.calls.length).toBe(
+        postMessageCallCount,
+      );
+    });
+
+    it('reuses the pipeline across multiple fallback calls', async () => {
+      const { pipeline: createPipeline } =
+        await import('@huggingface/transformers');
+
+      const buffer = createAudioBuffer();
+
+      // First call — trigger fallback
+      const promise1 = service.transcribe('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise1;
+
+      // Second call — reuses pipeline
+      mockTranscriberFn.mockResolvedValueOnce({
+        language: 'en',
+        chunks: [{ text: ' test', timestamp: [0.0, 0.5] }],
+      });
+      await service.transcribe('track-2', buffer);
+
+      // Pipeline created only once
+      expect(createPipeline).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('main-thread fallback audio preprocessing', () => {
+    it('downmixes stereo to mono for main-thread fallback', async () => {
+      const buffer = createAudioBuffer(2, 48000, 16000);
+
+      const promise = service.transcribe('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      // The main-thread transcriber should receive a Float32Array (mono)
+      const audioArg = mockTranscriberFn.mock.calls[0][0] as Float32Array;
+      expect(audioArg).toBeInstanceOf(Float32Array);
+      expect(audioArg.length).toBe(48000);
+    });
+
+    it('resamples from 44100 to 16000 for main-thread fallback', async () => {
+      // 3 seconds at 44100 Hz = 132300 samples
+      const buffer = createAudioBuffer(1, 132300, 44100);
+
+      const promise = service.transcribe('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      // After resampling: 3s * 16000 = 48000 samples
+      const audioArg = mockTranscriberFn.mock.calls[0][0] as Float32Array;
+      expect(audioArg.length).toBe(48000);
+    });
+
+    it('does not resample when already at 16 kHz', async () => {
+      const buffer = createAudioBuffer(1, 48000, 16000);
+
+      const promise = service.transcribe('track-1', buffer);
+      simulateWorkerError('Worker failed');
+      await promise;
+
+      const audioArg = mockTranscriberFn.mock.calls[0][0] as Float32Array;
+      expect(audioArg.length).toBe(48000);
     });
   });
 

--- a/src/services/__tests__/TranscriptionService.test.ts
+++ b/src/services/__tests__/TranscriptionService.test.ts
@@ -1,0 +1,396 @@
+import { vi } from 'vitest';
+import TranscriptionService from '../TranscriptionService';
+import type { TranscriptionSegment } from '../../types/transcription';
+
+type MockWorker = {
+  postMessage: ReturnType<typeof vi.fn>;
+  onmessage: ((event: MessageEvent) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  terminate: ReturnType<typeof vi.fn>;
+};
+
+let mockWorker: MockWorker;
+
+// Must be a regular function (not arrow) to support `new` in Vitest
+vi.stubGlobal(
+  'Worker',
+  vi.fn().mockImplementation(function () {
+    mockWorker = {
+      postMessage: vi.fn(),
+      onmessage: null,
+      onerror: null,
+      terminate: vi.fn(),
+    };
+    return mockWorker;
+  }),
+);
+
+function createAudioBuffer(
+  numberOfChannels = 1,
+  length = 48000,
+  sampleRate = 16000,
+): AudioBuffer {
+  const channelData: Float32Array[] = [];
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    channelData.push(new Float32Array(length));
+  }
+  return {
+    numberOfChannels,
+    length,
+    sampleRate,
+    duration: length / sampleRate,
+    getChannelData: (ch: number) => channelData[ch],
+  } as unknown as AudioBuffer;
+}
+
+const sampleSegments: TranscriptionSegment[] = [
+  {
+    text: 'Hello world',
+    start: 0.0,
+    end: 1.5,
+    words: [
+      { text: 'Hello', start: 0.0, end: 0.7 },
+      { text: 'world', start: 0.8, end: 1.5 },
+    ],
+  },
+];
+
+function simulateWorkerResult(
+  language: string,
+  segments: TranscriptionSegment[],
+  id = 0,
+): void {
+  mockWorker.onmessage!({
+    data: { id, type: 'result', language, segments },
+  } as MessageEvent);
+}
+
+function simulateWorkerError(message: string, id = 0): void {
+  mockWorker.onmessage!({
+    data: { id, type: 'error', message },
+  } as MessageEvent);
+}
+
+function simulateDownloadProgress(progress: number): void {
+  mockWorker.onmessage!({
+    data: { type: 'download-progress', progress },
+  } as MessageEvent);
+}
+
+let service: TranscriptionService;
+
+beforeEach(() => {
+  service = new TranscriptionService();
+});
+
+describe('TranscriptionService', () => {
+  describe('initial state', () => {
+    it('starts with empty transcriptions', () => {
+      expect(service.transcriptions.size).toBe(0);
+    });
+
+    it('returns undefined for unknown track', () => {
+      expect(service.getTranscription('unknown')).toBeUndefined();
+    });
+
+    it('returns idle state for unknown track', () => {
+      expect(service.getTranscriptionState('unknown')).toBe('idle');
+    });
+
+    it('starts with null download progress', () => {
+      expect(service.downloadProgress).toBeNull();
+    });
+  });
+
+  describe('worker-based transcription', () => {
+    it('creates a Worker on first transcribe call', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      expect(Worker).toHaveBeenCalledWith(expect.any(URL), {
+        type: 'module',
+      });
+    });
+
+    it('reuses the same Worker across multiple transcribe calls', async () => {
+      const buffer = createAudioBuffer();
+
+      const promise1 = service.transcribe('track-1', buffer);
+      simulateWorkerResult('en', sampleSegments, 0);
+      await promise1;
+
+      const promise2 = service.transcribe('track-2', buffer);
+      simulateWorkerResult('en', sampleSegments, 1);
+      await promise2;
+
+      expect(Worker).toHaveBeenCalledTimes(1);
+    });
+
+    it('posts channel data, sampleRate, and length to the worker', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      expect(mockWorker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 0,
+          type: 'transcribe',
+          sampleRate: 16000,
+          length: 48000,
+        }),
+        expect.any(Array),
+      );
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.channelData).toHaveLength(1);
+      expect(postedMessage.channelData[0]).toBeInstanceOf(Float32Array);
+    });
+
+    it('transfers channel data ArrayBuffers to avoid copying', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      const transferables = mockWorker.postMessage.mock.calls[0][1];
+      expect(transferables).toHaveLength(1);
+      expect(transferables[0]).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it('copies channel data before transfer to preserve the original AudioBuffer', async () => {
+      const originalData = new Float32Array(48000).fill(0.5);
+      const buffer = {
+        numberOfChannels: 1,
+        length: 48000,
+        sampleRate: 16000,
+        duration: 3,
+        getChannelData: vi.fn().mockReturnValue(originalData),
+      } as unknown as AudioBuffer;
+
+      const promise = service.transcribe('track-1', buffer);
+
+      const postedChannelData =
+        mockWorker.postMessage.mock.calls[0][0].channelData[0];
+      expect(postedChannelData).not.toBe(originalData);
+      expect(postedChannelData.length).toBe(originalData.length);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+    });
+
+    it('extracts all channels for multi-channel audio', async () => {
+      const buffer = createAudioBuffer(2, 48000, 16000);
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      const postedMessage = mockWorker.postMessage.mock.calls[0][0];
+      expect(postedMessage.channelData).toHaveLength(2);
+    });
+
+    it('stores the result in the transcriptions signal', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      const result = service.getTranscription('track-1');
+      expect(result).toEqual({
+        trackId: 'track-1',
+        language: 'en',
+        segments: sampleSegments,
+      });
+    });
+
+    it('sets state to done after transcription', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      expect(service.getTranscriptionState('track-1')).toBe('done');
+    });
+
+    it('returns cached result without re-running inference', async () => {
+      const buffer = createAudioBuffer();
+
+      const promise1 = service.transcribe('track-1', buffer);
+      simulateWorkerResult('en', sampleSegments);
+      await promise1;
+
+      const result = await service.transcribe('track-1', buffer);
+
+      expect(result.language).toBe('en');
+      expect(mockWorker.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('transcribes multiple tracks independently', async () => {
+      const buffer1 = createAudioBuffer();
+      const buffer2 = createAudioBuffer();
+
+      const otherSegments: TranscriptionSegment[] = [
+        {
+          text: 'Goodbye',
+          start: 0.0,
+          end: 0.8,
+          words: [{ text: 'Goodbye', start: 0.0, end: 0.8 }],
+        },
+      ];
+
+      const promise1 = service.transcribe('track-1', buffer1);
+      simulateWorkerResult('en', sampleSegments, 0);
+      await promise1;
+
+      const promise2 = service.transcribe('track-2', buffer2);
+      simulateWorkerResult('fr', otherSegments, 1);
+      await promise2;
+
+      expect(service.getTranscription('track-1')?.language).toBe('en');
+      expect(service.getTranscription('track-2')?.language).toBe('fr');
+      expect(service.transcriptions.size).toBe(2);
+    });
+
+    it('assigns sequential message IDs', async () => {
+      const buffer = createAudioBuffer();
+
+      const promise1 = service.transcribe('track-1', buffer);
+      simulateWorkerResult('en', sampleSegments, 0);
+      await promise1;
+
+      const promise2 = service.transcribe('track-2', buffer);
+      simulateWorkerResult('en', sampleSegments, 1);
+      await promise2;
+
+      expect(mockWorker.postMessage.mock.calls[0][0].id).toBe(0);
+      expect(mockWorker.postMessage.mock.calls[1][0].id).toBe(1);
+    });
+
+    it('sets state to transcribing while worker processes', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      expect(service.getTranscriptionState('track-1')).toBe('transcribing');
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+    });
+  });
+
+  describe('download progress', () => {
+    it('updates download progress when the worker reports it', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateDownloadProgress(45);
+
+      expect(service.downloadProgress).toBe(45);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+    });
+
+    it('clears download progress when transcription result arrives', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateDownloadProgress(75);
+      expect(service.downloadProgress).toBe(75);
+
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      expect(service.downloadProgress).toBeNull();
+    });
+
+    it('clears download progress on worker error', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateDownloadProgress(50);
+
+      mockWorker.onerror!({} as ErrorEvent);
+
+      await expect(promise).rejects.toThrow();
+      expect(service.downloadProgress).toBeNull();
+    });
+  });
+
+  describe('worker error handling', () => {
+    it('sets state to error when the worker responds with an error', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      simulateWorkerError('Whisper pipeline failed');
+
+      await expect(promise).rejects.toThrow(
+        'Transcription failed for track track-1',
+      );
+      expect(service.getTranscriptionState('track-1')).toBe('error');
+    });
+
+    it('sets state to error when the worker crashes', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+
+      mockWorker.onerror!({} as ErrorEvent);
+
+      await expect(promise).rejects.toThrow(
+        'Transcription failed for track track-1',
+      );
+      expect(service.getTranscriptionState('track-1')).toBe('error');
+    });
+
+    it('rejects all pending requests when the worker crashes', async () => {
+      const buffer = createAudioBuffer();
+      const promise1 = service.transcribe('track-1', buffer);
+      const promise2 = service.transcribe('track-2', buffer);
+
+      mockWorker.onerror!({} as ErrorEvent);
+
+      await expect(promise1).rejects.toThrow();
+      await expect(promise2).rejects.toThrow();
+    });
+  });
+
+  describe('removeTranscription', () => {
+    it('removes a transcription entry', async () => {
+      const buffer = createAudioBuffer();
+      const promise = service.transcribe('track-1', buffer);
+      simulateWorkerResult('en', sampleSegments);
+      await promise;
+
+      service.removeTranscription('track-1');
+
+      expect(service.getTranscription('track-1')).toBeUndefined();
+      expect(service.getTranscriptionState('track-1')).toBe('idle');
+      expect(service.transcriptions.size).toBe(0);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all transcriptions', async () => {
+      const buffer = createAudioBuffer();
+
+      const promise1 = service.transcribe('track-1', buffer);
+      simulateWorkerResult('en', sampleSegments, 0);
+      await promise1;
+
+      const promise2 = service.transcribe('track-2', buffer);
+      simulateWorkerResult('en', sampleSegments, 1);
+      await promise2;
+
+      service.reset();
+
+      expect(service.transcriptions.size).toBe(0);
+    });
+  });
+});

--- a/src/services/transcription.worker.ts
+++ b/src/services/transcription.worker.ts
@@ -15,8 +15,9 @@ import type {
 // Whisper expects 16 kHz mono audio
 const MODEL_SAMPLE_RATE = 16_000;
 
-// Use whisper-base for the balance of quality and download size (~142 MB)
-const MODEL_ID = 'onnx-community/whisper-base';
+// Default Whisper model — whisper-base for the balance of quality and
+// download size (~142 MB). Can be overridden per request.
+const DEFAULT_MODEL_ID = 'onnx-community/whisper-base';
 
 export type TranscribeRequest = {
   id: number;
@@ -24,6 +25,7 @@ export type TranscribeRequest = {
   channelData: Float32Array[];
   sampleRate: number;
   length: number;
+  modelId?: string;
 };
 
 export type TranscribeResponse =
@@ -56,14 +58,19 @@ type Pipeline = any;
 
 let pipeline: Pipeline | null = null;
 let pipelinePromise: Promise<Pipeline> | null = null;
+let loadedModelId: string | null = null;
 
-async function loadPipeline(): Promise<Pipeline> {
-  if (pipeline) return pipeline;
-  if (pipelinePromise) return pipelinePromise;
+async function loadPipeline(modelId: string): Promise<Pipeline> {
+  // Reuse existing pipeline if the model hasn't changed
+  if (pipeline && loadedModelId === modelId) return pipeline;
+  if (pipelinePromise && loadedModelId === modelId) return pipelinePromise;
 
-  pipelinePromise = initializePipeline();
+  // Different model requested — discard the old pipeline
+  pipeline = null;
+  pipelinePromise = initializePipeline(modelId);
   pipeline = await pipelinePromise;
   pipelinePromise = null;
+  loadedModelId = modelId;
   return pipeline;
 }
 
@@ -86,18 +93,21 @@ function reportProgress(file: string, loaded: number, total: number): void {
   } satisfies DownloadProgressMessage);
 }
 
-async function initializePipeline(): Promise<Pipeline> {
-  workerLog('log', '[transcription:worker] Loading Whisper model...');
+async function initializePipeline(modelId: string): Promise<Pipeline> {
+  workerLog(
+    'log',
+    `[transcription:worker] Loading Whisper model "${modelId}"...`,
+  );
 
   const { pipeline: createPipeline, env } =
     await import('@huggingface/transformers');
 
-  // Allow local model loading and configure cache
+  // Disable local model loading — always fetch from Hugging Face Hub
   env.allowLocalModels = false;
 
   const transcriber = await createPipeline(
     'automatic-speech-recognition',
-    MODEL_ID,
+    modelId,
     {
       dtype: 'q8',
       device: 'wasm',
@@ -271,7 +281,8 @@ function workerLog(level: WorkerLogMessage['level'], message: string): void {
 }
 
 workerSelf.onmessage = async (event: MessageEvent<TranscribeRequest>) => {
-  const { id, channelData, sampleRate, length } = event.data;
+  const { id, channelData, sampleRate, length, modelId } = event.data;
+  const resolvedModelId = modelId ?? DEFAULT_MODEL_ID;
 
   const channels = channelData.length;
   const durationSeconds = length / sampleRate;
@@ -291,7 +302,7 @@ workerSelf.onmessage = async (event: MessageEvent<TranscribeRequest>) => {
   }
 
   try {
-    const transcriber = await loadPipeline();
+    const transcriber = await loadPipeline(resolvedModelId);
 
     const mono = downmixToMono(channelData, length);
     const resampled = resampleLinear(mono, sampleRate, MODEL_SAMPLE_RATE);

--- a/src/services/transcription.worker.ts
+++ b/src/services/transcription.worker.ts
@@ -1,0 +1,322 @@
+// Transcription worker — runs Whisper speech-to-text inference off the main
+// thread using @huggingface/transformers.
+//
+// Pipeline: mono 16 kHz audio → Whisper (automatic-speech-recognition)
+//   → segments with word-level timestamps
+//
+// Model files are cached by transformers.js in the Cache API.
+// Download progress is reported back to the main thread.
+
+import type {
+  TranscriptionSegment,
+  TranscriptionWord,
+} from '../types/transcription';
+
+// Whisper expects 16 kHz mono audio
+const MODEL_SAMPLE_RATE = 16_000;
+
+// Use whisper-base for the balance of quality and download size (~142 MB)
+const MODEL_ID = 'onnx-community/whisper-base';
+
+export type TranscribeRequest = {
+  id: number;
+  type: 'transcribe';
+  channelData: Float32Array[];
+  sampleRate: number;
+  length: number;
+};
+
+export type TranscribeResponse =
+  | {
+      id: number;
+      type: 'result';
+      language: string;
+      segments: TranscriptionSegment[];
+    }
+  | { id: number; type: 'error'; message: string };
+
+export type DownloadProgressMessage = {
+  type: 'download-progress';
+  progress: number;
+};
+
+export type WorkerLogMessage = {
+  type: 'log';
+  level: 'log' | 'warn' | 'error' | 'debug';
+  message: string;
+};
+
+export type WorkerMessage =
+  | TranscribeResponse
+  | DownloadProgressMessage
+  | WorkerLogMessage;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Pipeline = any;
+
+let pipeline: Pipeline | null = null;
+let pipelinePromise: Promise<Pipeline> | null = null;
+
+async function loadPipeline(): Promise<Pipeline> {
+  if (pipeline) return pipeline;
+  if (pipelinePromise) return pipelinePromise;
+
+  pipelinePromise = initializePipeline();
+  pipeline = await pipelinePromise;
+  pipelinePromise = null;
+  return pipeline;
+}
+
+// --- Download progress tracking ---
+
+// Tracks per-file download progress to compute an overall percentage.
+const fileProgress = new Map<string, number>();
+
+function reportProgress(file: string, loaded: number, total: number): void {
+  const percentage = Math.round((loaded / total) * 100);
+  fileProgress.set(file, percentage);
+
+  let sum = 0;
+  for (const p of fileProgress.values()) sum += p;
+  const overall = Math.round(sum / fileProgress.size);
+
+  workerSelf.postMessage({
+    type: 'download-progress',
+    progress: overall,
+  } satisfies DownloadProgressMessage);
+}
+
+async function initializePipeline(): Promise<Pipeline> {
+  workerLog('log', '[transcription:worker] Loading Whisper model...');
+
+  const { pipeline: createPipeline, env } =
+    await import('@huggingface/transformers');
+
+  // Allow local model loading and configure cache
+  env.allowLocalModels = false;
+
+  const transcriber = await createPipeline(
+    'automatic-speech-recognition',
+    MODEL_ID,
+    {
+      dtype: 'q8',
+      device: 'wasm',
+      progress_callback: (progress: {
+        status: string;
+        file?: string;
+        loaded?: number;
+        total?: number;
+      }) => {
+        if (
+          progress.status === 'progress' &&
+          progress.file &&
+          progress.loaded != null &&
+          progress.total != null
+        ) {
+          reportProgress(progress.file, progress.loaded, progress.total);
+        }
+      },
+    },
+  );
+
+  workerLog('log', '[transcription:worker] Whisper model loaded');
+  return transcriber;
+}
+
+// --- Transcription ---
+
+type WhisperChunk = {
+  text: string;
+  timestamp: [number, number | null];
+};
+
+async function transcribe(
+  transcriber: Pipeline,
+  audio: Float32Array,
+): Promise<{ language: string; segments: TranscriptionSegment[] }> {
+  const durationSeconds = audio.length / MODEL_SAMPLE_RATE;
+  workerLog(
+    'debug',
+    `[transcription:worker] Transcribing ${audio.length} samples (${durationSeconds.toFixed(2)}s)...`,
+  );
+
+  const result = await transcriber(audio, {
+    return_timestamps: 'word',
+    language: null, // auto-detect
+  });
+
+  workerLog(
+    'debug',
+    `[transcription:worker] Raw result: ${JSON.stringify(result).slice(0, 500)}`,
+  );
+
+  const language = result.language ?? 'en';
+  const chunks: WhisperChunk[] = result.chunks ?? [];
+
+  const segments = groupWordsIntoSegments(chunks);
+
+  workerLog(
+    'log',
+    `[transcription:worker] Transcription complete: ${segments.length} segments, ${chunks.length} words, language="${language}"`,
+  );
+
+  return { language, segments };
+}
+
+// --- Segment grouping ---
+
+// Groups word-level chunks into segments by detecting pauses between words.
+// A new segment starts when the gap between consecutive words exceeds the threshold.
+const SEGMENT_GAP_THRESHOLD_SECONDS = 1.0;
+
+function groupWordsIntoSegments(
+  chunks: WhisperChunk[],
+): TranscriptionSegment[] {
+  if (chunks.length === 0) return [];
+
+  const segments: TranscriptionSegment[] = [];
+  let currentWords: TranscriptionWord[] = [];
+
+  for (const chunk of chunks) {
+    const word: TranscriptionWord = {
+      text: chunk.text.trim(),
+      start: chunk.timestamp[0],
+      end: chunk.timestamp[1] ?? chunk.timestamp[0],
+    };
+
+    if (word.text === '') continue;
+
+    if (currentWords.length > 0) {
+      const lastWord = currentWords[currentWords.length - 1];
+      const gap = word.start - lastWord.end;
+
+      if (gap >= SEGMENT_GAP_THRESHOLD_SECONDS) {
+        segments.push(buildSegment(currentWords));
+        currentWords = [];
+      }
+    }
+
+    currentWords.push(word);
+  }
+
+  if (currentWords.length > 0) {
+    segments.push(buildSegment(currentWords));
+  }
+
+  return segments;
+}
+
+function buildSegment(words: TranscriptionWord[]): TranscriptionSegment {
+  return {
+    text: words.map((w) => w.text).join(' '),
+    start: words[0].start,
+    end: words[words.length - 1].end,
+    words,
+  };
+}
+
+// --- Audio preprocessing ---
+
+function downmixToMono(
+  channelData: Float32Array[],
+  length: number,
+): Float32Array {
+  const numberOfChannels = channelData.length;
+  const mono = new Float32Array(length);
+  for (let ch = 0; ch < numberOfChannels; ch++) {
+    for (let i = 0; i < length; i++) {
+      mono[i] += channelData[ch][i] / numberOfChannels;
+    }
+  }
+  return mono;
+}
+
+function resampleLinear(
+  input: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
+  if (fromRate === toRate) return input;
+
+  const ratio = fromRate / toRate;
+  const outputLength = Math.round(input.length / ratio);
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < outputLength; i++) {
+    const srcIndex = i * ratio;
+    const low = Math.floor(srcIndex);
+    const high = Math.min(low + 1, input.length - 1);
+    const frac = srcIndex - low;
+    output[i] = input[low] * (1 - frac) + input[high] * frac;
+  }
+
+  return output;
+}
+
+// --- Worker message handler ---
+
+type WorkerSelf = {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: unknown): void;
+};
+
+const workerSelf = self as unknown as WorkerSelf;
+
+function workerLog(level: WorkerLogMessage['level'], message: string): void {
+  workerSelf.postMessage({
+    type: 'log',
+    level,
+    message,
+  } satisfies WorkerLogMessage);
+}
+
+workerSelf.onmessage = async (event: MessageEvent<TranscribeRequest>) => {
+  const { id, channelData, sampleRate, length } = event.data;
+
+  const channels = channelData.length;
+  const durationSeconds = length / sampleRate;
+  workerLog(
+    'debug',
+    `[transcription:worker] Received audio: ${channels}ch, ${length} samples, ${sampleRate} Hz, ${durationSeconds.toFixed(2)}s`,
+  );
+
+  if (length === 0 || channelData[0]?.length === 0) {
+    const response: TranscribeResponse = {
+      id,
+      type: 'error',
+      message: 'Worker received empty audio data',
+    };
+    workerSelf.postMessage(response);
+    return;
+  }
+
+  try {
+    const transcriber = await loadPipeline();
+
+    const mono = downmixToMono(channelData, length);
+    const resampled = resampleLinear(mono, sampleRate, MODEL_SAMPLE_RATE);
+
+    workerLog(
+      'debug',
+      `[transcription:worker] Preprocessed audio: ${resampled.length} samples at ${MODEL_SAMPLE_RATE} Hz`,
+    );
+
+    const result = await transcribe(transcriber, resampled);
+
+    const response: TranscribeResponse = {
+      id,
+      type: 'result',
+      language: result.language,
+      segments: result.segments,
+    };
+    workerSelf.postMessage(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    workerLog(
+      'error',
+      `[transcription:worker] Transcription failed: ${message}`,
+    );
+    const response: TranscribeResponse = { id, type: 'error', message };
+    workerSelf.postMessage(response);
+  }
+};

--- a/src/types/transcription.ts
+++ b/src/types/transcription.ts
@@ -1,0 +1,20 @@
+import type { TrackId } from './track';
+
+export type TranscriptionWord = {
+  text: string;
+  start: number; // seconds
+  end: number; // seconds
+};
+
+export type TranscriptionSegment = {
+  text: string;
+  start: number; // seconds
+  end: number; // seconds
+  words: TranscriptionWord[];
+};
+
+export type Transcription = {
+  trackId: TrackId;
+  language: string;
+  segments: TranscriptionSegment[];
+};


### PR DESCRIPTION
## Summary
- Add `TranscriptionService` following the signal ownership pattern, with per-track transcription state, caching, and download progress tracking
- Create `transcription.worker.ts` that loads Whisper (whisper-base) via `@huggingface/transformers` ONNX/WASM backend, preprocesses audio (downmix + resample to 16kHz), and returns word-level and segment-level timestamps with auto language detection
- Add `useTranscriptionService` bridge hook for React components
- Wire `TranscriptionService` into `AudioService` as a sub-service
- Define `Transcription`, `TranscriptionSegment`, and `TranscriptionWord` types

## Test plan
- [x] 24 unit tests covering worker communication, progress reporting, error handling, caching, and cleanup — all passing
- [x] Full test suite (901 tests) passes
- [x] ESLint passes with no warnings

Part of #319 (step 4).

https://claude.ai/code/session_01NiEZ7KK7z6jxr4MbrvJC44