### PR TITLE
Add light/dark mode theming

### DIFF
--- a/src/components/LogOverlay.css
+++ b/src/components/LogOverlay.css
@@ -7,8 +7,8 @@
   height: 40vh;
   display: flex;
   flex-direction: column;
-  background: #141414;
-  border-top: 1px solid #434343;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
   font-family: monospace;
   font-size: 11px;
 }
@@ -18,9 +18,9 @@
   justify-content: space-between;
   align-items: center;
   padding: 4px 8px;
-  background: #1f1f1f;
-  color: #d9d9d9;
-  border-bottom: 1px solid #434343;
+  background: var(--card);
+  color: var(--foreground);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
@@ -33,9 +33,9 @@
   padding: 2px 8px;
   font-size: 11px;
   font-family: monospace;
-  background: #2a2a2a;
-  color: #d9d9d9;
-  border: 1px solid #434343;
+  background: var(--secondary);
+  color: var(--foreground);
+  border: 1px solid var(--border);
   border-radius: 3px;
   cursor: pointer;
 }
@@ -51,19 +51,19 @@
   display: flex;
   gap: 6px;
   padding: 1px 8px;
-  color: #d9d9d9;
+  color: var(--foreground);
   word-break: break-all;
 }
 
 .log-entry-level {
   flex-shrink: 0;
   width: 28px;
-  color: #8c8c8c;
+  color: var(--muted-foreground);
 }
 
 .log-entry-time {
   flex-shrink: 0;
-  color: #595959;
+  color: var(--foreground-faint);
 }
 
 .log-entry-message {
@@ -87,5 +87,5 @@
 }
 
 .log-entry-debug {
-  color: #8c8c8c;
+  color: var(--muted-foreground);
 }

--- a/src/components/dropzone/Dropzone.css
+++ b/src/components/dropzone/Dropzone.css
@@ -4,7 +4,7 @@
 }
 
 .dropzone--active {
-  background: rgba(0, 0, 0, 0.65);
+  background: rgba(var(--shade-color), 0.65);
   border: 2px dashed var(--border);
   border-radius: 4px;
 }

--- a/src/components/fullscreen/Fullscreen.css
+++ b/src/components/fullscreen/Fullscreen.css
@@ -21,10 +21,10 @@
   justify-content: center;
   align-items: center;
   background: linear-gradient(
-    rgba(0, 0, 0, 0.65),
-    #000 25%,
-    #000 75%,
-    rgba(0, 0, 0, 0.65) 75%
+    var(--overlay-bg),
+    var(--overlay-solid) 25%,
+    var(--overlay-solid) 75%,
+    var(--overlay-bg) 75%
   );
 }
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -10,7 +10,7 @@ import { Toaster as Sonner, type ToasterProps } from 'sonner';
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
-      theme="dark"
+      theme="system"
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/src/components/workstation/BottomSheet.css
+++ b/src/components/workstation/BottomSheet.css
@@ -30,7 +30,7 @@
   height: 4px;
   margin-top: 8px;
   border-radius: 2px;
-  background-color: rgba(255, 255, 255, 0.3);
+  background-color: var(--foreground-faint);
 }
 
 .bottom-sheet__title-row {
@@ -45,13 +45,13 @@
   margin: 0;
   font-size: 20px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--foreground);
   text-align: left;
 }
 
 .bottom-sheet__close {
   flex-shrink: 0;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--foreground-muted);
 }
 
 .bottom-sheet__content {

--- a/src/components/workstation/CountIn.css
+++ b/src/components/workstation/CountIn.css
@@ -9,14 +9,14 @@
   justify-content: center;
   z-index: 9999;
   pointer-events: none;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(var(--shade-color), 0.2);
 }
 
 .count-in__beat {
   font-size: 12rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.9);
-  text-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
+  color: var(--foreground);
+  text-shadow: 0 0 40px rgba(var(--shade-color), 0.5);
   animation: count-in-pulse 450ms ease-out forwards;
   user-select: none;
 }

--- a/src/components/workstation/LyricsBottomSheet.css
+++ b/src/components/workstation/LyricsBottomSheet.css
@@ -1,6 +1,6 @@
 .lyrics-bottom-sheet__empty {
   padding: 16px;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--muted-foreground);
   text-align: center;
   font-size: 14px;
 }
@@ -31,7 +31,7 @@
 .lyrics-bottom-sheet__filename {
   flex: 1;
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -39,7 +39,7 @@
 
 .lyrics-bottom-sheet__spinner {
   animation: lyrics-spin 1s linear infinite;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--foreground-muted);
   flex-shrink: 0;
 }
 
@@ -59,21 +59,21 @@
 .lyrics-bottom-sheet__status-text {
   display: block;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--muted-foreground);
   margin-bottom: 6px;
 }
 
 .lyrics-bottom-sheet__error {
   padding: 4px 0 0 24px;
   font-size: 12px;
-  color: #ff4d4f;
+  color: var(--error);
   margin: 0;
 }
 
 .lyrics-bottom-sheet__no-speech {
   padding: 4px 0 0 24px;
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--muted-foreground);
   font-style: italic;
   margin: 0;
 }
@@ -84,7 +84,7 @@
 
 .lyrics-bottom-sheet__segment {
   font-size: 18px;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--foreground);
   line-height: 1.6;
   margin: 0 0 12px;
 }

--- a/src/components/workstation/Toolbar.css
+++ b/src/components/workstation/Toolbar.css
@@ -13,7 +13,7 @@
 }
 
 .show-lyrics {
-  color: var(--ant-color-primary);
+  color: var(--primary);
 }
 
 .fader-1,

--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -52,10 +52,10 @@
   height: 100%;
   background-image: linear-gradient(
     to right,
-    #000,
-    #0000 75%,
-    #000c 75%,
-    #000f 100%
+    rgb(var(--shade-color)),
+    rgba(var(--shade-color), 0) 75%,
+    rgba(var(--shade-color), 0.8) 75%,
+    rgb(var(--shade-color)) 100%
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,9 @@
   --color-surface: var(--surface);
   --color-foreground-muted: var(--foreground-muted);
   --color-foreground-faint: var(--foreground-faint);
+  --color-shade: var(--shade-color);
+  --color-overlay-bg: var(--overlay-bg);
+  --color-overlay-solid: var(--overlay-solid);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -33,58 +36,64 @@
 }
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(0 0% 3.9%);
+  --background: hsl(0 0% 96%);
+  --foreground: hsl(0 0% 9%);
   --card: hsl(0 0% 100%);
-  --card-foreground: hsl(0 0% 3.9%);
+  --card-foreground: hsl(0 0% 9%);
   --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(0 0% 3.9%);
+  --popover-foreground: hsl(0 0% 9%);
   --primary: hsl(0 0% 9%);
   --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(0 0% 96.1%);
+  --secondary: hsl(0 0% 92%);
   --secondary-foreground: hsl(0 0% 9%);
-  --muted: hsl(0 0% 96.1%);
-  --muted-foreground: hsl(0 0% 45.1%);
-  --accent: hsl(0 0% 96.1%);
+  --muted: hsl(0 0% 92%);
+  --muted-foreground: hsl(0 0% 40%);
+  --accent: hsl(0 0% 92%);
   --accent-foreground: hsl(0 0% 9%);
   --destructive: hsl(0 84.2% 60.2%);
   --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 89.8%);
-  --input: hsl(0 0% 89.8%);
+  --border: hsl(0 0% 87%);
+  --input: hsl(0 0% 87%);
   --ring: hsl(0 0% 3.9%);
   --radius: 0.5rem;
   --success: #52c41a;
   --error: #ff4d4f;
-  --surface: #f5f5f5;
+  --surface: hsl(0 0% 96%);
   --foreground-muted: rgba(0, 0, 0, 0.65);
   --foreground-faint: rgba(0, 0, 0, 0.3);
+  --shade-color: 255, 255, 255;
+  --overlay-bg: rgba(255, 255, 255, 0.65);
+  --overlay-solid: hsl(0 0% 96%);
 }
 
 .dark {
   --background: hsl(0 0% 0%);
   --foreground: rgba(255, 255, 255, 0.85);
-  --card: hsl(0 0% 7.8%);
+  --card: hsl(0 0% 8%);
   --card-foreground: hsl(0 0% 98%);
-  --popover: hsl(0 0% 7.8%);
+  --popover: hsl(0 0% 8%);
   --popover-foreground: hsl(0 0% 98%);
   --primary: hsl(0 0% 98%);
   --primary-foreground: hsl(0 0% 9%);
-  --secondary: hsl(0 0% 14.9%);
+  --secondary: hsl(0 0% 15%);
   --secondary-foreground: hsl(0 0% 98%);
-  --muted: hsl(0 0% 14.9%);
-  --muted-foreground: hsl(0 0% 63.9%);
-  --accent: hsl(0 0% 14.9%);
+  --muted: hsl(0 0% 15%);
+  --muted-foreground: hsl(0 0% 64%);
+  --accent: hsl(0 0% 15%);
   --accent-foreground: hsl(0 0% 98%);
   --destructive: hsl(0 62.8% 30.6%);
   --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 26.3%);
-  --input: hsl(0 0% 14.9%);
+  --border: hsl(0 0% 20%);
+  --input: hsl(0 0% 15%);
   --ring: hsl(0 0% 83.1%);
   --success: #52c41a;
   --error: #ff4d4f;
-  --surface: #141414;
+  --surface: hsl(0 0% 8%);
   --foreground-muted: rgba(255, 255, 255, 0.65);
   --foreground-faint: rgba(255, 255, 255, 0.3);
+  --shade-color: 0, 0, 0;
+  --overlay-bg: rgba(0, 0, 0, 0.65);
+  --overlay-solid: hsl(0 0% 0%);
 }
 
 body {
@@ -109,12 +118,12 @@ html {
 @media (hover: hover) and (pointer: fine) {
   /* Style scrollbar on desktop devices only. */
   html {
-    --scrollbar-track-color: #f5f5f5;
+    --scrollbar-track-color: hsl(0 0% 96%);
     --scrollbar-thumb-color: rgba(0, 0, 0, 0.35);
   }
 
   .dark {
-    --scrollbar-track-color: #141414;
+    --scrollbar-track-color: hsl(0 0% 8%);
     --scrollbar-thumb-color: rgba(255, 255, 255, 0.65);
   }
 
@@ -140,7 +149,7 @@ html {
 
 .button,
 .button:hover {
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--foreground-muted);
   background-color: transparent;
   border: none;
   border-radius: 2px;
@@ -148,25 +157,25 @@ html {
 }
 
 .button:focus {
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--foreground-muted);
   background-color: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.65);
+  border: 1px solid var(--foreground-muted);
 }
 
 .button:active {
-  color: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(255, 255, 255, 1);
+  color: var(--foreground);
+  border: 1px solid var(--foreground);
 }
 
 @media (hover: hover) and (pointer: fine) {
   /* Style button hover on desktop devices only. */
   .button:hover {
-    color: rgba(255, 255, 255, 1);
+    color: var(--foreground);
   }
 
   .button:hover:focus {
-    color: rgba(255, 255, 255, 1);
-    border: 1px solid rgba(255, 255, 255, 1);
+    color: var(--foreground);
+    border: 1px solid var(--foreground);
   }
 }
 
@@ -175,7 +184,7 @@ html {
 .button[disabled]:focus,
 .button[disabled]:active,
 .button--active[disabled] {
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--foreground-faint);
   border: none;
 }
 


### PR DESCRIPTION
## Summary
- Updated CSS custom variables so light mode uses white cards (`hsl(0 0% 100%)`) on a tinted white background (`hsl(0 0% 96%)`), and dark mode uses tinted black cards (`hsl(0 0% 8%)`) on a pure black background (`hsl(0 0% 0%)`)
- Replaced hardcoded `rgba(255,255,255,...)` and `rgba(0,0,0,...)` colors across 9 component CSS files with theme-aware CSS variables (`--foreground`, `--foreground-muted`, `--foreground-faint`, `--shade-color`, `--overlay-bg`, `--overlay-solid`)
- Made toast notifications theme-aware by switching Sonner from hardcoded `"dark"` to `"system"` theme

### Files changed
- `src/index.css` — Core theme variables for both light and dark modes, toolbar button styling
- `src/components/workstation/scrubber/Scrubber.css` — Shade gradient uses `--shade-color`
- `src/components/workstation/BottomSheet.css` — Handle bar, title, close button
- `src/components/workstation/LyricsBottomSheet.css` — All text colors
- `src/components/workstation/CountIn.css` — Overlay background and beat text
- `src/components/workstation/Toolbar.css` — Fixed stale `--ant-color-primary` reference
- `src/components/fullscreen/Fullscreen.css` — Overlay gradient
- `src/components/dropzone/Dropzone.css` — Active drop zone background
- `src/components/LogOverlay.css` — All hardcoded colors
- `src/components/ui/sonner.tsx` — Theme-aware toasts

## Test plan
- [x] All 933 unit tests pass
- [x] All 87 e2e tests pass (including visual regression)
- [ ] Manually verify light mode: white cards on tinted white background, dark text
- [ ] Manually verify dark mode: tinted black cards on black background, light text
- [ ] Toggle between light/dark/system in Settings and verify smooth transitions

https://claude.ai/code/session_01Eteh82Hn6eqwfHZqtH5D4y