### PR TITLE
Add neon rainbow gradient to home page header

### DIFF
--- a/src/components/home/HomePage.css
+++ b/src/components/home/HomePage.css
@@ -9,6 +9,18 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  background: linear-gradient(
+    135deg,
+    hsl(300, 100%, 50%) 0%,
+    hsl(270, 100%, 55%) 15%,
+    hsl(240, 100%, 60%) 30%,
+    hsl(180, 100%, 50%) 45%,
+    hsl(120, 100%, 45%) 60%,
+    hsl(60, 100%, 50%) 75%,
+    hsl(0, 100%, 55%) 90%,
+    hsl(330, 100%, 50%) 100%
+  );
+  border-radius: 0 0 16px 16px;
 }
 
 .home__header-row {
@@ -25,14 +37,16 @@
 
 .home__header-actions [data-slot='button'] {
   border-radius: 50%;
-  background-color: var(--secondary);
+  background-color: rgba(0, 0, 0, 0.25);
+  color: white;
 }
 
 .home__title {
   font-size: 28px;
   font-weight: 700;
-  color: var(--foreground);
+  color: white;
   margin: 0;
+  text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
 }
 
 .home__body {


### PR DESCRIPTION
## Summary
- Added a neon rainbow gradient background (`linear-gradient` at 135deg) to the `.home__header` spanning magenta, purple, blue, cyan, green, yellow, red
- Updated title color to white with a soft glow `text-shadow` for contrast against the gradient
- Changed header action buttons to use semi-transparent dark backgrounds (`rgba(0,0,0,0.25)`) with white icon color
- Added `border-radius: 0 0 16px 16px` to the header for a smooth transition into the content area

## Test plan
- [x] All 18 existing home page unit tests pass
- [ ] Visually verify the gradient renders correctly on the home page in both light and dark modes

https://claude.ai/code/session_018ehv8A1MYNvMf5bMjRR6FM