### PR TITLE
Flip scroll axis and playhead to vertical (#359)

### DIFF
--- a/src/components/workstation/Timeline.css
+++ b/src/components/workstation/Timeline.css
@@ -4,8 +4,8 @@
   grid-template-rows: 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
-  padding-left: calc(var(--cursor-position) * 100vw);
-  padding-right: calc((1 - var(--cursor-position)) * 100vw);
+  padding-top: calc(var(--cursor-position) * 100vh);
+  padding-bottom: calc((1 - var(--cursor-position)) * 100vh);
 }
 
 .timeline__track {

--- a/src/components/workstation/ZoomControls.css
+++ b/src/components/workstation/ZoomControls.css
@@ -1,7 +1,7 @@
 .zoom-controls {
   position: absolute;
   right: 16px;
-  bottom: 28px;
+  top: 8px;
   display: none;
   flex-direction: column;
   gap: 4px;

--- a/src/components/workstation/scrubber/PlasmaPlayhead.tsx
+++ b/src/components/workstation/scrubber/PlasmaPlayhead.tsx
@@ -12,7 +12,7 @@ export type PlasmaPlayheadHandle = {
   render: (
     frequencyData: Uint8Array | null,
     loudness: number,
-    scrollLeft: number,
+    scrollPosition: number,
     trackFrequencyInputs: TrackFrequencyInput[],
   ) => void;
   renderIdle: () => void;
@@ -35,7 +35,7 @@ const PlasmaPlayhead = forwardRef<PlasmaPlayheadHandle, PlasmaPlayheadProps>(
       render(
         frequencyData: Uint8Array | null,
         loudness: number,
-        scrollLeft: number,
+        scrollPosition: number,
         trackFrequencyInputs: TrackFrequencyInput[],
       ) {
         const canvas = canvasRef.current;
@@ -57,7 +57,7 @@ const PlasmaPlayhead = forwardRef<PlasmaPlayheadHandle, PlasmaPlayheadProps>(
           loudness,
           canvas.height,
           PLASMA_WIDTH,
-          scrollLeft,
+          scrollPosition,
           centerX,
           now,
           deltaTime,

--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -1,46 +1,48 @@
 .scrubber {
   flex: 1;
   display: flex;
+  flex-direction: column;
   width: 100vw;
   position: relative;
 }
 
 .scrubber--firefox-scroll-fix {
   /* Fix for flex scroll bug in Firefox https://stackoverflow.com/a/28639686 */
-  min-width: 0;
+  min-height: 0;
 }
 
 .scrubber__timeline {
   display: flex;
-  min-width: 100vw;
-  padding: var(--timeline-margin) 0;
-  overflow-x: scroll;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 0 0;
+  overflow-y: scroll;
 }
 
 .scrubber__shade {
   position: absolute;
   top: 0;
-  bottom: var(--timeline-margin);
+  bottom: var(--timeline-margin-bottom);
   left: 0;
   right: 0;
-  padding-top: var(--timeline-margin);
+  padding-top: var(--timeline-margin-top);
   pointer-events: none;
 }
 
 .scrubber__cursor {
   position: absolute;
-  top: 0;
-  left: calc(var(--cursor-position) * 100vw - 120px);
-  bottom: var(--timeline-margin);
-  padding-top: var(--timeline-margin);
-  width: 240px;
+  top: calc(var(--cursor-position) * 100vh - 120px);
+  left: 0;
+  right: 0;
+  padding-top: var(--timeline-margin-top);
+  height: 240px;
   pointer-events: none;
 }
 
 .scrubber__rewind {
   position: absolute;
   left: 8px;
-  bottom: 28px;
+  top: 8px;
 }
 
 .scrubber__rewind--hidden {
@@ -51,9 +53,9 @@
 .shade {
   height: 100%;
   background-image: linear-gradient(
-    to right,
+    to bottom,
     rgb(var(--shade-color)),
-    rgba(var(--shade-color), 0) 75%,
+    rgba(var(--shade-color), 0) 25%,
     rgba(var(--shade-color), 0.8) 75%,
     rgb(var(--shade-color)) 100%
   );

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -408,6 +408,6 @@ it('syncs timeline scroll position via imperative handle', () => {
     ref.current!.syncScrollToTime(2.5);
   });
 
-  // scrollLeft = time * pixelsPerSecond = 2.5 * 200 = 500
-  expect(timeline.scrollLeft).toBe(500);
+  // scrollTop = time * pixelsPerSecond = 2.5 * 200 = 500
+  expect(timeline.scrollTop).toBe(500);
 });

--- a/src/components/workstation/scrubber/plasmaRenderer.ts
+++ b/src/components/workstation/scrubber/plasmaRenderer.ts
@@ -420,7 +420,7 @@ function renderBeamToImageData(
 function renderEtchMarksToImageData(
   imageData: ImageData,
   state: PlasmaState,
-  scrollLeft: number,
+  scrollPosition: number,
   playheadScreenX: number,
   now: number,
 ): void {
@@ -432,7 +432,9 @@ function renderEtchMarksToImageData(
     const alpha = mark.intensity * fade * 0.35;
     if (alpha < 0.01) continue;
 
-    const screenX = Math.round(playheadScreenX - (scrollLeft - mark.scrollPx));
+    const screenX = Math.round(
+      playheadScreenX - (scrollPosition - mark.scrollPx),
+    );
     if (screenX < -1 || screenX > width + 1) continue;
 
     for (let dx = -1; dx <= 1; dx++) {
@@ -567,7 +569,7 @@ export function renderPlasmaFrame(
   loudness: number,
   height: number,
   canvasWidth: number,
-  scrollLeft: number,
+  scrollPosition: number,
   playheadScreenX: number,
   now: number,
   deltaTime: number,
@@ -579,7 +581,7 @@ export function renderPlasmaFrame(
   const isBeat = updateBeatDetection(state, loudness, deltaTime);
   if (isBeat) {
     spawnSparks(state, playheadScreenX, height, loudness);
-    stampEtchMark(state, scrollLeft, loudness, now);
+    stampEtchMark(state, scrollPosition, loudness, now);
   }
   updateSparks(state, deltaTime);
   pruneEtchMarks(state, now);
@@ -619,7 +621,7 @@ export function renderPlasmaFrame(
   renderEtchMarksToImageData(
     imageData,
     state,
-    scrollLeft,
+    scrollPosition,
     playheadScreenX,
     now,
   );

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -23,7 +23,7 @@ type UseScrubberOptions = {
   tracks: Track[];
 };
 
-// Keep in sync with --timeline-margin in index.css
+// Keep in sync with --timeline-margin-top / --timeline-margin-bottom in index.css
 const TIMELINE_MARGIN = 40;
 const SCROLL_DEBOUNCE_MS = 200;
 
@@ -80,9 +80,9 @@ export function useScrubber({
     (time: number) => {
       if (timelineScrollRef.current) {
         const scrollPosition = Math.trunc(time * pixelsPerSecond);
-        if (timelineScrollRef.current.scrollLeft !== scrollPosition) {
+        if (timelineScrollRef.current.scrollTop !== scrollPosition) {
           isProgrammaticScrollRef.current = true;
-          timelineScrollRef.current.scrollLeft = scrollPosition;
+          timelineScrollRef.current.scrollTop = scrollPosition;
         }
         setIsRewindButtonHidden(scrollPosition < 10);
       }
@@ -134,24 +134,24 @@ export function useScrubber({
             const color = track.color ?? { r: 100, g: 200, b: 255 };
             return { r: color.r, g: color.g, b: color.b, data: frequencyData };
           });
-        const scrollLeft = timelineScrollRef.current?.scrollLeft ?? 0;
+        const scrollTop = timelineScrollRef.current?.scrollTop ?? 0;
         plasmaRef.current?.render(
           frequencyData,
           currentLoudness,
-          scrollLeft,
+          scrollTop,
           trackFrequencyInputs,
         );
 
         // Skip end-of-scroll detection while recording — the recording
-        // spectrogram grows its container width progressively, so scrollWidth
-        // can momentarily equal clientWidth before new content is laid out.
+        // spectrogram grows its container height progressively, so scrollHeight
+        // can momentarily equal clientHeight before new content is laid out.
         // Stopping playback here would freeze transportTime updates and halt
         // the live spectrogram scroll.
         if (timelineScrollRef.current && !recording.isActivelyRecording) {
           const isEndOfScroll =
-            timelineScrollRef.current.scrollLeft +
-              timelineScrollRef.current.clientWidth >=
-            timelineScrollRef.current.scrollWidth;
+            timelineScrollRef.current.scrollTop +
+              timelineScrollRef.current.clientHeight >=
+            timelineScrollRef.current.scrollHeight;
           if (isEndOfScroll) {
             playback.rewind();
             return;
@@ -180,7 +180,7 @@ export function useScrubber({
 
   const setTransportTimeFromScroll = () => {
     if (timelineScrollRef.current) {
-      const scrollPosition = timelineScrollRef.current.scrollLeft;
+      const scrollPosition = timelineScrollRef.current.scrollTop;
       const time = scrollPosition / pixelsPerSecond;
       playback.seekTo(time);
     }
@@ -224,7 +224,7 @@ export function useScrubber({
     }
 
     if (timelineScrollRef.current) {
-      toggleRewindButton(timelineScrollRef.current.scrollLeft);
+      toggleRewindButton(timelineScrollRef.current.scrollTop);
     }
 
     if (recording.isActivelyRecording) return;

--- a/src/components/workstation/spectrogram/Spectrogram.css
+++ b/src/components/workstation/spectrogram/Spectrogram.css
@@ -6,14 +6,14 @@
 .spectrogram__canvas {
   grid-area: 1 / 1;
   position: sticky;
-  left: 0;
+  top: 0;
   display: block;
 }
 
 .spectrogram__overlay {
   grid-area: 1 / 1;
   position: sticky;
-  left: 0;
+  top: 0;
   display: block;
   pointer-events: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -110,9 +110,10 @@ body {
 }
 
 html {
-  /* Timeline layout: the cursor sits at 75% of viewport width */
-  --cursor-position: 0.75;
-  --timeline-margin: 40px;
+  /* Timeline layout: the playhead sits at 25% from the top of the viewport */
+  --cursor-position: 0.25;
+  --timeline-margin-top: 40px;
+  --timeline-margin-bottom: 40px;
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Summary
- Reoriented the timeline from horizontal to vertical scrolling, with the playhead positioned at 25% from the top of the viewport
- Updated all scroll logic (`scrollLeft` → `scrollTop`, `clientWidth` → `clientHeight`, `scrollWidth` → `scrollHeight`) in `useScrubber`
- Flipped CSS: shade gradient direction, cursor positioning, timeline padding axis, spectrogram sticky positioning, and scroll overflow direction
- Split `--timeline-margin` into `--timeline-margin-top` and `--timeline-margin-bottom` for independent control
- Renamed `scrollLeft` parameter to `scrollPosition` in plasma renderer for axis-agnostic naming

**Note:** Spectrogram content is still drawn in the old (horizontal) orientation — this is expected. Transposing the spectrogram rendering is covered by #360.

Closes #359

## Test plan
- [x] All 947 unit tests pass
- [x] ESLint passes
- [ ] Verify timeline scrolls vertically in browser
- [ ] Verify playhead overlay is at 25% from top of viewport
- [ ] Verify shade gradient darkens top and bottom edges
- [ ] Verify scrubbing (click/drag) seeks based on vertical position
- [ ] Verify playback auto-scrolls downward
- [ ] Verify rewind scrolls to top
- [ ] Verify Ctrl+wheel zooms without scrolling; plain wheel scrolls without zooming

https://claude.ai/code/session_01Eh2i3XDxKHrWv3jwoYxZ4G