### PR TITLE
Update home page design with list container and icon buttons

### DIFF
--- a/src/components/home/HomePage.css
+++ b/src/components/home/HomePage.css
@@ -39,6 +39,14 @@
   overflow-y: auto;
 }
 
+.home__list-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--card);
+  border-radius: 16px 16px 0 0;
+}
+
 .home__project-list {
   width: 100%;
   max-width: 640px;
@@ -79,6 +87,12 @@
   gap: 16px;
   align-items: center;
   font-size: 13px;
+}
+
+.home__project-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .home__storage {

--- a/src/components/home/HomePage.tsx
+++ b/src/components/home/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Plus } from 'lucide-react';
 import {
   deleteProject,
   getStorageEstimate,
@@ -86,26 +87,33 @@ const HomePage = () => {
             <div className="home__header-row">
               <h1 className="home__title">Mawimbi</h1>
               <div className="home__header-actions">
-                <Button variant="secondary" size="sm" onClick={handleCreate}>
-                  New Project
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={handleCreate}
+                  aria-label="New project"
+                >
+                  <Plus size={20} />
                 </Button>
                 <SettingsButton />
               </div>
             </div>
           </div>
           <div className="home__body">
-            {hasProjects ? (
-              <ProjectList
-                projects={projects}
-                onOpen={handleOpen}
-                onDelete={handleDelete}
-              />
-            ) : (
-              <EmptyProjectList onCreate={handleCreate} />
-            )}
-            {hasProjects && (
-              <StorageUsage usage={storage.usage} quota={storage.quota} />
-            )}
+            <div className="home__list-container">
+              {hasProjects ? (
+                <ProjectList
+                  projects={projects}
+                  onOpen={handleOpen}
+                  onDelete={handleDelete}
+                />
+              ) : (
+                <EmptyProjectList onCreate={handleCreate} />
+              )}
+              {hasProjects && (
+                <StorageUsage usage={storage.usage} quota={storage.quota} />
+              )}
+            </div>
           </div>
         </div>
       </PageContent>

--- a/src/components/home/ProjectList.tsx
+++ b/src/components/home/ProjectList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { FolderOpen, Trash2 } from 'lucide-react';
 import { Button } from '../ui/button';
 import {
   AlertDialog,
@@ -43,17 +44,31 @@ const ProjectList = ({ projects, onOpen, onDelete }: ProjectListProps) => {
                 </span>
               </div>
             </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-destructive hover:text-destructive"
-              onClick={(e) => {
-                e.stopPropagation();
-                setDeleteTarget(project.id);
-              }}
-            >
-              Delete
-            </Button>
+            <div className="home__project-actions">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpen(project.id);
+                }}
+                aria-label="Open project"
+              >
+                <FolderOpen size={16} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-destructive hover:text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setDeleteTarget(project.id);
+                }}
+                aria-label="Delete project"
+              >
+                <Trash2 size={16} />
+              </Button>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/components/home/__tests__/HomePage.test.tsx
+++ b/src/components/home/__tests__/HomePage.test.tsx
@@ -108,10 +108,10 @@ it('navigates to new project with UUID on create', async () => {
   render(<HomePage />);
 
   await waitFor(() => {
-    expect(screen.getByText('New Project')).toBeInTheDocument();
+    expect(screen.getByLabelText('New project')).toBeInTheDocument();
   });
 
-  fireEvent.click(screen.getByText('New Project'));
+  fireEvent.click(screen.getByLabelText('New project'));
 
   const navigate = useNavigate();
   expect(navigate).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ it('deletes a project after confirmation', async () => {
     expect(screen.getByText('My Song')).toBeInTheDocument();
   });
 
-  const deleteButtons = screen.getAllByText('Delete');
+  const deleteButtons = screen.getAllByLabelText('Delete project');
   fireEvent.click(deleteButtons[0]);
 
   // AlertDialog should appear


### PR DESCRIPTION
## Summary
- Added a list container with rounded top corners wrapping the project list and storage usage, inspired by the card-style design pattern
- Replaced the "New Project" text button with a plus (`+`) icon button in the top right corner of the header
- Replaced the text "Delete" button on each project list item with icon buttons: `FolderOpen` (open) and `Trash2` (delete) from lucide-react

## Test plan
- [x] All 18 unit tests pass (updated selectors to use `aria-label` for icon buttons)
- [x] All 87 e2e tests pass including visual regression
- [x] ESLint passes with no errors
- [x] Verify the plus button in the header creates a new project
- [x] Verify the folder icon opens the project
- [x] Verify the trash icon triggers the delete confirmation dialog
- [x] Verify the list container has rounded top corners

https://claude.ai/code/session_011WS4zvNc6HNgAAPDPMBxnu