### PR TITLE
Add settings page with theme toggle

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,12 +1,14 @@
 import { Route, Routes, useLocation } from 'react-router-dom';
 import HomePage from './home/HomePage';
 import ProjectPage from './project/ProjectPage';
+import SettingsPage from './settings/SettingsPage';
 
 const App = () => {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/project/:id" element={<ProjectPage />} />
+      <Route path="/settings" element={<SettingsPage />} />
       <Route path="*" element={<NoMatch />} />
     </Routes>
   );

--- a/src/components/home/HomePage.css
+++ b/src/components/home/HomePage.css
@@ -18,6 +18,12 @@
   align-items: center;
 }
 
+.home__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .home__title {
   font-size: 28px;
   font-weight: 700;

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -11,6 +11,7 @@ import { PageContent, PageLayout } from '../layout/PageLayout';
 import EmptyProjectList from './EmptyProjectList';
 import ProjectList from './ProjectList';
 import StorageUsage from './StorageUsage';
+import SettingsButton from './SettingsButton';
 import './HomePage.css';
 
 export type StorageInfo = {
@@ -84,9 +85,12 @@ const HomePage = () => {
           <div className="home__header">
             <div className="home__header-row">
               <h1 className="home__title">Mawimbi</h1>
-              <Button variant="secondary" size="sm" onClick={handleCreate}>
-                New Project
-              </Button>
+              <div className="home__header-actions">
+                <Button variant="secondary" size="sm" onClick={handleCreate}>
+                  New Project
+                </Button>
+                <SettingsButton />
+              </div>
             </div>
           </div>
           <div className="home__body">

--- a/src/components/home/SettingsButton.tsx
+++ b/src/components/home/SettingsButton.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../ui/button';
+
+const SettingsButton = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={() => navigate('/settings')}
+      aria-label="Settings"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    </Button>
+  );
+};
+
+export default SettingsButton;

--- a/src/components/settings/SettingsPage.css
+++ b/src/components/settings/SettingsPage.css
@@ -1,0 +1,88 @@
+.settings {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings__header {
+  border-bottom: 1px solid var(--border);
+  padding: 48px 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings__header-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.settings__title {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--foreground);
+  margin: 0;
+}
+
+.settings__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.settings__section {
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+.settings__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings__item-label {
+  font-weight: 500;
+  font-size: 15px;
+  color: var(--foreground);
+}
+
+.settings__theme-options {
+  display: flex;
+  gap: 0;
+  background-color: var(--secondary);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.settings__theme-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.settings__theme-option:hover {
+  color: var(--foreground);
+}
+
+.settings__theme-option--active {
+  background-color: var(--accent);
+  color: var(--foreground);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,135 @@
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../../hooks/useTheme';
+import { Button } from '../ui/button';
+import { PageContent, PageLayout } from '../layout/PageLayout';
+import './SettingsPage.css';
+
+type Theme = 'system' | 'light' | 'dark';
+
+const THEME_OPTIONS: { value: Theme; label: string; icon: React.ReactNode }[] =
+  [
+    {
+      value: 'system',
+      label: 'System',
+      icon: (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="2" y="3" width="20" height="14" rx="2" />
+          <line x1="8" y1="21" x2="16" y2="21" />
+          <line x1="12" y1="17" x2="12" y2="21" />
+        </svg>
+      ),
+    },
+    {
+      value: 'light',
+      label: 'Light',
+      icon: (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.93 4.93 1.41 1.41" />
+          <path d="m17.66 17.66 1.41 1.41" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.34 17.66-1.41 1.41" />
+          <path d="m19.07 4.93-1.41 1.41" />
+        </svg>
+      ),
+    },
+    {
+      value: 'dark',
+      label: 'Dark',
+      icon: (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </svg>
+      ),
+    },
+  ];
+
+const SettingsPage = () => {
+  const navigate = useNavigate();
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <PageLayout>
+      <PageContent>
+        <div className="settings">
+          <div className="settings__header">
+            <div className="settings__header-row">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => navigate('/')}
+                aria-label="Back"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m15 18-6-6 6-6" />
+                </svg>
+              </Button>
+              <h1 className="settings__title">Settings</h1>
+            </div>
+          </div>
+          <div className="settings__body">
+            <div className="settings__section">
+              <div className="settings__item">
+                <span className="settings__item-label">Application theme</span>
+                <div className="settings__theme-options">
+                  {THEME_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      className={`settings__theme-option${theme === option.value ? ' settings__theme-option--active' : ''}`}
+                      onClick={() => setTheme(option.value)}
+                      aria-label={option.label}
+                      title={option.label}
+                    >
+                      {option.icon}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </PageContent>
+    </PageLayout>
+  );
+};
+
+export default SettingsPage;

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const STORAGE_KEY = 'mawimbi-theme';
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getStoredTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark' || stored === 'system') {
+    return stored;
+  }
+  return 'dark';
+}
+
+function applyTheme(theme: Theme) {
+  const isDark =
+    theme === 'dark' ||
+    (theme === 'system' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+  if (isDark) {
+    document.documentElement.classList.add('dark');
+  } else {
+    document.documentElement.classList.remove('dark');
+  }
+}
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setThemeState] = useState<Theme>(getStoredTheme);
+
+  const setTheme = useCallback((newTheme: Theme) => {
+    localStorage.setItem(STORAGE_KEY, newTheme);
+    setThemeState(newTheme);
+    applyTheme(newTheme);
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== 'system') return;
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => applyTheme('system');
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,11 @@ html {
 @media (hover: hover) and (pointer: fine) {
   /* Style scrollbar on desktop devices only. */
   html {
+    --scrollbar-track-color: #f5f5f5;
+    --scrollbar-thumb-color: rgba(0, 0, 0, 0.35);
+  }
+
+  .dark {
     --scrollbar-track-color: #141414;
     --scrollbar-thumb-color: rgba(255, 255, 255, 0.65);
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,24 +4,24 @@ import { BrowserSupportProvider } from './browserSupport';
 import App from './components/App';
 import AudioStartup from './components/AudioStartup';
 import { Toaster } from './components/ui/sonner';
+import { ThemeProvider } from './hooks/useTheme';
 import LogService from './services/LogService';
 import './index.css';
 
 // Intercept console methods before any logging occurs
 LogService.install();
 
-// Enable dark theme CSS variables for shadcn/ui components
-document.documentElement.classList.add('dark');
-
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <>
     <AudioStartup />
-    <BrowserSupportProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </BrowserSupportProvider>
-    <Toaster />
+    <ThemeProvider>
+      <BrowserSupportProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </BrowserSupportProvider>
+      <Toaster />
+    </ThemeProvider>
   </>,
 );


### PR DESCRIPTION
## Summary
- Add a **Settings page** (`/settings`) with a light/dark/system theme toggle, similar to the reference design
- Create a `ThemeProvider` context (`useTheme` hook) that persists theme preference to `localStorage` and applies the appropriate CSS class to `<html>`
- Add a gear icon button in the home page header that navigates to the settings page
- Support system theme preference via `prefers-color-scheme` media query listener
- Make scrollbar colors theme-aware (previously hardcoded to dark)

## Test plan
- [x] All 909 unit tests pass
- [x] All 10 visual regression tests pass
- [x] 86/87 e2e tests pass (1 pre-existing flaky audio timing test)
- [ ] Manually verify theme switching between light, dark, and system modes
- [ ] Verify theme persists across page reloads
- [ ] Verify system mode responds to OS preference changes

https://claude.ai/code/session_016BYtj3iw835daKfLGfvC8c