### PR TITLE
Reorder channel toggle: Solo before Mute

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -227,18 +227,18 @@ test.describe('Mixer', () => {
 
     const track = page.locator('.timeline__track');
 
-    // Click once: on → mute
+    // Click once: on → solo
     await page.getByTitle('On').click();
-    await expect(track).toHaveClass(/timeline__track--muted/);
-    await expect(page.getByTitle('Muted')).toBeVisible();
-
-    // Click again: mute → solo
-    await page.getByTitle('Muted').click();
     await expect(track).not.toHaveClass(/timeline__track--muted/);
     await expect(page.getByTitle('Solo')).toBeVisible();
 
-    // Click again: solo → on
+    // Click again: solo → mute
     await page.getByTitle('Solo').click();
+    await expect(track).toHaveClass(/timeline__track--muted/);
+    await expect(page.getByTitle('Muted')).toBeVisible();
+
+    // Click again: mute → on
+    await page.getByTitle('Muted').click();
     await expect(page.getByTitle('On')).toBeVisible();
   });
 
@@ -249,10 +249,9 @@ test.describe('Mixer', () => {
 
     await page.getByTitle('Show mixer').click();
 
-    // Cycle the first channel button to solo (on → mute → solo)
+    // Cycle the first channel button to solo (on → solo)
     const channelButtons = page.getByTitle('On');
-    await channelButtons.first().click(); // on → mute
-    await page.getByTitle('Muted').click(); // mute → solo
+    await channelButtons.first().click(); // on → solo
 
     // The non-solo track should be muted
     const tracks = page.locator('.timeline__track');
@@ -477,7 +476,8 @@ test.describe('Visual regression - audio states', () => {
     await expect(page.locator('.timeline__track')).toBeVisible();
 
     await page.getByTitle('Show mixer').click();
-    await page.getByTitle('On').click(); // on → mute
+    await page.getByTitle('On').click(); // on → solo
+    await page.getByTitle('Solo').click(); // solo → mute
     await expect(
       page.locator('.timeline__track--muted'),
     ).toBeVisible();
@@ -494,10 +494,9 @@ test.describe('Visual regression - audio states', () => {
     await expect(page.locator('.timeline__track')).toHaveCount(2);
 
     await page.getByTitle('Show mixer').click();
-    // Cycle first channel to solo (on → mute → solo)
+    // Cycle first channel to solo (on → solo)
     const channelButtons = page.getByTitle('On');
-    await channelButtons.first().click(); // on → mute
-    await page.getByTitle('Muted').click(); // mute → solo
+    await channelButtons.first().click(); // on → solo
     await expect(page.locator('.timeline__track--muted')).toHaveCount(1);
 
     await expect(page.locator('.workstation')).toHaveScreenshot(

--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -2,7 +2,7 @@ import {
   GripVertical,
   Headphones,
   Loader2,
-  MicOff,
+  Volume,
   Volume2,
 } from 'lucide-react';
 import { Slider } from '../ui/slider';
@@ -123,7 +123,7 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
 
 function getChannelStateIcon(mute: boolean, solo: boolean) {
   if (solo) return <Headphones />;
-  if (mute) return <MicOff />;
+  if (mute) return <Volume />;
   return <Volume2 />;
 }
 

--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -56,35 +56,35 @@ it('renders move button', () => {
   expect(getByTitle('Move')).toBeInTheDocument();
 });
 
-it('cycles from on to mute on first click', () => {
+it('cycles from on to solo on first click', () => {
   const { getByTitle } = render(<Channel {...defaultProps} />);
 
   fireEvent.click(getByTitle('On'));
 
   const signals = trackService.getSignals('track-1')!;
-  expect(signals.mute.value).toBe(true);
-  expect(signals.solo.value).toBe(false);
-});
-
-it('cycles from mute to solo on second click', () => {
-  const signals = trackService.getSignals('track-1')!;
-  signals.mute.value = true;
-
-  const { getByTitle } = render(<Channel {...defaultProps} />);
-
-  fireEvent.click(getByTitle('Muted'));
-
   expect(signals.mute.value).toBe(false);
   expect(signals.solo.value).toBe(true);
 });
 
-it('cycles from solo to on on third click', () => {
+it('cycles from solo to mute on second click', () => {
   const signals = trackService.getSignals('track-1')!;
   signals.solo.value = true;
 
   const { getByTitle } = render(<Channel {...defaultProps} />);
 
   fireEvent.click(getByTitle('Solo'));
+
+  expect(signals.solo.value).toBe(false);
+  expect(signals.mute.value).toBe(true);
+});
+
+it('cycles from mute to on on third click', () => {
+  const signals = trackService.getSignals('track-1')!;
+  signals.mute.value = true;
+
+  const { getByTitle } = render(<Channel {...defaultProps} />);
+
+  fireEvent.click(getByTitle('Muted'));
 
   expect(signals.mute.value).toBe(false);
   expect(signals.solo.value).toBe(false);

--- a/src/components/workstation/useChannelControls.ts
+++ b/src/components/workstation/useChannelControls.ts
@@ -28,16 +28,16 @@ export function useChannelControls(trackId: TrackId) {
   const cycleState = () => {
     if (!trackSignals) return;
 
-    if (solo) {
-      // solo → on
-      trackSignals.solo.value = false;
-    } else if (mute) {
-      // mute → solo
+    if (mute) {
+      // mute → on
       trackSignals.mute.value = false;
-      trackSignals.solo.value = true;
-    } else {
-      // on → mute
+    } else if (solo) {
+      // solo → mute
+      trackSignals.solo.value = false;
       trackSignals.mute.value = true;
+    } else {
+      // on → solo
+      trackSignals.solo.value = true;
     }
   };
 


### PR DESCRIPTION
## Summary
- Changed the mute/solo/on toggle cycle order from **On → Mute → Solo → On** to **On → Solo → Mute → On**, placing Solo before Mute
- Replaced the `MicOff` icon with `Volume` (speaker without sound waves) for the muted state, giving a clearer visual cue
- Updated unit tests and e2e tests to match the new cycle order

## Test plan
- [x] Unit tests pass (26/26 in Channel.test.tsx)
- [x] E2e tests for cycle order, solo muting, and visual regressions pass
- [ ] Manual: open mixer, click the toggle button and verify it cycles On → Solo → Mute → On
- [ ] Manual: verify the muted state shows a speaker icon without sound waves

https://claude.ai/code/session_01QbHComMN4kxgtGzCy6AcxE