### PR TITLE
Enhance channel instrument UI with selector and new icons

### DIFF
--- a/src/components/workstation/Channel.css
+++ b/src/components/workstation/Channel.css
@@ -9,15 +9,37 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: stretch;
   width: 40px;
   font-size: 16px;
   color: rgba(0, 0, 0, 0.65);
   background-color: rgba(0, 0, 0, 0.35);
   margin: -4px 8px -4px -8px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  outline: none;
+}
+
+.channel__instrument:disabled {
+  cursor: default;
 }
 
 .channel--inverted .channel__instrument {
   color: rgba(255, 255, 255, 0.65);
+}
+
+.channel__instrument-option {
+  gap: 8px;
+}
+
+.channel__instrument-option .custom-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.channel__instrument-option--selected {
+  font-weight: 600;
 }
 
 .channel__download-progress {

--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -7,12 +7,24 @@ import {
 } from 'lucide-react';
 import { Slider } from '../ui/slider';
 import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 import classNames from 'classnames';
 import { useClassificationService } from '../../hooks/useClassificationService';
 import { FALLBACK_LABEL } from '../../services/instrumentLabels';
 import { type Track } from '../../types/track';
+import { SET_INSTRUMENT } from '../project/projectPageReducer';
+import useProjectDispatch from '../project/useProjectDispatch';
 import './Channel.css';
-import { getInstrumentIcon } from './instrumentIcons';
+import {
+  getInstrumentDisplayName,
+  getInstrumentIcon,
+  SELECTABLE_INSTRUMENTS,
+} from './instrumentIcons';
 import { useChannelControls } from './useChannelControls';
 
 type ChannelProps = {
@@ -25,6 +37,7 @@ const PERCENT_DIVISOR = 100;
 
 const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
   const { trackId, color } = track;
+  const dispatch = useProjectDispatch();
 
   const {
     volume,
@@ -45,6 +58,11 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
     (classificationState === 'error' ? FALLBACK_LABEL : undefined);
   const isDownloading =
     classificationState === 'classifying' && downloadProgress !== null;
+  const isClassifying = classificationState === 'classifying';
+
+  const handleSelectInstrument = (label: string) => {
+    dispatch([SET_INSTRUMENT, { trackId, instrument: label }]);
+  };
 
   const handleValueChange = (values: number[]) => {
     updateVolume(values[0]);
@@ -64,24 +82,46 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
         backgroundColor: channelColor,
       }}
     >
-      <div
-        className="channel__instrument"
-        title={
-          isDownloading ? `Downloading model: ${downloadProgress}%` : undefined
-        }
-      >
-        {classificationState === 'classifying' ? (
-          isDownloading ? (
-            <span className="channel__download-progress">
-              {downloadProgress}%
-            </span>
-          ) : (
-            <Loader2 className="animate-spin" />
-          )
-        ) : (
-          instrument !== undefined && getInstrumentIcon(instrument)
-        )}
-      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild disabled={isClassifying}>
+          <button
+            className="channel__instrument"
+            title={
+              isDownloading
+                ? `Downloading model: ${downloadProgress}%`
+                : instrument
+                  ? getInstrumentDisplayName(instrument)
+                  : undefined
+            }
+          >
+            {isClassifying ? (
+              isDownloading ? (
+                <span className="channel__download-progress">
+                  {downloadProgress}%
+                </span>
+              ) : (
+                <Loader2 className="animate-spin" />
+              )
+            ) : (
+              instrument !== undefined && getInstrumentIcon(instrument)
+            )}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="start">
+          {SELECTABLE_INSTRUMENTS.map((label) => (
+            <DropdownMenuItem
+              key={label}
+              className={classNames('channel__instrument-option', {
+                'channel__instrument-option--selected': instrument === label,
+              })}
+              onSelect={() => handleSelectInstrument(label)}
+            >
+              {getInstrumentIcon(label)}
+              <span>{getInstrumentDisplayName(label)}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
       <div className="channel__mute-solo">
         <Button
           variant="ghost"

--- a/src/components/workstation/instrumentIcons.tsx
+++ b/src/components/workstation/instrumentIcons.tsx
@@ -26,6 +26,39 @@ const INSTRUMENT_ICONS: Record<InstrumentLabel, React.ComponentType> = {
   unknown: UnknownSvg,
 };
 
+const INSTRUMENT_DISPLAY_NAMES: Record<InstrumentLabel, string> = {
+  vocals: 'Vocals',
+  guitar: 'Guitar',
+  bass: 'Bass',
+  drums: 'Drums',
+  keyboard: 'Keyboard',
+  strings: 'Strings',
+  brass: 'Brass',
+  woodwind: 'Woodwind',
+  synth: 'Synth',
+  percussion: 'Percussion',
+  unknown: 'Unknown',
+};
+
+export const SELECTABLE_INSTRUMENTS: InstrumentLabel[] = [
+  'vocals',
+  'guitar',
+  'bass',
+  'drums',
+  'keyboard',
+  'strings',
+  'brass',
+  'woodwind',
+  'synth',
+  'percussion',
+];
+
+export function getInstrumentDisplayName(label: string): string {
+  return label in INSTRUMENT_DISPLAY_NAMES
+    ? INSTRUMENT_DISPLAY_NAMES[label as InstrumentLabel]
+    : label;
+}
+
 export function getInstrumentIcon(label: string | undefined): React.ReactNode {
   const SvgComponent =
     label && label in INSTRUMENT_ICONS

--- a/src/icons/bass.svg
+++ b/src/icons/bass.svg
@@ -1,11 +1,17 @@
-<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
-  <!-- Bass guitar: body + long neck + tuning pegs -->
-  <path d="M224 544c0-88 72-160 160-160h32V160h64v224h32c88 0 160 72 160 160v96c0 88-72 160-160 160h-32v64h96v64H352v-64h96v-64h-64c-88 0-160-72-160-160v-96zm160-96c-53 0-96 43-96 96v96c0 53 43 96 96 96h256c53 0 96-43 96-96v-96c0-53-43-96-96-96H384z" fill="currentColor"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Bass guitar: long neck with tuning pegs, smaller body -->
+  <!-- Headstock -->
+  <circle cx="6" cy="3.5" r="0.8" fill="currentColor"/>
+  <circle cx="8" cy="3.5" r="0.8" fill="currentColor"/>
+  <!-- Neck -->
+  <line x1="7" y1="4.5" x2="7" y2="14"/>
+  <!-- Body -->
+  <path d="M4 14c-1.5 1-2 3-1.5 4.5S4 21 6 21.5s4-.5 5-2 1-3.5.5-5C11 13 9 12 7 12"/>
+  <path d="M3.5 16c1-.5 2.5-.5 3.5 0"/>
+  <!-- Pickup dots -->
+  <circle cx="6.5" cy="17.5" r="0.5" fill="currentColor"/>
+  <circle cx="8.5" cy="17" r="0.5" fill="currentColor"/>
   <!-- Strings -->
-  <rect x="432" y="160" width="16" height="128" fill="currentColor"/>
-  <rect x="480" y="160" width="16" height="128" fill="currentColor"/>
-  <rect x="432" y="480" width="16" height="192" fill="currentColor"/>
-  <rect x="480" y="480" width="16" height="192" fill="currentColor"/>
-  <rect x="528" y="480" width="16" height="192" fill="currentColor"/>
-  <rect x="576" y="480" width="16" height="192" fill="currentColor"/>
+  <line x1="6.5" y1="5" x2="6.5" y2="14"/>
+  <line x1="7.5" y1="5" x2="7.5" y2="14"/>
 </svg>

--- a/src/icons/drums.svg
+++ b/src/icons/drums.svg
@@ -1,10 +1,16 @@
-<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
-  <!-- Snare drum: cylinder with crossed sticks -->
-  <ellipse cx="512" cy="384" rx="288" ry="96" fill="none" stroke="currentColor" stroke-width="64"/>
-  <rect x="224" y="384" width="576" height="256" fill="currentColor"/>
-  <ellipse cx="512" cy="640" rx="288" ry="96" fill="currentColor"/>
-  <ellipse cx="512" cy="640" rx="288" ry="96" fill="none" stroke="currentColor" stroke-width="64"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Drum kit: snare + hi-hat + stick -->
+  <!-- Snare drum (top ellipse) -->
+  <ellipse cx="12" cy="14" rx="7" ry="2.5"/>
+  <!-- Drum body sides -->
+  <line x1="5" y1="14" x2="5" y2="19"/>
+  <line x1="19" y1="14" x2="19" y2="19"/>
+  <!-- Bottom ellipse -->
+  <ellipse cx="12" cy="19" rx="7" ry="2.5"/>
   <!-- Drumsticks crossed -->
-  <rect x="128" y="128" width="320" height="40" rx="20" transform="rotate(35 288 148)" fill="currentColor"/>
-  <rect x="576" y="128" width="320" height="40" rx="20" transform="rotate(-35 736 148)" fill="currentColor"/>
+  <line x1="6" y1="4" x2="14" y2="13"/>
+  <line x1="18" y1="4" x2="10" y2="13"/>
+  <!-- Stick tips -->
+  <circle cx="6" cy="4" r="0.7" fill="currentColor"/>
+  <circle cx="18" cy="4" r="0.7" fill="currentColor"/>
 </svg>

--- a/src/icons/guitar.svg
+++ b/src/icons/guitar.svg
@@ -1,4 +1,13 @@
-<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
-  <!-- Acoustic guitar: simplified silhouette -->
-  <path d="M800 96l-48 48 128 128 48-48c26-26 26-68 0-94l-34-34c-26-26-68-26-94 0zM720 176L368 528c-16-8-34-12-52-12-66 0-120 54-120 120 0 18 4 36 12 52l-80 80c-48 48-48 126 0 174s126 48 174 0l80-80c16 8 34 12 52 12 66 0 120-54 120-120 0-18-4-36-12-52L894 350l-46-46L720 176zM316 752c-28 0-52-24-52-52s24-52 52-52 52 24 52 52-24 52-52 52z" fill="currentColor"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Acoustic guitar: body, neck, headstock, sound hole -->
+  <path d="M16.5 19.5c2.5 0 4.5-2.7 4.5-5.5 0-2-1-3.7-2.5-4.5.3-1 .5-2 .5-3V3l-1 1-1-1v3.5c0 1-.2 2-.5 3C15 10.3 14 12 14 14c0 2.8 0 5.5 2.5 5.5z"/>
+  <circle cx="17" cy="14.5" r="1.5"/>
+  <line x1="19" y1="3" x2="19" y2="6.5"/>
+  <!-- Neck and frets -->
+  <line x1="17" y1="6.5" x2="17" y2="9.5"/>
+  <line x1="16" y1="7.5" x2="20" y2="7.5"/>
+  <line x1="16" y1="8.5" x2="20" y2="8.5"/>
+  <!-- Simplified body outline -->
+  <path d="M11 17c0-2 1-3.5 2-5"/>
+  <path d="M11 17c-1.5 0-3-1-3.5-2.5S7 12 7.5 11c.5-1 1.5-1.5 2.5-1.5"/>
 </svg>

--- a/src/icons/synth.svg
+++ b/src/icons/synth.svg
@@ -1,19 +1,21 @@
-<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
-  <!-- Synthesizer: waveform + keyboard -->
-  <!-- Sine wave on screen -->
-  <path d="M192 320c64-128 128 0 192-128s128 128 192 0 128-128 192 0" fill="none" stroke="currentColor" stroke-width="56" stroke-linecap="round"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Synthesizer: waveform on top, body with knobs and keys -->
+  <!-- Waveform -->
+  <path d="M3 6c1.5-3 3 0 4.5-3S10.5 6 12 3s3 3 4.5 0S19.5 6 21 3"/>
   <!-- Synth body -->
-  <rect x="128" y="448" width="768" height="384" rx="32" fill="none" stroke="currentColor" stroke-width="56"/>
-  <!-- Knobs -->
-  <circle cx="256" cy="544" r="40" fill="currentColor"/>
-  <circle cx="384" cy="544" r="40" fill="currentColor"/>
-  <circle cx="512" cy="544" r="40" fill="currentColor"/>
-  <!-- Keys bottom row -->
-  <rect x="192" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="288" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="384" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="480" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="576" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="672" y="672" width="80" height="112" rx="4" fill="currentColor"/>
-  <rect x="768" y="672" width="80" height="112" rx="4" fill="currentColor"/>
+  <rect x="2" y="10" width="20" height="11" rx="1.5"/>
+  <!-- Knobs row -->
+  <circle cx="6" cy="13.5" r="1.2"/>
+  <circle cx="10" cy="13.5" r="1.2"/>
+  <circle cx="14" cy="13.5" r="1.2"/>
+  <!-- Fader -->
+  <line x1="18" y1="11.5" x2="18" y2="15.5"/>
+  <line x1="17" y1="13" x2="19" y2="13"/>
+  <!-- Keys -->
+  <rect x="4" y="17" width="2.5" height="3" rx="0.3"/>
+  <rect x="7" y="17" width="2.5" height="3" rx="0.3"/>
+  <rect x="10" y="17" width="2.5" height="3" rx="0.3"/>
+  <rect x="13" y="17" width="2.5" height="3" rx="0.3"/>
+  <rect x="16" y="17" width="2.5" height="3" rx="0.3"/>
+  <rect x="19" y="17" width="2.5" height="3" rx="0.3"/>
 </svg>


### PR DESCRIPTION
## Summary
- Fixed the instrument div's shaded background to span the full height of the channel strip by adding `align-self: stretch`
- Replaced guitar, bass, drums, and synth SVG icons with cleaner line-art designs that are more recognizable at small sizes
- Added a dropdown popover menu on the instrument icon that lets users manually select a different instrument, which persists via the existing `SET_INSTRUMENT` reducer action

## Test plan
- [x] All 40 unit tests pass (Channel + instrumentIcons)
- [x] All 88 e2e tests pass
- [x] Build succeeds with no TypeScript errors
- [x] ESLint passes cleanly
- [ ] Verify instrument background visually spans full channel height in the mixer
- [ ] Verify new guitar, bass, drums, and synth icons render correctly
- [ ] Verify clicking the instrument icon opens a dropdown with all selectable instruments
- [ ] Verify selecting an instrument from the dropdown updates the channel icon
- [ ] Verify the dropdown is disabled while classification is in progress

https://claude.ai/code/session_01AYBYG5NTcXVxFLdrXPRxkc