### PR TITLE
Improve lyrics display with larger font and phrase line breaks

### DIFF
--- a/src/components/workstation/LyricsBottomSheet.css
+++ b/src/components/workstation/LyricsBottomSheet.css
@@ -83,8 +83,12 @@
 }
 
 .lyrics-bottom-sheet__segment {
-  font-size: 13px;
+  font-size: 18px;
   color: rgba(255, 255, 255, 0.85);
   line-height: 1.6;
-  margin: 0 0 4px;
+  margin: 0 0 12px;
+}
+
+.lyrics-bottom-sheet__phrase {
+  margin: 0;
 }

--- a/src/components/workstation/LyricsBottomSheet.tsx
+++ b/src/components/workstation/LyricsBottomSheet.tsx
@@ -4,7 +4,10 @@ import { useClassificationService } from '../../hooks/useClassificationService';
 import { useTrackService } from '../../hooks/useTrackService';
 import { useTranscriptionService } from '../../hooks/useTranscriptionService';
 import { type Track, type TrackId } from '../../types/track';
-import type { TranscriptionSegment } from '../../types/transcription';
+import type {
+  TranscriptionSegment,
+  TranscriptionWord,
+} from '../../types/transcription';
 import type { TranscriptionState } from '../../services/TranscriptionService';
 import { Button } from '../ui/button';
 import { Progress } from '../ui/progress';
@@ -203,9 +206,7 @@ const TrackContent = ({
     return (
       <div className="lyrics-bottom-sheet__segments">
         {segments.map((segment, index) => (
-          <p key={index} className="lyrics-bottom-sheet__segment">
-            {segment.text}
-          </p>
+          <SegmentPhrases key={index} segment={segment} />
         ))}
       </div>
     );
@@ -213,6 +214,54 @@ const TrackContent = ({
 
   // idle
   return null;
+};
+
+// --- Segment with phrase line breaks ---
+
+// Gap between words (in seconds) that indicates a new phrase
+const PHRASE_GAP_THRESHOLD_SECONDS = 0.3;
+
+function groupWordsIntoPhrases(words: TranscriptionWord[]): string[] {
+  if (words.length === 0) return [];
+
+  const phrases: string[] = [];
+  let currentPhrase: string[] = [words[0].text];
+
+  for (let i = 1; i < words.length; i++) {
+    const gap = words[i].start - words[i - 1].end;
+
+    if (gap >= PHRASE_GAP_THRESHOLD_SECONDS) {
+      phrases.push(currentPhrase.join(' '));
+      currentPhrase = [];
+    }
+
+    currentPhrase.push(words[i].text);
+  }
+
+  if (currentPhrase.length > 0) {
+    phrases.push(currentPhrase.join(' '));
+  }
+
+  return phrases;
+}
+
+const SegmentPhrases = ({ segment }: { segment: TranscriptionSegment }) => {
+  // Fall back to full text when word-level timestamps are unavailable
+  if (segment.words.length === 0) {
+    return <p className="lyrics-bottom-sheet__segment">{segment.text}</p>;
+  }
+
+  const phrases = groupWordsIntoPhrases(segment.words);
+
+  return (
+    <div className="lyrics-bottom-sheet__segment">
+      {phrases.map((phrase, index) => (
+        <p key={index} className="lyrics-bottom-sheet__phrase">
+          {phrase}
+        </p>
+      ))}
+    </div>
+  );
 };
 
 export default LyricsBottomSheet;

--- a/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
+++ b/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
@@ -276,6 +276,38 @@ it('displays transcription segments when done', () => {
   expect(queryByText('Transcribe')).not.toBeInTheDocument();
 });
 
+it('splits segment into phrases based on word timing gaps', () => {
+  mockGetClassification.mockReturnValue({ label: 'vocals', score: 0.93 });
+  mockGetTranscriptionState.mockReturnValue('done');
+  mockGetTranscription.mockReturnValue({
+    trackId: 'track-1',
+    language: 'en',
+    segments: [
+      {
+        text: 'Hello world goodbye world',
+        start: 0,
+        end: 5,
+        words: [
+          { text: 'Hello', start: 0, end: 0.3 },
+          { text: 'world', start: 0.35, end: 0.7 },
+          // 0.5s gap — triggers phrase break (>= 0.3s)
+          { text: 'goodbye', start: 1.2, end: 1.6 },
+          { text: 'world', start: 1.65, end: 2.0 },
+        ],
+      },
+    ],
+  });
+
+  const tracks = [mockTrack({ trackId: 'track-1' })];
+
+  const { getByText } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  expect(getByText('Hello world')).toBeInTheDocument();
+  expect(getByText('goodbye world')).toBeInTheDocument();
+});
+
 it('shows no-speech message when transcription has zero segments', () => {
   mockGetClassification.mockReturnValue({ label: 'vocals', score: 0.93 });
   mockGetTranscriptionState.mockReturnValue('done');


### PR DESCRIPTION
## Summary
- Increased lyrics transcription font size from 13px to 18px for better readability
- Added phrase-level line breaks within segments based on word timing gaps (>= 0.3s threshold), so the transcription follows natural speech phrasing instead of displaying as a single block of text
- Falls back to displaying the full segment text when word-level timestamps are unavailable

## Test plan
- [x] Unit test added verifying phrase splitting based on word timing gaps
- [x] Existing tests pass (934/934 unit tests, 84/84 stable e2e tests)
- [ ] Manual verification: upload a vocal track, transcribe, and confirm phrases appear on separate lines with larger font

https://claude.ai/code/session_01XYLkb7qd3XeG7FhkAR1oWr