### PR TITLE
Adapt spectrogram layout for vertical timeline

### DIFF
--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -145,11 +145,11 @@ const Spectrogram = ({
 
   const { opacity } = useTrackVolume(trackId);
 
-  // For non-recording tracks, width is set from audio buffer duration.
-  // For recording tracks, width is updated in the rAF loop directly on the
+  // For non-recording tracks, height is set from audio buffer duration.
+  // For recording tracks, height is updated in the rAF loop directly on the
   // DOM node to avoid React re-renders at 60fps.
-  const containerWidth = isRecordingTrack ? 0 : duration * pixelsPerSecond;
-  const containerMarginLeft = startTime * pixelsPerSecond;
+  const containerHeight = isRecordingTrack ? 0 : duration * pixelsPerSecond;
+  const containerMarginTop = startTime * pixelsPerSecond;
 
   return (
     <div
@@ -157,8 +157,8 @@ const Spectrogram = ({
       className="spectrogram"
       style={{
         opacity,
-        width: containerWidth,
-        marginLeft: containerMarginLeft,
+        height: containerHeight,
+        marginTop: containerMarginTop,
       }}
     >
       <canvas ref={canvasRef} className="spectrogram__canvas" />
@@ -192,9 +192,9 @@ function drawRecordingFrame(
   );
   const contentWidth = elapsed * pixelsPerSecond;
 
-  // Update container width and offset directly to avoid React re-renders
-  container.style.width = `${contentWidth}px`;
-  container.style.marginLeft = `${recordingStartTime * pixelsPerSecond}px`;
+  // Update container height and offset directly to avoid React re-renders
+  container.style.height = `${contentWidth}px`;
+  container.style.marginTop = `${recordingStartTime * pixelsPerSecond}px`;
 
   // Accumulate a new frame while recording is active
   if (isRecActive) {
@@ -207,15 +207,15 @@ function drawRecordingFrame(
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
 
-  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
-  const paddingLeft = timeline
-    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+  const paddingTop = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
-  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
+  const containerMarginTop = parseFloat(container.style.marginTop) || 0;
   const maxContentOffset = Math.max(0, contentWidth - viewportWidth);
   const contentOffset = Math.min(
-    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
+    Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
@@ -263,20 +263,20 @@ function drawTilesFrame(
     tileCount: number;
   }>,
 ): void {
-  const containerWidth = duration * pixelsPerSecond;
+  const contentLength = duration * pixelsPerSecond;
 
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
 
-  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
-  const paddingLeft = timeline
-    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+  const paddingTop = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
-  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
-  const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
+  const containerMarginTop = parseFloat(container.style.marginTop) || 0;
+  const maxContentOffset = Math.max(0, contentLength - viewportWidth);
   const contentOffset = Math.min(
-    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
+    Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
@@ -342,20 +342,20 @@ function drawMelodyOverlay(
     noteCount: number;
   }>,
 ): void {
-  const containerWidth = duration * pixelsPerSecond;
+  const contentLength = duration * pixelsPerSecond;
 
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
 
-  const scrollLeft = scrollParent?.scrollLeft ?? 0;
+  const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
-  const paddingLeft = timeline
-    ? parseFloat(getComputedStyle(timeline).paddingLeft) || 0
+  const paddingTop = timeline
+    ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
-  const containerMarginLeft = parseFloat(container.style.marginLeft) || 0;
-  const maxContentOffset = Math.max(0, containerWidth - viewportWidth);
+  const containerMarginTop = parseFloat(container.style.marginTop) || 0;
+  const maxContentOffset = Math.max(0, contentLength - viewportWidth);
   const contentOffset = Math.min(
-    Math.max(0, scrollLeft - paddingLeft - containerMarginLeft),
+    Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -246,7 +246,7 @@ it('does not trigger analysis without audio buffer', () => {
   expect(mockAnalyse).not.toHaveBeenCalled();
 });
 
-it('sets container width from duration and pixelsPerSecond', () => {
+it('sets container height from duration and pixelsPerSecond', () => {
   const duration = 2.5;
   const audioBuffer = { duration } as AudioBuffer;
   mockRetrieveAudioBuffer.mockReturnValue(audioBuffer);
@@ -254,8 +254,8 @@ it('sets container width from duration and pixelsPerSecond', () => {
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  // containerWidth = duration * pixelsPerSecond = 2.5 * 200 = 500
-  expect(spectrogram).toHaveStyle({ width: '500px' });
+  // containerHeight = duration * pixelsPerSecond = 2.5 * 200 = 500
+  expect(spectrogram).toHaveStyle({ height: '500px' });
 });
 
 it('offsets container by startTime for tracks recorded at non-zero position', () => {
@@ -268,8 +268,8 @@ it('offsets container by startTime for tracks recorded at non-zero position', ()
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  // marginLeft = startTime * pixelsPerSecond = 3.0 * 200 = 600
-  expect(spectrogram).toHaveStyle({ marginLeft: '600px' });
+  // marginTop = startTime * pixelsPerSecond = 3.0 * 200 = 600
+  expect(spectrogram).toHaveStyle({ marginTop: '600px' });
 });
 
 it('has no margin offset for tracks starting at position zero', () => {
@@ -281,16 +281,16 @@ it('has no margin offset for tracks starting at position zero', () => {
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  expect(spectrogram).toHaveStyle({ marginLeft: '0px' });
+  expect(spectrogram).toHaveStyle({ marginTop: '0px' });
 });
 
-it('sets container width to zero when no audio buffer', () => {
+it('sets container height to zero when no audio buffer', () => {
   mockRetrieveAudioBuffer.mockReturnValue(undefined);
 
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  expect(spectrogram).toHaveStyle({ width: '0px' });
+  expect(spectrogram).toHaveStyle({ height: '0px' });
 });
 
 describe('recording mode', () => {
@@ -327,11 +327,11 @@ describe('recording mode', () => {
     expect(mockAnalyse).not.toHaveBeenCalled();
   });
 
-  it('sets initial container width to zero in recording mode', () => {
+  it('sets initial container height to zero in recording mode', () => {
     const { container } = render(<Spectrogram {...recordingProps} />);
 
     const spectrogram = container.querySelector('.spectrogram');
-    expect(spectrogram).toHaveStyle({ width: '0px' });
+    expect(spectrogram).toHaveStyle({ height: '0px' });
   });
 
   it('offsets container by recording start time during overdub', () => {
@@ -364,8 +364,8 @@ describe('recording mode', () => {
     callback?.();
 
     const spectrogram = container.querySelector('.spectrogram');
-    // marginLeft = recordingStartTime * pixelsPerSecond = 3.0 * 200 = 600
-    expect(spectrogram).toHaveStyle({ marginLeft: '600px' });
+    // marginTop = recordingStartTime * pixelsPerSecond = 3.0 * 200 = 600
+    expect(spectrogram).toHaveStyle({ marginTop: '600px' });
 
     vi.restoreAllMocks();
   });
@@ -408,13 +408,13 @@ describe('recording mode', () => {
     callback?.();
 
     const spectrogram = container.querySelector('.spectrogram');
-    // elapsed = getEngineTime() - 0 = 2.0, width = 2.0 * 200 = 400
-    expect(spectrogram).toHaveStyle({ width: '400px' });
+    // elapsed = getEngineTime() - 0 = 2.0, height = 2.0 * 200 = 400
+    expect(spectrogram).toHaveStyle({ height: '400px' });
 
     vi.restoreAllMocks();
   });
 
-  it('updates container width based on elapsed recording time', () => {
+  it('updates container height based on elapsed recording time', () => {
     recordingService.arm();
     recordingService.startRecording();
     vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(2.0);
@@ -444,8 +444,8 @@ describe('recording mode', () => {
     callback?.();
 
     const spectrogram = container.querySelector('.spectrogram');
-    // elapsed = 2.0 - 0 = 2.0, width = 2.0 * 200 = 400
-    expect(spectrogram).toHaveStyle({ width: '400px' });
+    // elapsed = 2.0 - 0 = 2.0, height = 2.0 * 200 = 400
+    expect(spectrogram).toHaveStyle({ height: '400px' });
 
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary

- Applies the `Spectrogram.tsx` vertical layout changes from closed PR #369 that were not carried over to #370
- Container sizing switches from `width`/`marginLeft` to `height`/`marginTop` so spectrograms create vertical scroll extent
- All three draw functions (`drawRecordingFrame`, `drawTilesFrame`, `drawMelodyOverlay`) now read `scrollTop`/`paddingTop` instead of `scrollLeft`/`paddingLeft` for correct content offset in the vertical scroller
- Renames `containerWidth` → `contentLength` in `drawTilesFrame`/`drawMelodyOverlay` for clarity

Addresses gap identified in review of #364/#369 vs #370 (issue #359).

## Test plan

- [x] All 785 unit tests pass
- [ ] Verify spectrogram containers create vertical scroll extent when tracks are loaded
- [ ] Verify viewport-based tile rendering updates correctly when scrolling vertically

https://claude.ai/code/session_016JnkLGGUUHFm2wBK38W9sr