### PR TITLE
Enhance lyrics display with playback position following

### DIFF
--- a/src/components/workstation/LyricsBottomSheet.css
+++ b/src/components/workstation/LyricsBottomSheet.css
@@ -85,10 +85,18 @@
 .lyrics-bottom-sheet__segment {
   font-size: 18px;
   color: var(--foreground);
-  line-height: 1.6;
-  margin: 0 0 12px;
+  line-height: 2;
+  margin: 0 0 16px;
 }
 
 .lyrics-bottom-sheet__phrase {
-  margin: 0;
+  margin: 0 0 4px;
+}
+
+.lyrics-bottom-sheet__word {
+  transition: color 0.15s ease;
+}
+
+.lyrics-bottom-sheet__word--played {
+  color: var(--muted-foreground);
 }

--- a/src/components/workstation/LyricsBottomSheet.tsx
+++ b/src/components/workstation/LyricsBottomSheet.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { LoaderCircle } from 'lucide-react';
 import { useClassificationService } from '../../hooks/useClassificationService';
+import { usePlaybackService } from '../../hooks/usePlaybackService';
 import { useTrackService } from '../../hooks/useTrackService';
 import { useTranscriptionService } from '../../hooks/useTranscriptionService';
 import { type Track, type TrackId } from '../../types/track';
@@ -30,6 +31,7 @@ const LyricsBottomSheet = ({
   tracks,
 }: LyricsBottomSheetProps) => {
   const classification = useClassificationService();
+  const playback = usePlaybackService();
   const trackService = useTrackService();
   const transcription = useTranscriptionService();
   const vocalTracks = tracks.filter(
@@ -67,6 +69,7 @@ const LyricsBottomSheet = ({
               state={transcription.getTranscriptionState(track.trackId)}
               segments={transcription.getTranscription(track.trackId)?.segments}
               downloadProgress={transcription.downloadProgress}
+              transportTime={playback.transportTime}
               onTranscribe={handleTranscribe}
             />
           ))}
@@ -83,6 +86,7 @@ type TrackTranscriptionProps = {
   state: TranscriptionState;
   segments: TranscriptionSegment[] | undefined;
   downloadProgress: number | null;
+  transportTime: number;
   onTranscribe: (trackId: TrackId) => void;
 };
 
@@ -91,6 +95,7 @@ const TrackTranscription = ({
   state,
   segments,
   downloadProgress,
+  transportTime,
   onTranscribe,
 }: TrackTranscriptionProps) => {
   const handleClick = useCallback(() => {
@@ -113,6 +118,7 @@ const TrackTranscription = ({
         state={state}
         segments={segments}
         downloadProgress={downloadProgress}
+        transportTime={transportTime}
       />
     </li>
   );
@@ -162,12 +168,14 @@ type TrackContentProps = {
   state: TranscriptionState;
   segments: TranscriptionSegment[] | undefined;
   downloadProgress: number | null;
+  transportTime: number;
 };
 
 const TrackContent = ({
   state,
   segments,
   downloadProgress,
+  transportTime,
 }: TrackContentProps) => {
   if (state === 'transcribing') {
     const showProgress = downloadProgress !== null;
@@ -206,7 +214,11 @@ const TrackContent = ({
     return (
       <div className="lyrics-bottom-sheet__segments">
         {segments.map((segment, index) => (
-          <SegmentPhrases key={index} segment={segment} />
+          <SegmentPhrases
+            key={index}
+            segment={segment}
+            transportTime={transportTime}
+          />
         ))}
       </div>
     );
@@ -221,31 +233,43 @@ const TrackContent = ({
 // Gap between words (in seconds) that indicates a new phrase
 const PHRASE_GAP_THRESHOLD_SECONDS = 0.3;
 
-function groupWordsIntoPhrases(words: TranscriptionWord[]): string[] {
+function groupWordsIntoPhrases(
+  words: TranscriptionWord[],
+): TranscriptionWord[][] {
   if (words.length === 0) return [];
 
-  const phrases: string[] = [];
-  let currentPhrase: string[] = [words[0].text];
+  const phrases: TranscriptionWord[][] = [];
+  let currentPhrase: TranscriptionWord[] = [words[0]];
 
   for (let i = 1; i < words.length; i++) {
     const gap = words[i].start - words[i - 1].end;
 
     if (gap >= PHRASE_GAP_THRESHOLD_SECONDS) {
-      phrases.push(currentPhrase.join(' '));
+      phrases.push(currentPhrase);
       currentPhrase = [];
     }
 
-    currentPhrase.push(words[i].text);
+    currentPhrase.push(words[i]);
   }
 
   if (currentPhrase.length > 0) {
-    phrases.push(currentPhrase.join(' '));
+    phrases.push(currentPhrase);
   }
 
   return phrases;
 }
 
-const SegmentPhrases = ({ segment }: { segment: TranscriptionSegment }) => {
+function wordClassName(word: TranscriptionWord, transportTime: number): string {
+  if (transportTime <= word.start) return 'lyrics-bottom-sheet__word';
+  return 'lyrics-bottom-sheet__word lyrics-bottom-sheet__word--played';
+}
+
+type SegmentPhrasesProps = {
+  segment: TranscriptionSegment;
+  transportTime: number;
+};
+
+const SegmentPhrases = ({ segment, transportTime }: SegmentPhrasesProps) => {
   // Fall back to full text when word-level timestamps are unavailable
   if (segment.words.length === 0) {
     return <p className="lyrics-bottom-sheet__segment">{segment.text}</p>;
@@ -255,9 +279,17 @@ const SegmentPhrases = ({ segment }: { segment: TranscriptionSegment }) => {
 
   return (
     <div className="lyrics-bottom-sheet__segment">
-      {phrases.map((phrase, index) => (
-        <p key={index} className="lyrics-bottom-sheet__phrase">
-          {phrase}
+      {phrases.map((phrase, phraseIndex) => (
+        <p key={phraseIndex} className="lyrics-bottom-sheet__phrase">
+          {phrase.map((word, wordIndex) => (
+            <span
+              key={wordIndex}
+              className={wordClassName(word, transportTime)}
+            >
+              {wordIndex > 0 ? ' ' : ''}
+              {word.text}
+            </span>
+          ))}
         </p>
       ))}
     </div>

--- a/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
+++ b/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
@@ -23,6 +23,16 @@ vi.mock('../BottomSheet', () => ({
 
 const mockRetrieveAudioBuffer = vi.fn();
 
+let mockTransportTime = 0;
+
+vi.mock('../../../hooks/usePlaybackService', () => ({
+  usePlaybackService: () => ({
+    get transportTime() {
+      return mockTransportTime;
+    },
+  }),
+}));
+
 vi.mock('../../../hooks/useTrackService', () => ({
   useTrackService: () => ({
     retrieveAudioBuffer: mockRetrieveAudioBuffer,
@@ -66,6 +76,7 @@ const defaultProps = {
 
 beforeEach(() => {
   mockDownloadProgress = null;
+  mockTransportTime = 0;
   mockGetClassification.mockReturnValue(undefined);
   mockGetTranscriptionState.mockReturnValue('idle');
   mockGetTranscription.mockReturnValue(undefined);
@@ -300,12 +311,15 @@ it('splits segment into phrases based on word timing gaps', () => {
 
   const tracks = [mockTrack({ trackId: 'track-1' })];
 
-  const { getByText } = render(
+  const { container } = render(
     <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
   );
 
-  expect(getByText('Hello world')).toBeInTheDocument();
-  expect(getByText('goodbye world')).toBeInTheDocument();
+  const phrases = container.querySelectorAll('.lyrics-bottom-sheet__phrase');
+
+  expect(phrases).toHaveLength(2);
+  expect(phrases[0].textContent).toBe('Hello world');
+  expect(phrases[1].textContent).toBe('goodbye world');
 });
 
 it('shows no-speech message when transcription has zero segments', () => {
@@ -342,6 +356,80 @@ it('shows error message and retry button on failure', () => {
     getByText('Transcription failed. Click Retry to try again.'),
   ).toBeInTheDocument();
   expect(getByText('Retry')).toBeInTheDocument();
+});
+
+// --- Playback position following ---
+
+it('marks words before transport time as played', () => {
+  mockGetClassification.mockReturnValue({ label: 'vocals', score: 0.93 });
+  mockGetTranscriptionState.mockReturnValue('done');
+  mockGetTranscription.mockReturnValue({
+    trackId: 'track-1',
+    language: 'en',
+    segments: [
+      {
+        text: 'Hello world goodbye',
+        start: 0,
+        end: 2,
+        words: [
+          { text: 'Hello', start: 0, end: 0.3 },
+          { text: 'world', start: 0.35, end: 0.7 },
+          { text: 'goodbye', start: 1.2, end: 1.6 },
+        ],
+      },
+    ],
+  });
+  // Transport is at 0.5s — past "Hello" (end 0.3), at "world" (start 0.35)
+  mockTransportTime = 0.5;
+
+  const tracks = [mockTrack({ trackId: 'track-1' })];
+
+  const { container } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  const words = container.querySelectorAll('.lyrics-bottom-sheet__word');
+
+  expect(words).toHaveLength(3);
+  // "Hello" — transport (0.5) > start (0), so played
+  expect(words[0]).toHaveClass('lyrics-bottom-sheet__word--played');
+  // "world" — transport (0.5) > start (0.35), so played
+  expect(words[1]).toHaveClass('lyrics-bottom-sheet__word--played');
+  // "goodbye" — transport (0.5) <= start (1.2), so upcoming
+  expect(words[2]).not.toHaveClass('lyrics-bottom-sheet__word--played');
+});
+
+it('marks no words as played when transport time is zero', () => {
+  mockGetClassification.mockReturnValue({ label: 'vocals', score: 0.93 });
+  mockGetTranscriptionState.mockReturnValue('done');
+  mockGetTranscription.mockReturnValue({
+    trackId: 'track-1',
+    language: 'en',
+    segments: [
+      {
+        text: 'Hello world',
+        start: 0,
+        end: 1,
+        words: [
+          { text: 'Hello', start: 0, end: 0.3 },
+          { text: 'world', start: 0.35, end: 0.7 },
+        ],
+      },
+    ],
+  });
+  mockTransportTime = 0;
+
+  const tracks = [mockTrack({ trackId: 'track-1' })];
+
+  const { container } = render(
+    <LyricsBottomSheet {...defaultProps} tracks={tracks} />,
+  );
+
+  const playedWords = container.querySelectorAll(
+    '.lyrics-bottom-sheet__word--played',
+  );
+
+  expect(playedWords).toHaveLength(0);
 });
 
 it('retries transcription on Retry click', () => {


### PR DESCRIPTION
## Summary
- Render each transcription word as an individual `<span>` element with timing-aware CSS classes
- Words past the transport position are tinted (dimmed via `--muted-foreground`) to draw focus to upcoming lyrics
- Increased line spacing (`line-height: 2`, added phrase margins) for better readability
- Prepares for #326 where words will become clickable to seek to that position

## Test plan
- [x] Unit tests pass (936/936) — added 2 new tests for playback-position word coloring
- [x] E2e tests pass (87/88 — 1 pre-existing failure in toolbar visual regression, unrelated)
- [ ] Manually verify lyrics display with a vocal track: words behind playback position should appear dimmed
- [ ] Verify line spacing is visually improved

https://claude.ai/code/session_015Qn9bmBGw4L4ouHsdGsTwk