### PR TITLE
Replace @ant-design/icons with Lucide icons (#293)

### DIFF
--- a/e2e/classification.spec.ts
+++ b/e2e/classification.spec.ts
@@ -39,7 +39,7 @@ test.describe('Instrument classification on upload', () => {
     await expect(page.locator('.channel')).toBeVisible();
 
     // Wait for classification to finish (loading spinner should disappear).
-    // The channel__instrument div shows a LoadingOutlined icon while
+    // The channel__instrument div shows a Loader2 spinner while
     // classifying, then switches to an instrument icon or nothing.
     const instrumentDiv = page.locator('.channel__instrument');
 
@@ -48,7 +48,7 @@ test.describe('Instrument classification on upload', () => {
     // the main-thread fallback also fails, so classification enters 'error'
     // state and shows the unknown icon. Without the bug, models would load
     // and classification would show the correct instrument icon.
-    await expect(instrumentDiv.locator('.anticon-loading')).toBeHidden({
+    await expect(instrumentDiv.locator('.animate-spin')).toBeHidden({
       timeout: 15_000,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "mawimbi",
       "version": "0.1.0",
       "dependencies": {
-        "@ant-design/icons": "^5.3.7",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.3.7",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/src/components/dropzone/Dropzone.tsx
+++ b/src/components/dropzone/Dropzone.tsx
@@ -1,4 +1,4 @@
-import { UploadOutlined } from '@ant-design/icons';
+import { Upload } from 'lucide-react';
 import classNames from 'classnames';
 import React from 'react';
 import './Dropzone.css';
@@ -24,7 +24,7 @@ const Dropzone = (props: DropzoneProps) => {
       <input {...inputProps} />
       <div className="dropzone__content">
         <span>
-          <UploadOutlined className="upload-icon" />
+          <Upload className="upload-icon" />
         </span>
         {isDragAccept && (
           <h4 className="text-xl font-semibold">

--- a/src/components/fullscreen/Fullscreen.tsx
+++ b/src/components/fullscreen/Fullscreen.tsx
@@ -1,4 +1,4 @@
-import { FullscreenOutlined } from '@ant-design/icons';
+import { Maximize } from 'lucide-react';
 import { Button } from '../ui/button';
 import React, { useState } from 'react';
 import { FullScreen, FullScreenHandle } from 'react-full-screen';
@@ -45,7 +45,7 @@ const Fullscreen = (props: FullscreenProps) => {
         <div className="fullscreen__overlay">
           <div className="overlay-content" onClick={activateFullscreen}>
             <span>
-              <FullscreenOutlined className="fullscreen-icon" />
+              <Maximize className="fullscreen-icon" />
             </span>
             <h4 className="text-xl font-semibold">Tap to enter full screen</h4>
             <Button

--- a/src/components/project/ProjectPageHeader.tsx
+++ b/src/components/project/ProjectPageHeader.tsx
@@ -1,10 +1,4 @@
-import {
-  ArrowLeftOutlined,
-  EllipsisOutlined,
-  RedoOutlined,
-  UndoOutlined,
-  UploadOutlined,
-} from '@ant-design/icons';
+import { ArrowLeft, Ellipsis, Redo, Undo, Upload } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '../ui/button';
@@ -64,7 +58,7 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
           className="button back-button"
           tabIndex={-1}
         >
-          <ArrowLeftOutlined />
+          <ArrowLeft />
         </Button>
       </Link>
       <h4 className="project-page-header__title" onClick={openRenameModal}>
@@ -103,7 +97,7 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
           disabled={!props.canUndo}
           onClick={props.undo}
         >
-          <UndoOutlined />
+          <Undo />
         </Button>
         <Button
           variant="ghost"
@@ -113,7 +107,7 @@ const ProjectPageHeader = (props: ProjectPageHeaderProps) => {
           disabled={!props.canRedo}
           onClick={props.redo}
         >
-          <RedoOutlined />
+          <Redo />
         </Button>
         <UploadButton uploadFile={props.uploadFile} />
         <OverflowMenu
@@ -161,7 +155,7 @@ const UploadButton = (props: UploadButtonProps) => {
         className="button"
         onClick={() => fileInputRef.current?.click()}
       >
-        <UploadOutlined />
+        <Upload />
         <span className="hidden-lt768">Upload files</span>
       </Button>
     </>
@@ -188,7 +182,7 @@ const OverflowMenu = (props: OverflowMenuProps) => {
           className="button overflow-button"
           aria-label="More"
         >
-          <EllipsisOutlined />
+          <Ellipsis />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -1,10 +1,10 @@
 import {
-  AudioMutedOutlined,
-  CustomerServiceOutlined,
-  LoadingOutlined,
-  MenuOutlined,
-  SoundOutlined,
-} from '@ant-design/icons';
+  GripVertical,
+  Headphones,
+  Loader2,
+  MicOff,
+  Volume2,
+} from 'lucide-react';
 import { Slider } from '../ui/slider';
 import { Button } from '../ui/button';
 import classNames from 'classnames';
@@ -76,7 +76,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
               {downloadProgress}%
             </span>
           ) : (
-            <LoadingOutlined />
+            <Loader2 className="animate-spin" />
           )
         ) : (
           instrument !== undefined && getInstrumentIcon(instrument)
@@ -114,7 +114,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
           title="Move"
           disabled
         >
-          <MenuOutlined />
+          <GripVertical />
         </Button>
       </div>
     </div>
@@ -122,9 +122,9 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
 };
 
 function getChannelStateIcon(mute: boolean, solo: boolean) {
-  if (solo) return <CustomerServiceOutlined />;
-  if (mute) return <AudioMutedOutlined />;
-  return <SoundOutlined />;
+  if (solo) return <Headphones />;
+  if (mute) return <MicOff />;
+  return <Volume2 />;
 }
 
 function getChannelStateTitle(mute: boolean, solo: boolean) {

--- a/src/components/workstation/Toolbar.tsx
+++ b/src/components/workstation/Toolbar.tsx
@@ -1,10 +1,4 @@
-import Icon, {
-  AudioFilled,
-  AudioOutlined,
-  CaretRightOutlined,
-  PauseOutlined,
-  StepBackwardOutlined,
-} from '@ant-design/icons';
+import { Mic, Pause, Play, SkipBack } from 'lucide-react';
 import { Button } from '../ui/button';
 import classNames from 'classnames';
 import ControlSvg from '../../icons/control.svg?react';
@@ -25,8 +19,14 @@ const Toolbar = (props: ToolbarProps) => {
   const { isMixerOpen, isEmpty, onToggleMixer, onToggleRecording } = props;
   const isRecordActive = recordingState !== 'idle';
 
-  const mixerIconClass = classNames({ 'show-mixer': isMixerOpen });
-  const mixerIcon = <Icon component={ControlSvg} className={mixerIconClass} />;
+  const mixerIconClass = classNames('custom-icon', {
+    'show-mixer': isMixerOpen,
+  });
+  const mixerIcon = (
+    <span className={mixerIconClass}>
+      <ControlSvg />
+    </span>
+  );
 
   const mixerButton = (
     <Button
@@ -50,7 +50,7 @@ const Toolbar = (props: ToolbarProps) => {
       onClick={rewind}
       disabled={isEmpty || isTransportLocked || isStopped}
     >
-      <StepBackwardOutlined />
+      <SkipBack />
     </Button>
   );
 
@@ -63,7 +63,7 @@ const Toolbar = (props: ToolbarProps) => {
       onClick={togglePlayback}
       disabled={isEmpty || isTransportLocked}
     >
-      {isPlaying ? <PauseOutlined /> : <CaretRightOutlined />}
+      {isPlaying ? <Pause /> : <Play />}
     </Button>
   );
 
@@ -75,7 +75,7 @@ const Toolbar = (props: ToolbarProps) => {
       title="Record"
       onClick={onToggleRecording}
     >
-      {isRecordActive ? <AudioFilled /> : <AudioOutlined />}
+      {isRecordActive ? <Mic className="text-red-500" /> : <Mic />}
     </Button>
   );
 

--- a/src/components/workstation/ZoomControls.tsx
+++ b/src/components/workstation/ZoomControls.tsx
@@ -1,4 +1,4 @@
-import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
+import { Minus, Plus } from 'lucide-react';
 import { Button } from '../ui/button';
 import { type CSSProperties } from 'react';
 import { useRecordingService } from '../../hooks/useRecordingService';
@@ -23,7 +23,7 @@ const ZoomControls = ({ style }: ZoomControlsProps) => {
         onClick={zoomIn}
         disabled={isMaxZoom || isRecording}
       >
-        <PlusOutlined />
+        <Plus />
       </Button>
       <Button
         variant="ghost"
@@ -33,7 +33,7 @@ const ZoomControls = ({ style }: ZoomControlsProps) => {
         onClick={zoomOut}
         disabled={isMinZoom || isRecording}
       >
-        <MinusOutlined />
+        <Minus />
       </Button>
     </div>
   );

--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -214,7 +214,7 @@ it('shows no icon in instrument div when classification is idle and no instrumen
   const { container } = render(<Channel {...defaultProps} />);
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).not.toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).not.toBeInTheDocument();
 });
 
 it('shows loading indicator in instrument div when classification is in progress', () => {
@@ -223,7 +223,7 @@ it('shows loading indicator in instrument div when classification is in progress
   const { container } = render(<Channel {...defaultProps} />);
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).toBeInTheDocument();
 });
 
 it('shows instrument icon in instrument div when classification is done', () => {
@@ -233,7 +233,7 @@ it('shows instrument icon in instrument div when classification is done', () => 
   const { container } = render(<Channel {...defaultProps} />);
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).toBeInTheDocument();
 });
 
 it('shows instrument icon from track prop when service has no classification', () => {
@@ -244,7 +244,7 @@ it('shows instrument icon from track prop when service has no classification', (
   const { container } = render(<Channel {...{ ...defaultProps, track }} />);
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).toBeInTheDocument();
 });
 
 it('prefers service classification over track instrument prop', () => {
@@ -255,7 +255,7 @@ it('prefers service classification over track instrument prop', () => {
   const { container } = render(<Channel {...{ ...defaultProps, track }} />);
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).toBeInTheDocument();
 });
 
 it('shows download progress percentage when model is downloading', () => {
@@ -279,7 +279,7 @@ it('shows loading spinner when classifying without download', () => {
   expect(progressEl).not.toBeInTheDocument();
 
   const instrumentDiv = container.querySelector('.channel__instrument');
-  expect(instrumentDiv?.querySelector('[role="img"]')).toBeInTheDocument();
+  expect(instrumentDiv?.querySelector('svg')).toBeInTheDocument();
 });
 
 it('sets title attribute with download progress', () => {

--- a/src/components/workstation/__tests__/Toolbar.test.tsx
+++ b/src/components/workstation/__tests__/Toolbar.test.tsx
@@ -53,7 +53,7 @@ it('renders play icon when stopped', () => {
   const { getByTitle } = render(<Toolbar {...defaultProps} />);
 
   const playButton = getByTitle('Play');
-  const playIcon = playButton.querySelector('[aria-label="caret-right"]');
+  const playIcon = playButton.querySelector('svg');
 
   expect(playButton).toBeInTheDocument();
   expect(playIcon).toBeInTheDocument();
@@ -65,7 +65,7 @@ it('renders pause icon when playing', () => {
   const { getByTitle } = render(<Toolbar {...defaultProps} />);
 
   const pauseButton = getByTitle('Pause');
-  const pauseIcon = pauseButton.querySelector('[aria-label="pause"]');
+  const pauseIcon = pauseButton.querySelector('svg');
 
   expect(pauseButton).toBeInTheDocument();
   expect(pauseIcon).toBeInTheDocument();
@@ -75,7 +75,7 @@ it('renders microphone icon', () => {
   const { getByTitle } = render(<Toolbar {...defaultProps} />);
 
   const recordButton = getByTitle('Record');
-  const recordIcon = recordButton.querySelector('[aria-label="audio"]');
+  const recordIcon = recordButton.querySelector('svg');
 
   expect(recordButton).toBeInTheDocument();
   expect(recordIcon).toBeInTheDocument();

--- a/src/components/workstation/__tests__/instrumentIcons.test.tsx
+++ b/src/components/workstation/__tests__/instrumentIcons.test.tsx
@@ -22,7 +22,7 @@ it.each(ALL_LABELS)('returns an icon for "%s"', (label) => {
 
   const { container } = render(<>{icon}</>);
 
-  expect(container.querySelector('.anticon')).toBeInTheDocument();
+  expect(container.querySelector('.custom-icon')).toBeInTheDocument();
 });
 
 it('returns fallback icon for undefined label', () => {
@@ -30,7 +30,7 @@ it('returns fallback icon for undefined label', () => {
 
   const { container } = render(<>{icon}</>);
 
-  expect(container.querySelector('.anticon')).toBeInTheDocument();
+  expect(container.querySelector('.custom-icon')).toBeInTheDocument();
 });
 
 it('returns fallback icon for unknown label', () => {
@@ -38,7 +38,7 @@ it('returns fallback icon for unknown label', () => {
 
   const { container } = render(<>{icon}</>);
 
-  expect(container.querySelector('.anticon')).toBeInTheDocument();
+  expect(container.querySelector('.custom-icon')).toBeInTheDocument();
 });
 
 it('returns different icons for different labels', () => {

--- a/src/components/workstation/instrumentIcons.tsx
+++ b/src/components/workstation/instrumentIcons.tsx
@@ -1,4 +1,3 @@
-import Icon from '@ant-design/icons';
 import type { InstrumentLabel } from '../../services/instrumentLabels';
 
 import BassSvg from '../../icons/bass.svg?react';
@@ -33,5 +32,9 @@ export function getInstrumentIcon(label: string | undefined): React.ReactNode {
       ? INSTRUMENT_ICONS[label as InstrumentLabel]
       : INSTRUMENT_ICONS.unknown;
 
-  return <Icon component={SvgComponent} />;
+  return (
+    <span className="custom-icon">
+      <SvgComponent />
+    </span>
+  );
 }

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -1,4 +1,4 @@
-import { StepBackwardOutlined } from '@ant-design/icons';
+import { SkipBack } from 'lucide-react';
 import { Button } from '../../ui/button';
 import classNames from 'classnames';
 import { PropsWithChildren } from 'react';
@@ -78,7 +78,7 @@ const Scrubber = (props: ScrubberProps) => {
           title="Rewind"
           onClick={handleStopAndRewind}
         >
-          <StepBackwardOutlined />
+          <SkipBack />
         </Button>
       </div>
       <ZoomControls style={rewindButtonStyle} />

--- a/src/index.css
+++ b/src/index.css
@@ -187,6 +187,19 @@ html {
   border: none;
 }
 
+/* Custom SVG icon wrapper — replaces @ant-design/icons Icon component */
+.custom-icon {
+  display: inline-flex;
+  align-items: center;
+  line-height: 0;
+}
+
+.custom-icon > svg {
+  width: 1em;
+  height: 1em;
+  fill: currentColor;
+}
+
 @media (max-width: 768px) {
   .hidden-lt768 {
     display: none !important;


### PR DESCRIPTION
## Summary

- Replaced all 18 `@ant-design/icons` imports with `lucide-react` equivalents across 8 source files
- Migrated custom SVG instrument icons from Ant Design's `Icon` wrapper to a lightweight `.custom-icon` CSS wrapper
- Removed `@ant-design/icons` dependency from `package.json`
- Updated unit tests to use `svg` and `.custom-icon` selectors instead of `[role="img"]` and `.anticon`
- Updated e2e classification test to use `.animate-spin` selector instead of `.anticon-loading`

### Icon mapping

| Ant Design | Lucide | File(s) |
|---|---|---|
| `CaretRightOutlined` | `Play` | Toolbar |
| `PauseOutlined` | `Pause` | Toolbar |
| `StepBackwardOutlined` | `SkipBack` | Toolbar, Scrubber |
| `AudioFilled` / `AudioOutlined` | `Mic` | Toolbar |
| `AudioMutedOutlined` | `MicOff` | Channel |
| `CustomerServiceOutlined` | `Headphones` | Channel |
| `SoundOutlined` | `Volume2` | Channel |
| `LoadingOutlined` | `Loader2` | Channel |
| `MenuOutlined` | `GripVertical` | Channel |
| `ArrowLeftOutlined` | `ArrowLeft` | ProjectPageHeader |
| `UndoOutlined` | `Undo` | ProjectPageHeader |
| `RedoOutlined` | `Redo` | ProjectPageHeader |
| `UploadOutlined` | `Upload` | ProjectPageHeader, Dropzone |
| `EllipsisOutlined` | `Ellipsis` | ProjectPageHeader |
| `FullscreenOutlined` | `Maximize` | Fullscreen |
| `PlusOutlined` | `Plus` | ZoomControls |
| `MinusOutlined` | `Minus` | ZoomControls |
| `Icon` (base) | `.custom-icon` wrapper | Toolbar, instrumentIcons |

## Test plan

- [x] All 909 unit tests pass
- [x] All 86 e2e tests pass
- [x] ESLint passes
- [ ] Verify icon appearance matches expected design in browser

https://claude.ai/code/session_01RMFXH2hPM7MMSuiEyM8zUg