### PR TITLE
Fix lyrics transcription: use timestamped Whisper model

### DIFF
--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -19,7 +19,7 @@ import type { WorkerMessage, TranscribeResponse } from './transcription.worker';
 export type TranscriptionState = 'idle' | 'transcribing' | 'done' | 'error';
 
 // Default Whisper model — matches the worker default.
-const DEFAULT_MODEL_ID = 'onnx-community/whisper-base';
+const DEFAULT_MODEL_ID = 'onnx-community/whisper-base_timestamped';
 
 type TranscriptionEntry = {
   state: TranscriptionState;

--- a/src/services/__tests__/TranscriptionService.test.ts
+++ b/src/services/__tests__/TranscriptionService.test.ts
@@ -125,7 +125,7 @@ describe('TranscriptionService', () => {
     });
 
     it('uses default model ID when not specified', () => {
-      expect(service.modelId).toBe('onnx-community/whisper-base');
+      expect(service.modelId).toBe('onnx-community/whisper-base_timestamped');
     });
 
     it('accepts a custom model ID', () => {
@@ -174,7 +174,7 @@ describe('TranscriptionService', () => {
           type: 'transcribe',
           sampleRate: 16000,
           length: 48000,
-          modelId: 'onnx-community/whisper-base',
+          modelId: 'onnx-community/whisper-base_timestamped',
         }),
         expect.any(Array),
       );

--- a/src/services/transcription.worker.ts
+++ b/src/services/transcription.worker.ts
@@ -17,7 +17,7 @@ const MODEL_SAMPLE_RATE = 16_000;
 
 // Default Whisper model — whisper-base for the balance of quality and
 // download size (~142 MB). Can be overridden per request.
-const DEFAULT_MODEL_ID = 'onnx-community/whisper-base';
+const DEFAULT_MODEL_ID = 'onnx-community/whisper-base_timestamped';
 
 export type TranscribeRequest = {
   id: number;


### PR DESCRIPTION
## Summary
- Lyrics transcription was failing with: *"Model outputs must contain cross attentions to extract timestamps. This is most likely because the model was not exported with `output_attentions=True`"*
- The `onnx-community/whisper-base` ONNX model doesn't include cross-attention decoder outputs, which are required for word-level timestamps (`return_timestamps: 'word'`)
- Switched to `onnx-community/whisper-base_timestamped` — the same Whisper base model but exported with `--output_attentions` and `alignment_heads` configured

## Test plan
- [x] All 32 TranscriptionService unit tests pass
- [ ] Deploy to Netlify preview and verify lyrics transcription completes on a vocal track
- [ ] Verify word-level timestamps appear correctly in the lyrics bottom sheet

https://claude.ai/code/session_01Mi3HouSMAFvTNPE3yQaAAv