### PR TITLE
Fix DB versioning breaking home page

### DIFF
--- a/src/services/ProjectStorageService.ts
+++ b/src/services/ProjectStorageService.ts
@@ -83,6 +83,15 @@ function getDB(): Promise<IDBPDatabase<MawimbiDB>> {
           db.createObjectStore('transcriptions', { keyPath: 'trackId' });
         }
       },
+      blocked() {
+        // Version upgrade blocked by another tab holding an older connection.
+        // The openDB promise will hang until that tab closes or refreshes.
+        console.warn('Database upgrade blocked. Close other tabs to continue.');
+      },
+    }).catch((error) => {
+      // Reset so the next call retries instead of returning this cached rejection
+      dbPromise = null;
+      throw error;
     });
   }
   return dbPromise;

--- a/src/services/__tests__/ProjectStorageService.errorRecovery.test.ts
+++ b/src/services/__tests__/ProjectStorageService.errorRecovery.test.ts
@@ -1,0 +1,39 @@
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+const { mockOpenDB } = vi.hoisted(() => ({
+  mockOpenDB: vi.fn(),
+}));
+
+vi.mock('idb', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('idb')>();
+  return {
+    ...actual,
+    openDB: (...args: Parameters<typeof actual.openDB>) =>
+      mockOpenDB(...args) ?? actual.openDB(...args),
+  };
+});
+
+import { listProjects, resetDB } from '../ProjectStorageService';
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: new IDBFactory(),
+    configurable: true,
+  });
+  resetDB();
+  mockOpenDB.mockReset();
+});
+
+describe('ProjectStorageService error recovery', () => {
+  it('retries after a failed DB open instead of caching the rejected promise', async () => {
+    // First call: openDB returns a promise that rejects
+    mockOpenDB.mockRejectedValueOnce(new Error('upgrade blocked'));
+
+    await expect(listProjects()).rejects.toThrow('upgrade blocked');
+
+    // Subsequent calls should retry with real openDB (mockOpenDB returns undefined → falls through)
+    const projects = await listProjects();
+    expect(projects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed a bug where a failed `openDB` call (e.g., upgrade blocked by another tab, corrupt DB) cached the rejected promise in `dbPromise`, causing all subsequent IndexedDB operations — including `listProjects()` on the home page — to fail permanently for the session
- Added `.catch()` handler to reset `dbPromise` to `null` on rejection so subsequent calls retry instead of returning the cached rejection
- Added `blocked` callback to `openDB` to warn when a version upgrade is blocked by another tab holding an older connection

## Test plan
- [x] Added `ProjectStorageService.errorRecovery.test.ts` with a test that verifies the retry behavior: first `listProjects()` rejects, second call succeeds after `dbPromise` reset
- [x] All 931 unit tests pass
- [x] All e2e tests pass

https://claude.ai/code/session_01PhB8mabBheqgsWLnQKj5Bc