### PR TITLE
Transpose spectrogram rendering for vertical timeline (#360)

### DIFF
--- a/src/components/workstation/Timeline.tsx
+++ b/src/components/workstation/Timeline.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { useContainerHeight } from '../../hooks/useContainerHeight';
 import { useRecordingService } from '../../hooks/useRecordingService';
 import { useTrackService } from '../../hooks/useTrackService';
 import { type Track, type TrackColor, type TrackId } from '../../types/track';
@@ -21,7 +20,6 @@ const Timeline = ({
 }: TimelineProps) => {
   const { isRecording } = useRecordingService();
   const { mutedTracks, focusedTracks } = useTrackService();
-  const { containerRef, height } = useContainerHeight();
 
   const recordingTrack: Track = {
     trackId: RECORDING_TRACK_ID,
@@ -31,36 +29,27 @@ const Timeline = ({
   };
 
   return (
-    <div ref={containerRef} className="timeline">
-      {height > 0 && (
-        <>
-          {tracks.map((track) => {
-            const timelineTrackClass = getTimelineTrackClass(
-              track,
-              mutedTracks,
-              focusedTracks,
-            );
-            return (
-              <div key={track.trackId} className={timelineTrackClass}>
-                <Spectrogram
-                  height={height}
-                  pixelsPerSecond={pixelsPerSecond}
-                  track={track}
-                />
-              </div>
-            );
-          })}
-          {isRecording && (
-            <div className="timeline__track">
-              <Spectrogram
-                height={height}
-                pixelsPerSecond={pixelsPerSecond}
-                track={recordingTrack}
-                isRecordingTrack
-              />
-            </div>
-          )}
-        </>
+    <div className="timeline">
+      {tracks.map((track) => {
+        const timelineTrackClass = getTimelineTrackClass(
+          track,
+          mutedTracks,
+          focusedTracks,
+        );
+        return (
+          <div key={track.trackId} className={timelineTrackClass}>
+            <Spectrogram pixelsPerSecond={pixelsPerSecond} track={track} />
+          </div>
+        );
+      })}
+      {isRecording && (
+        <div className="timeline__track">
+          <Spectrogram
+            pixelsPerSecond={pixelsPerSecond}
+            track={recordingTrack}
+            isRecordingTrack
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/workstation/spectrogram/PianoRollRenderer.ts
+++ b/src/components/workstation/spectrogram/PianoRollRenderer.ts
@@ -11,7 +11,9 @@
  *   binIndex = 24 × log2(freq / 32.7)
  *
  * Each semitone spans 2 CQT bins (24 bins/octave ÷ 12 semitones).
- * Bin 0 is at the bottom of the canvas, matching the spectrogram orientation.
+ *
+ * Transposed for vertical timeline: frequency maps to X axis (bin 0 on
+ * the left = low frequency) and time maps to Y axis (top-to-bottom).
  */
 
 import { type MelodyNote } from '../../../services/MelodyExtractor';
@@ -84,13 +86,13 @@ export function midiNoteToBin(midiNote: number): number {
 export type PianoRollViewport = {
   /** Pixels per second (zoom level). */
   pixelsPerSecond: number;
-  /** Horizontal scroll offset in content pixels. */
+  /** Vertical scroll offset in content pixels (time axis). */
   contentOffset: number;
-  /** Canvas / viewport width in pixels. */
-  viewportWidth: number;
-  /** Canvas height in pixels. */
-  canvasHeight: number;
-  /** Total number of CQT frequency bins (determines y-axis scale). */
+  /** Canvas / viewport height in pixels (time axis). */
+  viewportHeight: number;
+  /** Canvas width in pixels (frequency axis). */
+  canvasWidth: number;
+  /** Total number of CQT frequency bins (determines x-axis scale). */
   frequencyBinCount: number;
   /** Current playhead time in seconds (-1 or undefined = no glow effect). */
   playheadTime?: number;
@@ -102,8 +104,9 @@ export type PianoRollViewport = {
  * Notes have a gradient fill for a 3D appearance and a distinct border.
  * Notes intersecting the playhead receive a bright glow effect.
  *
- * Only notes within the visible viewport are rendered (horizontal culling).
- * Vertical positions are mapped from MIDI note → CQT bin → canvas pixel.
+ * Transposed for vertical timeline: time maps to Y axis (vertical culling),
+ * frequency maps to X axis (MIDI note → CQT bin → canvas x-coordinate,
+ * bin 0 on the left = low frequency).
  */
 export function drawPianoRoll(
   ctx: CanvasRenderingContext2D,
@@ -114,17 +117,17 @@ export function drawPianoRoll(
   const {
     pixelsPerSecond,
     contentOffset,
-    viewportWidth,
-    canvasHeight,
+    viewportHeight,
+    canvasWidth,
     frequencyBinCount,
     playheadTime,
   } = viewport;
 
   if (notes.length === 0 || frequencyBinCount === 0) return;
 
-  const pixelsPerBin = canvasHeight / frequencyBinCount;
+  const pixelsPerBin = canvasWidth / frequencyBinCount;
   const viewStartTime = contentOffset / pixelsPerSecond;
-  const viewEndTime = (contentOffset + viewportWidth) / pixelsPerSecond;
+  const viewEndTime = (contentOffset + viewportHeight) / pixelsPerSecond;
 
   const { r, g, b } = color;
   const hasPlayhead =
@@ -138,20 +141,19 @@ export function drawPianoRoll(
       continue;
     }
 
-    const x = note.startTime * pixelsPerSecond - contentOffset;
-    const width = (note.endTime - note.startTime) * pixelsPerSecond;
+    // Time maps to Y axis (top-to-bottom)
+    const y = note.startTime * pixelsPerSecond - contentOffset;
+    const height = (note.endTime - note.startTime) * pixelsPerSecond;
 
-    // Map MIDI note to CQT bin, then to canvas y-coordinate.
-    // Bin 0 is at the bottom of the canvas (row = canvasHeight - 1).
+    // Map MIDI note to CQT bin, then to canvas x-coordinate.
+    // Bin 0 is on the left (low frequency).
     const binIndex = midiNoteToBin(note.midiNote);
-    const noteTopBin = binIndex + NOTE_HEIGHT_BINS / 2;
-    const noteBottomBin = binIndex - NOTE_HEIGHT_BINS / 2;
+    const noteLeftBin = binIndex - NOTE_HEIGHT_BINS / 2;
 
-    // Canvas y: top of canvas = highest bin, bottom = bin 0
-    const y = canvasHeight - noteTopBin * pixelsPerBin;
-    const height = (noteTopBin - noteBottomBin) * pixelsPerBin;
+    const x = noteLeftBin * pixelsPerBin;
+    const width = NOTE_HEIGHT_BINS * pixelsPerBin;
 
-    if (height < 1) continue;
+    if (width < 1) continue;
 
     const isActive =
       hasPlayhead &&
@@ -162,18 +164,7 @@ export function drawPianoRoll(
 
     // Draw pitch bend line if the note has bend data
     if (note.pitchBends && note.pitchBends.length > 1) {
-      drawPitchBendLine(
-        ctx,
-        x,
-        width,
-        canvasHeight,
-        pixelsPerBin,
-        note,
-        r,
-        g,
-        b,
-        isActive,
-      );
+      drawPitchBendLine(ctx, y, height, pixelsPerBin, note, r, g, b, isActive);
     }
   }
 }
@@ -182,14 +173,13 @@ export function drawPianoRoll(
  * Draws a pitch bend line through the center of a note.
  *
  * Each pitch bend value represents a deviation in semitones from the note's
- * base pitch. The line traces these deviations across the note duration,
- * making slides, vibratos, and bends visible on the piano roll.
+ * base pitch. The line traces these deviations along the note duration
+ * (Y axis), with horizontal offsets for pitch deviation (X axis).
  */
 function drawPitchBendLine(
   ctx: CanvasRenderingContext2D,
-  noteX: number,
-  noteWidth: number,
-  canvasHeight: number,
+  noteY: number,
+  noteHeight: number,
   pixelsPerBin: number,
   note: MelodyNote,
   r: number,
@@ -199,11 +189,11 @@ function drawPitchBendLine(
 ): void {
   const bends = note.pitchBends!;
   const bendCount = bends.length;
-  const pxPerBend = noteWidth / bendCount;
+  const pxPerBend = noteHeight / bendCount;
 
   // Each semitone = 2 CQT bins; bend values are in semitones
   const baseBin = midiNoteToBin(note.midiNote);
-  const baseY = canvasHeight - baseBin * pixelsPerBin;
+  const baseX = baseBin * pixelsPerBin;
 
   const opacity = isActive ? ACTIVE_FILL_OPACITY : PITCH_BEND_OPACITY;
   ctx.save();
@@ -214,10 +204,10 @@ function drawPitchBendLine(
 
   ctx.beginPath();
   for (let i = 0; i < bendCount; i++) {
-    // Bend in semitones → vertical offset in CQT bins (2 bins/semitone)
+    // Bend in semitones → horizontal offset in CQT bins (2 bins/semitone)
     const bendBins = bends[i] * NOTE_HEIGHT_BINS;
-    const px = noteX + i * pxPerBend;
-    const py = baseY - bendBins * pixelsPerBin;
+    const px = baseX + bendBins * pixelsPerBin;
+    const py = noteY + i * pxPerBend;
     if (i === 0) {
       ctx.moveTo(px, py);
     } else {
@@ -255,8 +245,8 @@ function drawNote(
     ctx.restore();
   }
 
-  // 3D gradient fill: lighter at top, darker at bottom
-  const gradient = ctx.createLinearGradient(x, y, x, y + height);
+  // 3D gradient fill: lighter on the left, darker on the right
+  const gradient = ctx.createLinearGradient(x, y, x + width, y);
   const rTop = Math.min(255, r + HIGHLIGHT_LIGHTNESS_BOOST);
   const gTop = Math.min(255, g + HIGHLIGHT_LIGHTNESS_BOOST);
   const bTop = Math.min(255, b + HIGHLIGHT_LIGHTNESS_BOOST);
@@ -275,18 +265,18 @@ function drawNote(
   ctx.fill();
   ctx.stroke();
 
-  // Inner top highlight line for extra depth
-  drawTopHighlight(ctx, x, y, width, r, g, b, fillOpacity);
+  // Inner left highlight line for extra depth
+  drawLeftHighlight(ctx, x, y, height, r, g, b, fillOpacity);
 }
 
 /**
- * Draws a thin highlight line along the top edge of a note for a 3D bevel.
+ * Draws a thin highlight line along the left edge of a note for a 3D bevel.
  */
-function drawTopHighlight(
+function drawLeftHighlight(
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
-  width: number,
+  height: number,
   r: number,
   g: number,
   b: number,
@@ -296,8 +286,8 @@ function drawTopHighlight(
   ctx.strokeStyle = `rgba(${Math.min(255, r + 80)}, ${Math.min(255, g + 80)}, ${Math.min(255, b + 80)}, ${highlightOpacity})`;
   ctx.lineWidth = 0.5;
   ctx.beginPath();
-  ctx.moveTo(x + CORNER_RADIUS, y + 0.5);
-  ctx.lineTo(x + width - CORNER_RADIUS, y + 0.5);
+  ctx.moveTo(x + 0.5, y + CORNER_RADIUS);
+  ctx.lineTo(x + 0.5, y + height - CORNER_RADIUS);
   ctx.stroke();
 }
 

--- a/src/components/workstation/spectrogram/RecordingBuffer.ts
+++ b/src/components/workstation/spectrogram/RecordingBuffer.ts
@@ -1,17 +1,17 @@
 import { createColorMap } from '../../../services/SpectrogramTileRenderer';
 import { type TrackColor } from '../../../types/track';
 
-const INITIAL_WIDTH = 8192;
+const INITIAL_HEIGHT = 8192;
 const BYTES_PER_PIXEL = 4;
 
 /**
  * Accumulates live visualization data during recording into an
  * OffscreenCanvas buffer. Each call to addFrame() appends a single-pixel
- * column. The buffer grows automatically when full.
+ * row. The buffer grows vertically when full.
  *
- * Input data is pre-processed (dual-band merged, log-frequency mapped,
- * 0–255 byte values) by the FrequencyVisualizer service. Bins are drawn
- * bottom-to-top (bin 0 at bottom).
+ * Transposed for vertical timeline: frequency bins map to columns
+ * (X axis, bin 0 on the left = low frequency) and time frames map
+ * to rows (Y axis, appended downward).
  */
 class RecordingBuffer {
   frameCount = 0;
@@ -19,30 +19,30 @@ class RecordingBuffer {
   private canvas: OffscreenCanvas;
   private ctx: OffscreenCanvasRenderingContext2D;
   private colorMap: Uint8Array;
-  private height: number;
+  private width: number;
 
   constructor(color: TrackColor, frequencyBinCount: number) {
-    this.height = frequencyBinCount;
-    this.canvas = new OffscreenCanvas(INITIAL_WIDTH, frequencyBinCount);
+    this.width = frequencyBinCount;
+    this.canvas = new OffscreenCanvas(frequencyBinCount, INITIAL_HEIGHT);
     this.ctx = this.canvas.getContext('2d')!;
     this.colorMap = createColorMap(color);
   }
 
   addFrame(visualizationData: Uint8Array): void {
-    if (this.frameCount >= this.canvas.width) {
+    if (this.frameCount >= this.canvas.height) {
       this.grow();
     }
 
-    const col = this.frameCount;
-    const bins = Math.min(visualizationData.length, this.height);
-    const imageData = this.ctx.createImageData(1, this.height);
+    const row = this.frameCount;
+    const bins = Math.min(visualizationData.length, this.width);
+    const imageData = this.ctx.createImageData(this.width, 1);
     const pixels = imageData.data;
 
     for (let bin = 0; bin < bins; bin++) {
       const byte = visualizationData[bin];
-      // bin 0 → bottom row, last bin → top row
-      const row = this.height - 1 - bin;
-      const pixelOffset = row * BYTES_PER_PIXEL;
+      // bin 0 → left column (col 0), last bin → right column
+      const col = bin;
+      const pixelOffset = col * BYTES_PER_PIXEL;
       const colorOffset = byte * BYTES_PER_PIXEL;
 
       pixels[pixelOffset] = this.colorMap[colorOffset];
@@ -51,40 +51,40 @@ class RecordingBuffer {
       pixels[pixelOffset + 3] = this.colorMap[colorOffset + 3];
     }
 
-    this.ctx.putImageData(imageData, col, 0);
+    this.ctx.putImageData(imageData, 0, row);
     this.frameCount++;
   }
 
   /**
    * Draws a region of the recording buffer to a destination canvas,
-   * scaling from the buffer's native frequency bin height to the
-   * display height.
+   * scaling from the buffer's native frequency bin width to the
+   * display width.
    */
   drawTo(
     ctx: CanvasRenderingContext2D,
-    srcX: number,
-    srcWidth: number,
-    destX: number,
-    destWidth: number,
+    srcY: number,
+    srcHeight: number,
+    destY: number,
     destHeight: number,
+    destWidth: number,
   ): void {
-    if (this.frameCount === 0 || srcWidth <= 0) return;
+    if (this.frameCount === 0 || srcHeight <= 0) return;
     ctx.drawImage(
       this.canvas,
-      srcX,
       0,
-      srcWidth,
-      this.height,
-      destX,
+      srcY,
+      this.width,
+      srcHeight,
       0,
+      destY,
       destWidth,
       destHeight,
     );
   }
 
   private grow(): void {
-    const newWidth = this.canvas.width * 2;
-    const newCanvas = new OffscreenCanvas(newWidth, this.height);
+    const newHeight = this.canvas.height * 2;
+    const newCanvas = new OffscreenCanvas(this.width, newHeight);
     const newCtx = newCanvas.getContext('2d')!;
     newCtx.drawImage(this.canvas, 0, 0);
     this.canvas = newCanvas;

--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -14,17 +14,15 @@ import './Spectrogram.css';
 import { useSpectrogramCache } from './useSpectrogramCache';
 
 type SpectrogramProps = {
-  height: number;
   pixelsPerSecond: number;
   track: Track;
   isRecordingTrack?: boolean;
 };
 
-const TILE_WIDTH = 4096;
+const TILE_FRAMES = 4096;
 const SCROLL_CONTAINER_CLASS = '.scrubber__timeline';
 
 const Spectrogram = ({
-  height,
   pixelsPerSecond,
   track,
   isRecordingTrack = false,
@@ -58,8 +56,8 @@ const Spectrogram = ({
   const duration = audioBuffer?.duration ?? 0;
 
   const timeResolution = entry?.data.timeResolution ?? 0.025;
-  const frameDisplayWidth = pixelsPerSecond * timeResolution;
-  const tileDisplayWidth = TILE_WIDTH * frameDisplayWidth;
+  const frameDisplayHeight = pixelsPerSecond * timeResolution;
+  const tileDisplayHeight = TILE_FRAMES * frameDisplayHeight;
   const frequencyBinCount = entry?.data.frequencyBinCount ?? 0;
   const totalFrames = entry?.data.frequencyFrames.length ?? 0;
   const tiles = entry?.tiles ?? [];
@@ -105,7 +103,6 @@ const Spectrogram = ({
         recording,
         playback,
         pixelsPerSecond,
-        height,
       );
       return;
     }
@@ -116,11 +113,10 @@ const Spectrogram = ({
       canvas,
       container,
       pixelsPerSecond,
-      height,
       tiles,
       totalFrames,
-      frameDisplayWidth,
-      tileDisplayWidth,
+      frameDisplayHeight,
+      tileDisplayHeight,
       duration,
       lastDrawnRef,
     );
@@ -130,7 +126,6 @@ const Spectrogram = ({
         overlay,
         container,
         pixelsPerSecond,
-        height,
         melodyNotes,
         color,
         frequencyBinCount,
@@ -175,7 +170,6 @@ function drawRecordingFrame(
   recordingHook: ReturnType<typeof useRecordingService>,
   playbackHook: ReturnType<typeof usePlaybackService>,
   pixelsPerSecond: number,
-  height: number,
 ): void {
   if (!buffer || !visualizer) return;
 
@@ -190,10 +184,10 @@ function drawRecordingFrame(
     0,
     playbackHook.getEngineTime() - recordingStartTime,
   );
-  const contentWidth = elapsed * pixelsPerSecond;
+  const contentHeight = elapsed * pixelsPerSecond;
 
   // Update container height and offset directly to avoid React re-renders
-  container.style.height = `${contentWidth}px`;
+  container.style.height = `${contentHeight}px`;
   container.style.marginTop = `${recordingStartTime * pixelsPerSecond}px`;
 
   // Accumulate a new frame while recording is active
@@ -206,6 +200,7 @@ function drawRecordingFrame(
 
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+  const viewportHeight = scrollParent?.clientHeight ?? window.innerHeight;
 
   const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
@@ -213,17 +208,17 @@ function drawRecordingFrame(
     ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
   const containerMarginTop = parseFloat(container.style.marginTop) || 0;
-  const maxContentOffset = Math.max(0, contentWidth - viewportWidth);
+  const maxContentOffset = Math.max(0, contentHeight - viewportHeight);
   const contentOffset = Math.min(
     Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
   const needsResize =
-    canvas.width !== viewportWidth || canvas.height !== height;
+    canvas.width !== viewportWidth || canvas.height !== viewportHeight;
   if (needsResize) {
     canvas.width = viewportWidth;
-    canvas.height = height;
+    canvas.height = viewportHeight;
   }
 
   const ctx = canvas.getContext('2d');
@@ -231,31 +226,30 @@ function drawRecordingFrame(
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
   // Map buffer frames (1 frame = 1 pixel in the buffer) to display pixels.
-  // bufferFrames maps to contentWidth display pixels.
-  const framesPerPixel = buffer.frameCount / contentWidth;
-  // Clamp destination width so the buffer is never stretched beyond the
+  // bufferFrames maps to contentHeight display pixels.
+  const framesPerPixel = buffer.frameCount / contentHeight;
+  // Clamp destination height so the buffer is never stretched beyond the
   // actual content area. Without this, when the recording is shorter than
-  // the viewport the buffer was drawn across the full viewport width,
+  // the viewport the buffer was drawn across the full viewport height,
   // making the spectrogram appear to move faster than existing tracks.
-  const destWidth = Math.min(viewportWidth, contentWidth - contentOffset);
-  const srcX = Math.floor(contentOffset * framesPerPixel);
-  const srcWidth = Math.min(
-    Math.ceil(destWidth * framesPerPixel),
-    buffer.frameCount - srcX,
+  const destHeight = Math.min(viewportHeight, contentHeight - contentOffset);
+  const srcY = Math.floor(contentOffset * framesPerPixel);
+  const srcHeight = Math.min(
+    Math.ceil(destHeight * framesPerPixel),
+    buffer.frameCount - srcY,
   );
 
-  buffer.drawTo(ctx, srcX, srcWidth, 0, destWidth, height);
+  buffer.drawTo(ctx, srcY, srcHeight, 0, destHeight, viewportWidth);
 }
 
 function drawTilesFrame(
   canvas: HTMLCanvasElement,
   container: HTMLDivElement,
   pixelsPerSecond: number,
-  height: number,
   tiles: ImageBitmap[],
   totalFrames: number,
-  frameDisplayWidth: number,
-  tileDisplayWidth: number,
+  frameDisplayHeight: number,
+  tileDisplayHeight: number,
   duration: number,
   lastDrawnRef: React.MutableRefObject<{
     offset: number;
@@ -267,6 +261,7 @@ function drawTilesFrame(
 
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+  const viewportHeight = scrollParent?.clientHeight ?? window.innerHeight;
 
   const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
@@ -274,14 +269,14 @@ function drawTilesFrame(
     ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
   const containerMarginTop = parseFloat(container.style.marginTop) || 0;
-  const maxContentOffset = Math.max(0, contentLength - viewportWidth);
+  const maxContentOffset = Math.max(0, contentLength - viewportHeight);
   const contentOffset = Math.min(
     Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
   const needsResize =
-    canvas.width !== viewportWidth || canvas.height !== height;
+    canvas.width !== viewportWidth || canvas.height !== viewportHeight;
 
   const last = lastDrawnRef.current;
   if (
@@ -298,29 +293,29 @@ function drawTilesFrame(
 
   if (needsResize) {
     canvas.width = viewportWidth;
-    canvas.height = height;
+    canvas.height = viewportHeight;
   }
 
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayWidth));
+  const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayHeight));
   const lastTile = Math.min(
     tiles.length - 1,
-    Math.floor((contentOffset + viewportWidth) / tileDisplayWidth),
+    Math.floor((contentOffset + viewportHeight) / tileDisplayHeight),
   );
 
   for (let t = firstTile; t <= lastTile; t++) {
-    const tileLeftPx = t * tileDisplayWidth;
-    const drawX = tileLeftPx - contentOffset;
+    const tileTopPx = t * tileDisplayHeight;
+    const drawY = tileTopPx - contentOffset;
     const isLastTile = t === tiles.length - 1;
     const tileFrameCount = isLastTile
-      ? totalFrames - t * TILE_WIDTH
-      : TILE_WIDTH;
-    const drawWidth = tileFrameCount * frameDisplayWidth;
+      ? totalFrames - t * TILE_FRAMES
+      : TILE_FRAMES;
+    const drawHeight = tileFrameCount * frameDisplayHeight;
 
-    ctx.drawImage(tiles[t], drawX, 0, drawWidth, height);
+    ctx.drawImage(tiles[t], 0, drawY, viewportWidth, drawHeight);
   }
 }
 
@@ -328,7 +323,6 @@ function drawMelodyOverlay(
   canvas: HTMLCanvasElement,
   container: HTMLDivElement,
   pixelsPerSecond: number,
-  height: number,
   notes: MelodyNote[],
   color: TrackColor,
   frequencyBinCount: number,
@@ -346,6 +340,7 @@ function drawMelodyOverlay(
 
   const scrollParent = container.closest(SCROLL_CONTAINER_CLASS);
   const viewportWidth = scrollParent?.clientWidth ?? window.innerWidth;
+  const viewportHeight = scrollParent?.clientHeight ?? window.innerHeight;
 
   const scrollTop = scrollParent?.scrollTop ?? 0;
   const timeline = container.closest('.timeline');
@@ -353,14 +348,14 @@ function drawMelodyOverlay(
     ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
   const containerMarginTop = parseFloat(container.style.marginTop) || 0;
-  const maxContentOffset = Math.max(0, contentLength - viewportWidth);
+  const maxContentOffset = Math.max(0, contentLength - viewportHeight);
   const contentOffset = Math.min(
     Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
   const needsResize =
-    canvas.width !== viewportWidth || canvas.height !== height;
+    canvas.width !== viewportWidth || canvas.height !== viewportHeight;
 
   // During playback, always redraw to update the playhead glow effect.
   // When stopped, use memoization to skip unchanged frames.
@@ -380,7 +375,7 @@ function drawMelodyOverlay(
 
   if (needsResize) {
     canvas.width = viewportWidth;
-    canvas.height = height;
+    canvas.height = viewportHeight;
   }
 
   const ctx = canvas.getContext('2d');
@@ -393,8 +388,8 @@ function drawMelodyOverlay(
   const viewport: PianoRollViewport = {
     pixelsPerSecond,
     contentOffset,
-    viewportWidth,
-    canvasHeight: height,
+    viewportHeight,
+    canvasWidth: viewportWidth,
     frequencyBinCount,
     playheadTime: trackPlayheadTime,
   };

--- a/src/services/SpectrogramTileRenderer.ts
+++ b/src/services/SpectrogramTileRenderer.ts
@@ -27,23 +27,24 @@ export function createColorMap(color: TrackColor): Uint8Array {
 /**
  * Renders a single tile's pixel data into an ImageData buffer.
  *
- * Frequency bins are drawn bottom-to-top: bin 0 is at the bottom row,
- * bin N-1 is at the top row — matching the convention in SpectrogramCanvasRenderer.
+ * Tiles are transposed for the vertical timeline: frequency bins map to
+ * columns (X axis, bin 0 on the left = low frequency) and time frames
+ * map to rows (Y axis, frame 0 at the top = earliest time).
  */
 function renderTilePixels(
   imageData: ImageData,
   frames: Uint8Array[],
   colorMap: Uint8Array,
-  height: number,
+  frequencyBinCount: number,
 ): void {
   const pixels = imageData.data;
   const width = imageData.width;
 
-  for (let col = 0; col < frames.length; col++) {
-    const frame = frames[col];
-    for (let bin = 0; bin < height; bin++) {
-      // bin 0 → bottom row (height - 1), bin N-1 → top row (0)
-      const row = height - 1 - bin;
+  for (let row = 0; row < frames.length; row++) {
+    const frame = frames[row];
+    for (let bin = 0; bin < frequencyBinCount; bin++) {
+      // bin 0 → left column (col 0), bin N-1 → right column (col N-1)
+      const col = bin;
       const pixelOffset = (row * width + col) * BYTES_PER_PIXEL;
       const colorOffset = frame[bin] * BYTES_PER_PIXEL;
 
@@ -58,13 +59,14 @@ function renderTilePixels(
 /**
  * Converts SpectrogramData + track colour into an array of ImageBitmap tiles.
  *
- * Each tile is up to `tileWidth` pixels wide (the last tile may be narrower).
- * Height equals `frequencyBinCount`. Uses ImageData batch painting for performance.
+ * Tiles are transposed for vertical timeline rendering: width equals
+ * `frequencyBinCount` (frequency axis, left-to-right) and height is up to
+ * `tileFrames` frames (time axis, top-to-bottom). The last tile may be shorter.
  */
 export function renderTiles(
   data: SpectrogramData,
   color: TrackColor,
-  tileWidth: number = DEFAULT_TILE_WIDTH,
+  tileFrames: number = DEFAULT_TILE_WIDTH,
 ): ImageBitmap[] {
   const { frequencyFrames, frequencyBinCount } = data;
   const totalFrames = frequencyFrames.length;
@@ -74,20 +76,20 @@ export function renderTiles(
   }
 
   const colorMap = createColorMap(color);
-  const tileCount = Math.ceil(totalFrames / tileWidth);
+  const tileCount = Math.ceil(totalFrames / tileFrames);
   const tiles: ImageBitmap[] = [];
 
   for (let t = 0; t < tileCount; t++) {
-    const startFrame = t * tileWidth;
-    const endFrame = Math.min(startFrame + tileWidth, totalFrames);
-    const currentTileWidth = endFrame - startFrame;
-    const tileFrames = frequencyFrames.slice(startFrame, endFrame);
+    const startFrame = t * tileFrames;
+    const endFrame = Math.min(startFrame + tileFrames, totalFrames);
+    const currentTileHeight = endFrame - startFrame;
+    const frames = frequencyFrames.slice(startFrame, endFrame);
 
-    const canvas = new OffscreenCanvas(currentTileWidth, frequencyBinCount);
+    const canvas = new OffscreenCanvas(frequencyBinCount, currentTileHeight);
     const ctx = canvas.getContext('2d')!;
-    const imageData = ctx.createImageData(currentTileWidth, frequencyBinCount);
+    const imageData = ctx.createImageData(frequencyBinCount, currentTileHeight);
 
-    renderTilePixels(imageData, tileFrames, colorMap, frequencyBinCount);
+    renderTilePixels(imageData, frames, colorMap, frequencyBinCount);
     ctx.putImageData(imageData, 0, 0);
 
     tiles.push(canvas.transferToImageBitmap());


### PR DESCRIPTION
## Summary

Implements sub-issue #360 of the vertical timeline epic (#358). Transposes all spectrogram canvas drawing so that time flows top-to-bottom (Y axis) and frequency flows left-to-right (X axis, low frequencies on left).

- **SpectrogramTileRenderer**: Tiles transposed from `(timeFrames × frequencyBins)` to `(frequencyBins × timeFrames)` at cache time (Option A per issue). Bin 0 maps to left column naturally (no Y-flip needed).
- **RecordingBuffer**: Accumulates horizontal rows instead of vertical columns; canvas grows vertically with time.
- **drawTilesFrame / drawRecordingFrame**: Canvas sized to scroll container viewport; tiles drawn top-to-bottom with vertical culling; content offset derived from `scrollTop`.
- **PianoRollRenderer**: Notes rendered as vertical bars (x = frequency bin, y = time); gradient and highlight adjusted for horizontal frequency axis; pitch bend traces along Y axis.
- **Timeline**: Removed `height` prop and `useContainerHeight` dependency — canvas dimensions now derived from scroll container viewport.

Existing IndexedDB-cached spectrograms will be re-analysed on next load (no migration needed).

**Note**: E2e visual regression tests are expected to fail until #362 updates the snapshots.

## Test plan
- [x] All 785 unit tests pass
- [x] Lint clean
- [x] Build succeeds
- [ ] Manual: upload audio file, verify spectrogram renders with low frequencies on left, high on right
- [ ] Manual: verify time axis flows top-to-bottom matching scroll direction
- [ ] Manual: verify live recording spectrogram grows downward
- [ ] Manual: verify melody overlay notes are correctly transposed
- [ ] Visual regression snapshots updated in #362

https://claude.ai/code/session_01KoskPio9ubTrbjkYkDC2Jp