### PR TITLE
Add transcriptions to IndexedDB

### DIFF
--- a/src/services/ProjectStorageService.ts
+++ b/src/services/ProjectStorageService.ts
@@ -1,9 +1,10 @@
 import { type DBSchema, type IDBPDatabase, openDB } from 'idb';
 import { type MelodyNote } from './MelodyExtractor';
 import { type Track } from '../types/track';
+import { type TranscriptionSegment } from '../types/transcription';
 
 const DB_NAME = 'mawimbi-db';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 
 export type StoredProject = {
   id: string;
@@ -30,6 +31,12 @@ export type MelodyStoreData = {
   timeResolution: number;
 };
 
+export type TranscriptionStoreData = {
+  trackId: string;
+  language: string;
+  segments: TranscriptionSegment[];
+};
+
 interface MawimbiDB extends DBSchema {
   projects: {
     key: string;
@@ -47,6 +54,10 @@ interface MawimbiDB extends DBSchema {
   melodies: {
     key: string;
     value: MelodyStoreData;
+  };
+  transcriptions: {
+    key: string;
+    value: TranscriptionStoreData;
   };
 }
 
@@ -67,6 +78,9 @@ function getDB(): Promise<IDBPDatabase<MawimbiDB>> {
         }
         if (oldVersion < 2) {
           db.createObjectStore('melodies', { keyPath: 'trackId' });
+        }
+        if (oldVersion < 3) {
+          db.createObjectStore('transcriptions', { keyPath: 'trackId' });
         }
       },
     });
@@ -97,7 +111,7 @@ export async function deleteProject(id: string): Promise<void> {
   if (project) {
     const trackIds = project.tracks.map((t) => t.trackId);
     const tx = db.transaction(
-      ['projects', 'audioData', 'spectrograms', 'melodies'],
+      ['projects', 'audioData', 'spectrograms', 'melodies', 'transcriptions'],
       'readwrite',
     );
     tx.objectStore('projects').delete(id);
@@ -105,6 +119,7 @@ export async function deleteProject(id: string): Promise<void> {
       tx.objectStore('audioData').delete(trackId);
       tx.objectStore('spectrograms').delete(trackId);
       tx.objectStore('melodies').delete(trackId);
+      tx.objectStore('transcriptions').delete(trackId);
     }
     await tx.done;
   }
@@ -167,6 +182,26 @@ export async function loadMelodyData(
 export async function deleteMelodyData(trackId: string): Promise<void> {
   const db = await getDB();
   await db.delete('melodies', trackId);
+}
+
+export async function saveTranscription(
+  data: TranscriptionStoreData,
+): Promise<void> {
+  const db = await getDB();
+  await db.put('transcriptions', data);
+}
+
+export async function loadTranscription(
+  trackId: string,
+): Promise<TranscriptionStoreData | null> {
+  const db = await getDB();
+  const entry = await db.get('transcriptions', trackId);
+  return entry ?? null;
+}
+
+export async function deleteTranscription(trackId: string): Promise<void> {
+  const db = await getDB();
+  await db.delete('transcriptions', trackId);
 }
 
 export async function getStorageEstimate(): Promise<StorageEstimate> {

--- a/src/services/__tests__/ProjectStorageService.test.ts
+++ b/src/services/__tests__/ProjectStorageService.test.ts
@@ -14,11 +14,15 @@ import {
   saveMelodyData,
   loadMelodyData,
   deleteMelodyData,
+  saveTranscription,
+  loadTranscription,
+  deleteTranscription,
   getStorageEstimate,
   resetDB,
   type StoredProject,
   type SpectrogramStoreData,
   type MelodyStoreData,
+  type TranscriptionStoreData,
 } from '../ProjectStorageService';
 
 function createProject(overrides: Partial<StoredProject> = {}): StoredProject {
@@ -53,6 +57,24 @@ function createMelodyData(trackId: string): MelodyStoreData {
       { startTime: 0.6, endTime: 1.0, midiNote: 64, confidence: 0.85 },
     ],
     timeResolution: 0.0029,
+  };
+}
+
+function createTranscriptionData(trackId: string): TranscriptionStoreData {
+  return {
+    trackId,
+    language: 'en',
+    segments: [
+      {
+        text: 'Hello world',
+        start: 0.0,
+        end: 1.5,
+        words: [
+          { text: 'Hello', start: 0.0, end: 0.7 },
+          { text: 'world', start: 0.8, end: 1.5 },
+        ],
+      },
+    ],
   };
 }
 
@@ -137,7 +159,7 @@ describe('ProjectStorageService', () => {
   });
 
   describe('deleteProject cleans up related data', () => {
-    it('deletes associated audio, spectrogram, and melody data', async () => {
+    it('deletes associated audio, spectrogram, melody, and transcription data', async () => {
       const project = createProject({
         tracks: [
           {
@@ -161,6 +183,8 @@ describe('ProjectStorageService', () => {
       await saveSpectrogramData(createSpectrogramData('track-2'));
       await saveMelodyData(createMelodyData('track-1'));
       await saveMelodyData(createMelodyData('track-2'));
+      await saveTranscription(createTranscriptionData('track-1'));
+      await saveTranscription(createTranscriptionData('track-2'));
 
       await deleteProject('project-1');
 
@@ -170,6 +194,8 @@ describe('ProjectStorageService', () => {
       expect(await loadSpectrogramData('track-2')).toBeNull();
       expect(await loadMelodyData('track-1')).toBeNull();
       expect(await loadMelodyData('track-2')).toBeNull();
+      expect(await loadTranscription('track-1')).toBeNull();
+      expect(await loadTranscription('track-2')).toBeNull();
     });
   });
 
@@ -297,6 +323,54 @@ describe('ProjectStorageService', () => {
 
     it('deleting non-existent melody data does not throw', async () => {
       await expect(deleteMelodyData('does-not-exist')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('transcription data CRUD', () => {
+    it('saves and loads transcription data', async () => {
+      const data = createTranscriptionData('track-1');
+      await saveTranscription(data);
+
+      const loaded = await loadTranscription('track-1');
+      expect(loaded?.trackId).toBe('track-1');
+      expect(loaded?.language).toBe('en');
+      expect(loaded?.segments).toHaveLength(1);
+      expect(loaded?.segments[0].text).toBe('Hello world');
+      expect(loaded?.segments[0].words).toHaveLength(2);
+      expect(loaded?.segments[0].words[0]).toEqual({
+        text: 'Hello',
+        start: 0.0,
+        end: 0.7,
+      });
+    });
+
+    it('returns null for non-existent transcription data', async () => {
+      const loaded = await loadTranscription('does-not-exist');
+      expect(loaded).toBeNull();
+    });
+
+    it('overwrites existing transcription data', async () => {
+      await saveTranscription(createTranscriptionData('track-1'));
+      const updated = createTranscriptionData('track-1');
+      updated.language = 'fr';
+      await saveTranscription(updated);
+
+      const loaded = await loadTranscription('track-1');
+      expect(loaded?.language).toBe('fr');
+    });
+
+    it('deletes transcription data', async () => {
+      await saveTranscription(createTranscriptionData('track-1'));
+      await deleteTranscription('track-1');
+
+      const loaded = await loadTranscription('track-1');
+      expect(loaded).toBeNull();
+    });
+
+    it('deleting non-existent transcription data does not throw', async () => {
+      await expect(
+        deleteTranscription('does-not-exist'),
+      ).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Bump `DB_VERSION` from 2 to 3 and add `transcriptions` object store (keyed by `trackId`) in the IndexedDB upgrade handler
- Add `TranscriptionStoreData` type to the DB schema, reusing `TranscriptionSegment` from the existing `types/transcription.ts`
- Implement `saveTranscription()`, `loadTranscription()`, and `deleteTranscription()` CRUD functions following the existing melody/spectrogram pattern
- Add `transcriptions` to the cascade delete in `deleteProject()` so transcription data is cleaned up when a project is removed
- Add comprehensive tests for the new CRUD functions and update the cascade delete test

## Test plan
- [x] All 31 `ProjectStorageService` tests pass (including 5 new transcription CRUD tests and the updated cascade delete test)
- [x] Full test suite passes (923 tests across 66 files)
- [x] ESLint passes with no errors

Closes #324

https://claude.ai/code/session_01YXbtGnPYN3NR7KPptsLhHh