### PR TITLE
Speed up e2e tests by blocking ONNX downloads and removing blind waits

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/dragndrop.spec.ts
+++ b/e2e/dragndrop.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared Playwright fixtures that extend the base `test` object.
+ *
+ * All e2e tests should import `{ test, expect }` from this module instead of
+ * `@playwright/test` so the shared fixtures are automatically applied.
+ *
+ * Current fixtures:
+ * - **blockModelRequests** (auto, per-page): Intercepts `/models/*.onnx`
+ *   requests and returns an empty 200 response. This prevents every test that
+ *   uploads audio from downloading ~50 MB of ONNX classification models from
+ *   essentia.upf.edu, which would otherwise happen because AudioService
+ *   fires classification on every track creation.
+ */
+import { test as base, expect } from '@playwright/test';
+
+export { expect };
+
+export const test = base.extend<{ blockModelRequests: void }>({
+  // eslint-disable-next-line no-empty-pattern
+  blockModelRequests: [async ({ page }, use) => {
+    await page.route('**/models/*.onnx', (route) =>
+      route.fulfill({ status: 200, body: '' }),
+    );
+    await use();
+  }, { auto: true }],
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('Home page', () => {
   test('displays title and Create Project button, navigates to project', async ({

--- a/e2e/mixer-reorder.spec.ts
+++ b/e2e/mixer-reorder.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('Navigation', () => {
   test('shows a 404 message for unknown routes', async ({ page }) => {

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/project.spec.ts
+++ b/e2e/project.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('Project page', () => {
   test('header shows back button, upload button, and overflow menu', async ({

--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -89,7 +89,10 @@ async function ensureAudioContextRunning(
  */
 async function recordAudio(
   page: import('@playwright/test').Page,
-  durationMs = 2000,
+  {
+    durationMs = 1000,
+    expectedTrackCount = 1,
+  }: { durationMs?: number; expectedTrackCount?: number } = {},
 ) {
   const recordButton = page.getByTitle('Record');
 
@@ -104,8 +107,12 @@ async function recordAudio(
   await page.waitForTimeout(durationMs);
   await recordButton.click();
 
-  // Wait for async track creation (decode + channel setup)
-  await page.waitForTimeout(3000);
+  // Wait for async track creation (decode + channel setup) by polling
+  // for the expected number of tracks in the DOM.
+  await expect(page.locator('.timeline__track')).toHaveCount(
+    expectedTrackCount,
+    { timeout: 5000 },
+  );
 }
 
 test.describe('Recording', () => {
@@ -126,15 +133,17 @@ test.describe('Recording', () => {
     // Track has a visible spectrogram canvas with content
     const canvas = timelineTrack.locator('canvas');
     await expect(canvas.first()).toBeVisible({ timeout: 5000 });
-    const hasContent = await canvas
-      .first()
-      .evaluate((el: HTMLCanvasElement) => {
-        const ctx = el.getContext('2d');
-        if (!ctx) return false;
-        const imageData = ctx.getImageData(0, 0, el.width, el.height);
-        return imageData.data.some((value, i) => i % 4 === 3 && value > 0);
-      });
-    expect(hasContent).toBe(true);
+    await expect(async () => {
+      const hasContent = await canvas
+        .first()
+        .evaluate((el: HTMLCanvasElement) => {
+          const ctx = el.getContext('2d');
+          if (!ctx) return false;
+          const imageData = ctx.getImageData(0, 0, el.width, el.height);
+          return imageData.data.some((value, i) => i % 4 === 3 && value > 0);
+        });
+      expect(hasContent).toBe(true);
+    }).toPass({ timeout: 5000 });
 
     // Transport is rewound to the start after recording stops
     const scrollBefore = await page
@@ -163,10 +172,9 @@ test.describe('Recording with existing tracks', () => {
     await fileInput.setInputFiles(SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
-    await recordAudio(page, 1500);
-
-    await expect(page.locator('.timeline__track')).toHaveCount(2, {
-      timeout: 5000,
+    await recordAudio(page, {
+      durationMs: 1500,
+      expectedTrackCount: 2,
     });
 
     await page.getByTitle('Play').click();

--- a/e2e/scrubber-seek.spec.ts
+++ b/e2e/scrubber-seek.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -250,7 +250,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
       contentInfo.paddingLeft + contentInfo.spectrogramWidth,
     );
 
-    const numSteps = 20;
+    const numSteps = 10;
     const results: Array<{ scrollPos: number; ratio: number }> = [];
 
     for (let i = 0; i <= numSteps; i++) {

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/e2e/visual.spec.ts
+++ b/e2e/visual.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { test, expect } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
## Summary
- **Block ONNX model downloads** in all non-classification e2e tests via a shared Playwright fixture (`e2e/fixtures.ts`) that intercepts `/models/*.onnx` requests. Every test that uploads audio was triggering ~50 MB of ONNX classification model downloads from `essentia.upf.edu`, since `AudioService` fires classification on every track creation.
- **Replace `waitForTimeout(3000)`** in recording tests with DOM-based polling (`expect .timeline__track count`), eliminating a 3-second blind wait per recording test.
- **Reduce recording duration** from 2s to 1s (sufficient for audio capture).
- **Reduce spectrogram scan steps** from 20 to 10 in the coverage consistency test.
- **Poll for canvas content** with `toPass()` instead of a one-shot check to handle async spectrogram rendering.

Total suite time: **~50s → ~34s (32% faster)**.

## Test plan
- [x] All 41 e2e tests pass
- [x] Classification test still uses `@playwright/test` directly (not the shared fixture), so it continues testing real model loading and CORS behavior
- [x] Recording tests properly wait for DOM state instead of blind timeouts
- [x] Spectrogram coverage test still validates coverage across the full scroll range (10 positions instead of 20)

https://claude.ai/code/session_01XR1dHnD7n8AGq1j1iPGf9N