### PR TITLE
Fix instrument dropdown in channel popover

### DIFF
--- a/src/components/workstation/Channel.tsx
+++ b/src/components/workstation/Channel.tsx
@@ -29,13 +29,21 @@ import { useChannelControls } from './useChannelControls';
 
 type ChannelProps = {
   dragHandleProps?: Record<string, unknown>;
+  isInstrumentDropdownOpen?: boolean;
   isMuted: boolean;
+  onInstrumentDropdownOpenChange?: (open: boolean) => void;
   track: Track;
 };
 
 const PERCENT_DIVISOR = 100;
 
-const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
+const Channel = ({
+  isMuted,
+  isInstrumentDropdownOpen,
+  onInstrumentDropdownOpenChange,
+  track,
+  dragHandleProps = {},
+}: ChannelProps) => {
   const { trackId, color } = track;
   const dispatch = useProjectDispatch();
 
@@ -82,7 +90,11 @@ const Channel = ({ isMuted, track, dragHandleProps = {} }: ChannelProps) => {
         backgroundColor: channelColor,
       }}
     >
-      <DropdownMenu>
+      <DropdownMenu
+        modal={false}
+        open={isInstrumentDropdownOpen}
+        onOpenChange={onInstrumentDropdownOpenChange}
+      >
         <DropdownMenuTrigger asChild disabled={isClassifying}>
           <button
             className="channel__instrument"

--- a/src/components/workstation/Mixer.tsx
+++ b/src/components/workstation/Mixer.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import {
   DndContext,
   DragEndEvent,
@@ -26,9 +27,22 @@ const Mixer = ({ tracks }: MixerProps) => {
   const { mutedTracks } = useTrackService();
   const projectDispatch = useProjectDispatch();
   const sensors = useSensors(useSensor(PointerSensor));
+  const [openDropdownId, setOpenDropdownId] = useState<TrackId | null>(null);
 
   const reversedTracks = tracks.slice().reverse();
   const reversedIds = reversedTracks.map((t) => t.trackId);
+
+  const handleDropdownOpenChange = useCallback(
+    (trackId: TrackId, open: boolean) => {
+      setOpenDropdownId((prev) => {
+        if (open) return trackId;
+        // Only close if this track's dropdown is the one currently open.
+        // Prevents a closing dropdown from overriding a newly opened one.
+        return prev === trackId ? null : prev;
+      });
+    },
+    [],
+  );
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -54,6 +68,8 @@ const Mixer = ({ tracks }: MixerProps) => {
               key={track.trackId}
               track={track}
               isMuted={mutedTracks.includes(track.trackId)}
+              isInstrumentDropdownOpen={openDropdownId === track.trackId}
+              onInstrumentDropdownOpenChange={handleDropdownOpenChange}
             />
           ))}
         </div>
@@ -65,9 +81,16 @@ const Mixer = ({ tracks }: MixerProps) => {
 type SortableChannelItemProps = {
   track: Track;
   isMuted: boolean;
+  isInstrumentDropdownOpen: boolean;
+  onInstrumentDropdownOpenChange: (trackId: TrackId, open: boolean) => void;
 };
 
-const SortableChannelItem = ({ track, isMuted }: SortableChannelItemProps) => {
+const SortableChannelItem = ({
+  track,
+  isMuted,
+  isInstrumentDropdownOpen,
+  onInstrumentDropdownOpenChange,
+}: SortableChannelItemProps) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: track.trackId });
 
@@ -76,10 +99,21 @@ const SortableChannelItem = ({ track, isMuted }: SortableChannelItemProps) => {
     transition,
   };
 
+  const handleDropdownOpenChange = useCallback(
+    (open: boolean) => {
+      onInstrumentDropdownOpenChange(track.trackId, open);
+    },
+    // onInstrumentDropdownOpenChange is stable (useCallback in Mixer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [track.trackId],
+  );
+
   return (
     <div className="mixer__channel" ref={setNodeRef} style={style}>
       <Channel
         isMuted={isMuted}
+        isInstrumentDropdownOpen={isInstrumentDropdownOpen}
+        onInstrumentDropdownOpenChange={handleDropdownOpenChange}
         track={track}
         dragHandleProps={{ ...attributes, ...listeners }}
       />

--- a/src/components/workstation/__tests__/Channel.test.tsx
+++ b/src/components/workstation/__tests__/Channel.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
 import { getFocusedTracks } from '../../../signals/focusSignals';
@@ -6,6 +7,12 @@ import AudioService from '../../../services/AudioService';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
 import { mockTrack } from '../../../testUtils';
 import Channel from '../Channel';
+
+const mockProjectDispatch = vi.fn();
+
+vi.mock('../../project/useProjectDispatch', () => ({
+  default: () => mockProjectDispatch,
+}));
 
 const mockGetClassification = vi.fn().mockReturnValue(undefined);
 const mockGetClassificationState = vi.fn().mockReturnValue('idle');
@@ -290,4 +297,24 @@ it('sets title attribute with download progress', () => {
 
   const instrumentDiv = container.querySelector('.channel__instrument');
   expect(instrumentDiv).toHaveAttribute('title', 'Downloading model: 72%');
+});
+
+it('dispatches SET_INSTRUMENT when selecting an instrument from dropdown', async () => {
+  const user = userEvent.setup();
+  mockGetClassification.mockReturnValue({ label: 'guitar', score: 0.85 });
+  mockGetClassificationState.mockReturnValue('done');
+
+  const track = mockTrack({ trackId: 'track-1', instrument: 'guitar' });
+  render(<Channel {...{ ...defaultProps, track }} />);
+
+  const trigger = screen.getByTitle('Guitar');
+  await user.click(trigger);
+
+  const drumItem = await screen.findByText('Drums');
+  await user.click(drumItem);
+
+  expect(mockProjectDispatch).toHaveBeenCalledWith([
+    'SET_INSTRUMENT',
+    { trackId: 'track-1', instrument: 'drums' },
+  ]);
 });

--- a/src/components/workstation/__tests__/Mixer.test.tsx
+++ b/src/components/workstation/__tests__/Mixer.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import AudioService from '../../../services/AudioService';
 import { resetAllSignals } from '../../../signals/__tests__/testUtils';
@@ -11,6 +12,17 @@ const mockProjectDispatch = vi.fn();
 
 vi.mock('../../project/useProjectDispatch', () => ({
   default: () => mockProjectDispatch,
+}));
+
+vi.mock('../../../hooks/useClassificationService', () => ({
+  useClassificationService: () => ({
+    classifications: new Map(),
+    downloadProgress: null,
+    getClassification: () => undefined,
+    getClassificationState: () => 'idle',
+    removeClassification: vi.fn(),
+    reset: vi.fn(),
+  }),
 }));
 
 afterEach(() => {
@@ -36,6 +48,32 @@ it('renders a channel for each track', () => {
   // Each channel renders a mute/solo button
   const channelButtons = getAllByTitle('On');
   expect(channelButtons).toHaveLength(3);
+});
+
+it('closes other instrument dropdowns when one opens', async () => {
+  const user = userEvent.setup();
+  trackService.createSignals('track-1');
+  trackService.createSignals('track-2');
+  const tracks = [
+    mockTrack({ trackId: 'track-1', index: 0, instrument: 'guitar' }),
+    mockTrack({ trackId: 'track-2', index: 1, instrument: 'drums' }),
+  ];
+
+  render(<Mixer tracks={tracks} />);
+
+  const triggers = screen.getAllByRole('button', { name: /Guitar|Drums/ });
+  const guitarTrigger = triggers.find((t) => t.title === 'Guitar')!;
+  const drumsTrigger = triggers.find((t) => t.title === 'Drums')!;
+
+  // Open guitar channel's dropdown
+  await user.click(guitarTrigger);
+  const menus = screen.getAllByRole('menu');
+  expect(menus).toHaveLength(1);
+
+  // Open drums channel's dropdown — guitar's should close
+  await user.click(drumsTrigger);
+  const menusAfter = screen.getAllByRole('menu');
+  expect(menusAfter).toHaveLength(1);
 });
 
 it('marks channel as muted via mute signal', () => {


### PR DESCRIPTION
## Summary
- Set `modal={false}` on the instrument `DropdownMenu` in Channel to prevent Radix's default modal overlay from blocking pointer events on dropdown items and other channel triggers
- Lift instrument dropdown open state from individual Channels to Mixer, ensuring only one dropdown is open at a time — opening one automatically closes any other
- Use functional state updater in the open change handler to correctly resolve close/open race conditions when switching between dropdowns

## Test plan
- [x] Unit test: selecting an instrument from the dropdown dispatches `SET_INSTRUMENT` (Channel.test.tsx)
- [x] Unit test: opening one channel's dropdown closes another channel's dropdown (Mixer.test.tsx)
- [x] All 955 unit tests pass
- [x] All 88 e2e tests pass
- [x] Build and lint pass

https://claude.ai/code/session_01EH9nuXuYtHwTu8odQxFMjR