### PR TITLE
Wire transcription into LyricsBottomSheet (#325)

### DIFF
--- a/src/components/workstation/LyricsBottomSheet.css
+++ b/src/components/workstation/LyricsBottomSheet.css
@@ -12,10 +12,13 @@
 }
 
 .lyrics-bottom-sheet__item {
+  padding: 8px 16px;
+}
+
+.lyrics-bottom-sheet__header {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 16px;
 }
 
 .lyrics-bottom-sheet__color {
@@ -32,4 +35,56 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.lyrics-bottom-sheet__spinner {
+  animation: lyrics-spin 1s linear infinite;
+  color: rgba(255, 255, 255, 0.65);
+  flex-shrink: 0;
+}
+
+@keyframes lyrics-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.lyrics-bottom-sheet__status {
+  padding: 8px 0 4px 24px;
+}
+
+.lyrics-bottom-sheet__status-text {
+  display: block;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 6px;
+}
+
+.lyrics-bottom-sheet__error {
+  padding: 4px 0 0 24px;
+  font-size: 12px;
+  color: #ff4d4f;
+  margin: 0;
+}
+
+.lyrics-bottom-sheet__no-speech {
+  padding: 4px 0 0 24px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.45);
+  font-style: italic;
+  margin: 0;
+}
+
+.lyrics-bottom-sheet__segments {
+  padding: 8px 0 4px 24px;
+}
+
+.lyrics-bottom-sheet__segment {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.6;
+  margin: 0 0 4px;
 }

--- a/src/components/workstation/LyricsBottomSheet.tsx
+++ b/src/components/workstation/LyricsBottomSheet.tsx
@@ -1,5 +1,12 @@
-import { type Track } from '../../types/track';
+import { useCallback } from 'react';
+import { LoaderCircle } from 'lucide-react';
+import { useTrackService } from '../../hooks/useTrackService';
+import { useTranscriptionService } from '../../hooks/useTranscriptionService';
+import { type Track, type TrackId } from '../../types/track';
+import type { TranscriptionSegment } from '../../types/transcription';
+import type { TranscriptionState } from '../../services/TranscriptionService';
 import { Button } from '../ui/button';
+import { Progress } from '../ui/progress';
 import BottomSheet from './BottomSheet';
 import './LyricsBottomSheet.css';
 
@@ -18,8 +25,22 @@ const LyricsBottomSheet = ({
   onHeightChange,
   tracks,
 }: LyricsBottomSheetProps) => {
+  const trackService = useTrackService();
+  const transcription = useTranscriptionService();
   const vocalTracks = tracks.filter(
     (track) => track.instrument === VOICE_INSTRUMENT,
+  );
+
+  const handleTranscribe = useCallback(
+    (trackId: TrackId) => {
+      const audioBuffer = trackService.retrieveAudioBuffer(trackId);
+      if (!audioBuffer) return;
+      // Fire-and-forget — state is tracked via signals
+      transcription.transcribe(trackId, audioBuffer);
+    },
+    // trackService and transcription are stable refs from context
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 
   return (
@@ -34,25 +55,161 @@ const LyricsBottomSheet = ({
       ) : (
         <ul className="lyrics-bottom-sheet__list">
           {vocalTracks.map((track) => (
-            <li key={track.trackId} className="lyrics-bottom-sheet__item">
-              <span
-                className="lyrics-bottom-sheet__color"
-                style={{
-                  backgroundColor: `rgb(${track.color.r},${track.color.g},${track.color.b})`,
-                }}
-              />
-              <span className="lyrics-bottom-sheet__filename">
-                {track.fileName}
-              </span>
-              <Button variant="outline" size="sm" disabled>
-                Transcribe
-              </Button>
-            </li>
+            <TrackTranscription
+              key={track.trackId}
+              track={track}
+              state={transcription.getTranscriptionState(track.trackId)}
+              segments={transcription.getTranscription(track.trackId)?.segments}
+              downloadProgress={transcription.downloadProgress}
+              onTranscribe={handleTranscribe}
+            />
           ))}
         </ul>
       )}
     </BottomSheet>
   );
+};
+
+// --- Per-track transcription row ---
+
+type TrackTranscriptionProps = {
+  track: Track;
+  state: TranscriptionState;
+  segments: TranscriptionSegment[] | undefined;
+  downloadProgress: number | null;
+  onTranscribe: (trackId: TrackId) => void;
+};
+
+const TrackTranscription = ({
+  track,
+  state,
+  segments,
+  downloadProgress,
+  onTranscribe,
+}: TrackTranscriptionProps) => {
+  const handleClick = useCallback(() => {
+    onTranscribe(track.trackId);
+  }, [onTranscribe, track.trackId]);
+
+  return (
+    <li className="lyrics-bottom-sheet__item">
+      <div className="lyrics-bottom-sheet__header">
+        <span
+          className="lyrics-bottom-sheet__color"
+          style={{
+            backgroundColor: `rgb(${track.color.r},${track.color.g},${track.color.b})`,
+          }}
+        />
+        <span className="lyrics-bottom-sheet__filename">{track.fileName}</span>
+        <TrackAction state={state} onClick={handleClick} />
+      </div>
+      <TrackContent
+        state={state}
+        segments={segments}
+        downloadProgress={downloadProgress}
+      />
+    </li>
+  );
+};
+
+// --- Action button per state ---
+
+type TrackActionProps = {
+  state: TranscriptionState;
+  onClick: () => void;
+};
+
+const TrackAction = ({ state, onClick }: TrackActionProps) => {
+  if (state === 'transcribing') {
+    return (
+      <LoaderCircle
+        className="lyrics-bottom-sheet__spinner"
+        size={16}
+        aria-label="Transcribing"
+      />
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <Button variant="outline" size="sm" onClick={onClick}>
+        Retry
+      </Button>
+    );
+  }
+
+  if (state === 'done') {
+    return null;
+  }
+
+  // idle
+  return (
+    <Button variant="outline" size="sm" onClick={onClick}>
+      Transcribe
+    </Button>
+  );
+};
+
+// --- Content area per state ---
+
+type TrackContentProps = {
+  state: TranscriptionState;
+  segments: TranscriptionSegment[] | undefined;
+  downloadProgress: number | null;
+};
+
+const TrackContent = ({
+  state,
+  segments,
+  downloadProgress,
+}: TrackContentProps) => {
+  if (state === 'transcribing') {
+    const showProgress = downloadProgress !== null;
+    return (
+      <div className="lyrics-bottom-sheet__status">
+        {showProgress ? (
+          <>
+            <span className="lyrics-bottom-sheet__status-text">
+              Downloading model… {Math.round(downloadProgress)}%
+            </span>
+            <Progress value={downloadProgress} />
+          </>
+        ) : (
+          <span className="lyrics-bottom-sheet__status-text">
+            Transcribing…
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <p className="lyrics-bottom-sheet__error">
+        Transcription failed. Click Retry to try again.
+      </p>
+    );
+  }
+
+  if (state === 'done' && segments) {
+    if (segments.length === 0) {
+      return (
+        <p className="lyrics-bottom-sheet__no-speech">No speech detected</p>
+      );
+    }
+    return (
+      <div className="lyrics-bottom-sheet__segments">
+        {segments.map((segment, index) => (
+          <p key={index} className="lyrics-bottom-sheet__segment">
+            {segment.text}
+          </p>
+        ))}
+      </div>
+    );
+  }
+
+  // idle
+  return null;
 };
 
 export default LyricsBottomSheet;

--- a/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
+++ b/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
@@ -1,6 +1,9 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
 import { mockTrack } from '../../../testUtils';
+import type { TranscriptionState } from '../../../services/TranscriptionService';
+import type { Transcription } from '../../../types/transcription';
+import type { TrackId } from '../../../types/track';
 import LyricsBottomSheet from '../LyricsBottomSheet';
 
 vi.mock('../BottomSheet', () => ({
@@ -17,12 +20,45 @@ vi.mock('../BottomSheet', () => ({
   ),
 }));
 
+const mockRetrieveAudioBuffer = vi.fn();
+
+vi.mock('../../../hooks/useTrackService', () => ({
+  useTrackService: () => ({
+    retrieveAudioBuffer: mockRetrieveAudioBuffer,
+  }),
+}));
+
+const mockTranscribe = vi.fn();
+const mockGetTranscriptionState = vi.fn<(id: TrackId) => TranscriptionState>(
+  () => 'idle',
+);
+const mockGetTranscription =
+  vi.fn<(id: TrackId) => Transcription | undefined>();
+let mockDownloadProgress: number | null = null;
+
+vi.mock('../../../hooks/useTranscriptionService', () => ({
+  useTranscriptionService: () => ({
+    getTranscriptionState: mockGetTranscriptionState,
+    getTranscription: mockGetTranscription,
+    get downloadProgress() {
+      return mockDownloadProgress;
+    },
+    transcribe: mockTranscribe,
+  }),
+}));
+
 const defaultProps = {
   isOpen: true,
   onOpenChange: vi.fn(),
   onHeightChange: vi.fn(),
   tracks: [] as ReturnType<typeof mockTrack>[],
 };
+
+beforeEach(() => {
+  mockDownloadProgress = null;
+  mockGetTranscriptionState.mockReturnValue('idle');
+  mockGetTranscription.mockReturnValue(undefined);
+});
 
 it('shows empty state when no vocal tracks exist', () => {
   const { getByText } = render(<LyricsBottomSheet {...defaultProps} />);
@@ -106,18 +142,154 @@ it('filters out non-vocal tracks', () => {
   expect(queryByText('drums.wav')).not.toBeInTheDocument();
 });
 
-it('renders transcribe button as disabled placeholder', () => {
+it('passes title "Lyrics" to BottomSheet', () => {
+  const { getByTestId } = render(<LyricsBottomSheet {...defaultProps} />);
+
+  expect(getByTestId('bottom-sheet')).toHaveAttribute('data-title', 'Lyrics');
+});
+
+// --- Transcribe button click ---
+
+it('calls transcribe with audioBuffer on Transcribe click', () => {
+  const fakeBuffer = {} as AudioBuffer;
+  mockRetrieveAudioBuffer.mockReturnValue(fakeBuffer);
+
   const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
 
   const { getByText } = render(
     <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
   );
 
-  expect(getByText('Transcribe')).toBeDisabled();
+  fireEvent.click(getByText('Transcribe'));
+
+  expect(mockRetrieveAudioBuffer).toHaveBeenCalledWith('track-1');
+  expect(mockTranscribe).toHaveBeenCalledWith('track-1', fakeBuffer);
 });
 
-it('passes title "Lyrics" to BottomSheet', () => {
-  const { getByTestId } = render(<LyricsBottomSheet {...defaultProps} />);
+it('does not call transcribe when audioBuffer is unavailable', () => {
+  mockRetrieveAudioBuffer.mockReturnValue(undefined);
 
-  expect(getByTestId('bottom-sheet')).toHaveAttribute('data-title', 'Lyrics');
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  fireEvent.click(getByText('Transcribe'));
+
+  expect(mockTranscribe).not.toHaveBeenCalled();
+});
+
+// --- Transcribing state ---
+
+it('shows spinner when track is transcribing', () => {
+  mockGetTranscriptionState.mockReturnValue('transcribing');
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByLabelText, getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(getByLabelText('Transcribing')).toBeInTheDocument();
+  expect(getByText('Transcribing…')).toBeInTheDocument();
+});
+
+it('shows download progress bar during model download', () => {
+  mockGetTranscriptionState.mockReturnValue('transcribing');
+  mockDownloadProgress = 42;
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText, getByRole } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(getByText('Downloading model… 42%')).toBeInTheDocument();
+  expect(getByRole('progressbar')).toBeInTheDocument();
+});
+
+// --- Done state ---
+
+it('displays transcription segments when done', () => {
+  mockGetTranscriptionState.mockReturnValue('done');
+  mockGetTranscription.mockReturnValue({
+    trackId: 'track-1',
+    language: 'en',
+    segments: [
+      {
+        text: 'Hello world, this is a test',
+        start: 0,
+        end: 3,
+        words: [],
+      },
+      {
+        text: 'The second line of the song',
+        start: 4,
+        end: 7,
+        words: [],
+      },
+    ],
+  });
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText, queryByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(getByText('Hello world, this is a test')).toBeInTheDocument();
+  expect(getByText('The second line of the song')).toBeInTheDocument();
+  // Transcribe button should be hidden when done
+  expect(queryByText('Transcribe')).not.toBeInTheDocument();
+});
+
+it('shows no-speech message when transcription has zero segments', () => {
+  mockGetTranscriptionState.mockReturnValue('done');
+  mockGetTranscription.mockReturnValue({
+    trackId: 'track-1',
+    language: 'en',
+    segments: [],
+  });
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(getByText('No speech detected')).toBeInTheDocument();
+});
+
+// --- Error state ---
+
+it('shows error message and retry button on failure', () => {
+  mockGetTranscriptionState.mockReturnValue('error');
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(
+    getByText('Transcription failed. Click Retry to try again.'),
+  ).toBeInTheDocument();
+  expect(getByText('Retry')).toBeInTheDocument();
+});
+
+it('retries transcription on Retry click', () => {
+  mockGetTranscriptionState.mockReturnValue('error');
+  const fakeBuffer = {} as AudioBuffer;
+  mockRetrieveAudioBuffer.mockReturnValue(fakeBuffer);
+
+  const tracks = [mockTrack({ trackId: 'track-1', instrument: 'voice' })];
+
+  const { getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  fireEvent.click(getByText('Retry'));
+
+  expect(mockTranscribe).toHaveBeenCalledWith('track-1', fakeBuffer);
 });


### PR DESCRIPTION
## Summary

- Connected the "Transcribe" button in `LyricsBottomSheet` to `TranscriptionService` via the `useTranscriptionService` bridge hook
- Each vocal track now shows state-dependent UI across four states: idle (Transcribe button), transcribing (spinner + optional model download progress bar), done (segmented text paragraphs), and error (message with Retry button)
- Extracted per-track rendering into `TrackTranscription`, `TrackAction`, and `TrackContent` sub-components for clarity

## Test plan

- [x] All 930 unit tests pass (`npm test -- --run`)
- [x] ESLint passes (`npm run lint`)
- [x] 14 LyricsBottomSheet-specific tests cover: empty state, vocal filtering, Transcribe click, audioBuffer retrieval, spinner during transcription, download progress bar, segmented text display, no-speech message, error state with Retry, and retry click behavior
- [ ] Manual: open Lyrics bottom sheet with a vocal track, click Transcribe, verify progress indicators and final text display

https://claude.ai/code/session_018JrMCmVnrqtqVGC8nHZLB4