### PR TITLE
Sync timeline scroll on lyrics word click and center active word

### DIFF
--- a/src/components/workstation/LyricsBottomSheet.tsx
+++ b/src/components/workstation/LyricsBottomSheet.tsx
@@ -22,6 +22,7 @@ type LyricsBottomSheetProps = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onHeightChange: (height: number) => void;
+  onSeekTo: (time: number) => void;
   tracks: Track[];
 };
 
@@ -29,6 +30,7 @@ const LyricsBottomSheet = ({
   isOpen,
   onOpenChange,
   onHeightChange,
+  onSeekTo,
   tracks,
 }: LyricsBottomSheetProps) => {
   const classification = useClassificationService();
@@ -65,15 +67,6 @@ const LyricsBottomSheet = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
-  const handleSeekTo = useCallback(
-    (time: number) => {
-      playback.seekTo(time);
-    },
-    // playback is a stable ref from context
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
   return (
     <BottomSheet
       isOpen={isOpen}
@@ -94,7 +87,7 @@ const LyricsBottomSheet = ({
               downloadProgress={transcription.downloadProgress}
               transportTime={playback.transportTime}
               onTranscribe={handleTranscribe}
-              onSeekTo={handleSeekTo}
+              onSeekTo={onSeekTo}
             />
           ))}
         </ul>
@@ -327,12 +320,12 @@ const SegmentPhrases = ({
 }: SegmentPhrasesProps) => {
   const activeWordRef = useRef<HTMLSpanElement>(null);
 
-  // Auto-scroll to keep the active word visible
+  // Auto-scroll to keep the active word centered in the bottom sheet
   useEffect(() => {
     if (activeWordRef.current?.scrollIntoView) {
       activeWordRef.current.scrollIntoView({
         behavior: 'smooth',
-        block: 'nearest',
+        block: 'center',
       });
     }
   }, [relativeTime]);

--- a/src/components/workstation/Workstation.tsx
+++ b/src/components/workstation/Workstation.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import { usePlaybackService } from '../../hooks/usePlaybackService';
 import { useRecordingService } from '../../hooks/useRecordingService';
 import { useWorkstation } from '../../hooks/useWorkstation';
 import { type Track, type TrackColor } from '../../types/track';
@@ -8,7 +9,7 @@ import { useFileDropzone } from '../dropzone/useFileDropzone';
 import EmptyTimeline from './EmptyTimeline';
 import MixerBottomSheet from './MixerBottomSheet';
 import LyricsBottomSheet from './LyricsBottomSheet';
-import Scrubber from './scrubber/Scrubber';
+import Scrubber, { type ScrubberHandle } from './scrubber/Scrubber';
 import Timeline from './Timeline';
 import Toolbar from './Toolbar';
 import './Workstation.css';
@@ -29,6 +30,7 @@ type WorkstationProps = {
 };
 
 const Workstation = (props: WorkstationProps) => {
+  const playback = usePlaybackService();
   const recording = useRecordingService();
   const { pixelsPerSecond } = useWorkstation();
   const [activeSheet, setActiveSheet] = useState<ActiveSheet>(null);
@@ -36,6 +38,7 @@ const Workstation = (props: WorkstationProps) => {
   const [isCountingIn, setIsCountingIn] = useState(false);
   const [drawerHeight, setDrawerHeight] = useState(0);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const scrubberRef = useRef<ScrubberHandle>(null);
 
   const { recordingColor, tracks, uploadFile } = props;
   const hasTracks = tracks.length > 0;
@@ -97,6 +100,16 @@ const Workstation = (props: WorkstationProps) => {
     setActiveSheet(open ? 'lyrics' : null);
   }, []);
 
+  const handleLyricsSeekTo = useCallback(
+    (time: number) => {
+      playback.seekTo(time);
+      scrubberRef.current?.syncScrollToTime(time);
+    },
+    // playback is a stable ref from context
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
   // Show the timeline when tracks exist or when recording is active.
   // Use the recording state machine signal (not local state) so the
   // timeline stays visible during the async stop-recording transition
@@ -119,6 +132,7 @@ const Workstation = (props: WorkstationProps) => {
         <div className="editor__timeline">
           {showTimeline ? (
             <Scrubber
+              ref={scrubberRef}
               drawerHeight={drawerHeight}
               onStopRecording={handleStopRecording}
               pixelsPerSecond={pixelsPerSecond}
@@ -163,6 +177,7 @@ const Workstation = (props: WorkstationProps) => {
         isOpen={isLyricsOpen}
         onOpenChange={handleLyricsOpenChange}
         onHeightChange={handleDrawerHeightChange}
+        onSeekTo={handleLyricsSeekTo}
         tracks={tracks}
       />
       {countInBeat !== null && <CountIn beat={countInBeat} />}

--- a/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
+++ b/src/components/workstation/__tests__/LyricsBottomSheet.test.tsx
@@ -75,6 +75,7 @@ const defaultProps = {
   isOpen: true,
   onOpenChange: vi.fn(),
   onHeightChange: vi.fn(),
+  onSeekTo: mockSeekTo,
   tracks: [] as ReturnType<typeof mockTrack>[],
 };
 

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -1,7 +1,7 @@
 import { SkipBack } from 'lucide-react';
 import { Button } from '../../ui/button';
 import classNames from 'classnames';
-import { PropsWithChildren } from 'react';
+import { forwardRef, PropsWithChildren, useImperativeHandle } from 'react';
 import { usePlaybackService } from '../../../hooks/usePlaybackService';
 import { useRecordingService } from '../../../hooks/useRecordingService';
 import { type Track } from '../../../types/track';
@@ -10,6 +10,10 @@ import PlasmaPlayhead from './PlasmaPlayhead';
 import './Scrubber.css';
 import { useScrubber } from './useScrubber';
 
+export type ScrubberHandle = {
+  syncScrollToTime: (time: number) => void;
+};
+
 type ScrubberProps = PropsWithChildren<{
   drawerHeight: number;
   onStopRecording: () => void;
@@ -17,7 +21,7 @@ type ScrubberProps = PropsWithChildren<{
   tracks: Track[];
 }>;
 
-const Scrubber = (props: ScrubberProps) => {
+const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   const playback = usePlaybackService();
   const recording = useRecordingService();
   const { drawerHeight, onStopRecording, pixelsPerSecond, tracks } = props;
@@ -33,7 +37,10 @@ const Scrubber = (props: ScrubberProps) => {
     handleWheel,
     handleTouchMove,
     handleStopAndRewind,
+    syncScrollToTime,
   } = useScrubber({ drawerHeight, pixelsPerSecond, tracks });
+
+  useImperativeHandle(ref, () => ({ syncScrollToTime }), [syncScrollToTime]);
 
   const handleTimelineClick = () => {
     if (recording.isCountingIn || recording.isActivelyRecording) {
@@ -84,6 +91,8 @@ const Scrubber = (props: ScrubberProps) => {
       <ZoomControls style={rewindButtonStyle} />
     </div>
   );
-};
+});
+
+Scrubber.displayName = 'Scrubber';
 
 export default Scrubber;

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -1,8 +1,9 @@
 import { isInaccessible } from '@testing-library/dom';
 import { act, fireEvent, render } from '@testing-library/react';
+import { createRef } from 'react';
 import * as Tone from 'tone';
 import AudioService from '../../../../services/AudioService';
-import Scrubber from '../Scrubber';
+import Scrubber, { type ScrubberHandle } from '../Scrubber';
 
 const audioService = AudioService.getInstance();
 const playbackService = audioService.playbackService;
@@ -394,4 +395,19 @@ it('does not update transportTime during count-in', () => {
   // transportTime should stay at the pre-count-in value, not update
   // to the current transport position (3.5) during count-in
   expect(playbackService.transportTime).toBe(5.0);
+});
+
+it('syncs timeline scroll position via imperative handle', () => {
+  const ref = createRef<ScrubberHandle>();
+
+  const { container } = render(<Scrubber ref={ref} {...defaultProps} />);
+
+  const timeline = container.querySelector('.scrubber__timeline')!;
+
+  act(() => {
+    ref.current!.syncScrollToTime(2.5);
+  });
+
+  // scrollLeft = time * pixelsPerSecond = 2.5 * 200 = 500
+  expect(timeline.scrollLeft).toBe(500);
 });

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -271,6 +271,14 @@ export function useScrubber({
     timelineScaleFactor,
   );
 
+  const syncScrollToTime = useCallback(
+    (time: number) => {
+      setScrollPosition(time);
+      plasmaRef.current?.renderIdle();
+    },
+    [setScrollPosition],
+  );
+
   return {
     timelineScrollRef,
     cursorContainerRef,
@@ -282,6 +290,7 @@ export function useScrubber({
     handleWheel,
     handleTouchMove,
     handleStopAndRewind,
+    syncScrollToTime,
   };
 }
 


### PR DESCRIPTION
## Summary
- When clicking a word in the lyrics transcription while paused/stopped, the timeline now scrolls to match the seek position. Previously, the timeline only scrolled during active playback.
- The lyrics auto-scroll now uses `block: 'center'` instead of `block: 'nearest'`, keeping the active word centered in the bottom sheet rather than at the edge.
- Scrubber exposes a `syncScrollToTime` imperative handle so Workstation can coordinate the seek + scroll in a single workflow.

## Test plan
- [x] All 953 unit tests pass
- [x] All 88 e2e tests pass
- [x] ESLint passes
- [ ] Open the lyrics panel, transcribe a vocal track, and click a word while paused — verify the timeline scrolls to that position
- [ ] Play a track and verify the active word stays centered in the bottom sheet as lyrics scroll
- [ ] Click a word while playing — verify both timeline and lyrics still work correctly

https://claude.ai/code/session_017yQBZndk41weMZhnyPu1nr