### PR TITLE
Adapt zoom, container measurement, and track layout for vertical timeline (#361)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ src/
 │   ├── useThrottled.tsx               # Leading throttle wrapper
 │   ├── useTimelineZoom.ts             # Timeline zoom interaction
 │   ├── useTrackVolume.ts              # Track volume control
-│   ├── useContainerHeight.ts          # Container height measurement
+│   ├── useContainerDimensions.ts      # Container width/height measurement
 │   └── useUndoReducer.ts             # Undo/redo reducer wrapper
 │
 ├── components/

--- a/src/hooks/useContainerDimensions.ts
+++ b/src/hooks/useContainerDimensions.ts
@@ -1,8 +1,16 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 
-export function useContainerHeight() {
+type ContainerDimensions = {
+  width: number;
+  height: number;
+};
+
+export function useContainerDimensions() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState(0);
+  const [dimensions, setDimensions] = useState<ContainerDimensions>({
+    width: 0,
+    height: 0,
+  });
 
   useLayoutEffect(() => {
     const el = containerRef.current;
@@ -10,14 +18,17 @@ export function useContainerHeight() {
 
     // Synchronous initial measurement (prevents flash of empty content)
     const rect = el.getBoundingClientRect();
-    setHeight(rect.height);
+    setDimensions({ width: rect.width, height: rect.height });
 
     // Re-measure when the container resizes. This handles the case where
     // the initial measurement returns 0 (e.g. Timeline mounting before
-    // flex layout resolves) and the container gains height later.
+    // flex layout resolves) and the container gains dimensions later.
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        setHeight(entry.contentRect.height);
+        setDimensions({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
       }
     });
     observer.observe(el);
@@ -25,5 +36,5 @@ export function useContainerHeight() {
     return () => observer.disconnect();
   }, []);
 
-  return { containerRef, height };
+  return { containerRef, ...dimensions };
 }


### PR DESCRIPTION
## Summary

- Generalized `useContainerHeight` hook to `useContainerDimensions`, returning both `width` and `height` via `ResizeObserver`. The frequency axis now maps to container width in the vertical timeline, so the hook needs to measure both dimensions.
- Updated CLAUDE.md file map to reflect the renamed hook.
- Verified that the existing vertical timeline infrastructure from #359 and #360 already satisfies the remaining acceptance criteria:
  - **Zoom**: `pixelsPerSecond` is axis-agnostic and controls vertical extent via `duration * pixelsPerSecond`
  - **Scroll preservation**: `useScrubber.setScrollPosition` re-syncs on `pixelsPerSecond` change
  - **Canvas sizing**: `getViewportInfo()` reads `clientWidth`/`clientHeight` from scroll parent each frame
  - **Mixer scaling**: `scaleY()` compresses the time axis, matching the vertical layout
  - **Pinch zoom**: `getTouchDistance()` uses Euclidean distance (axis-agnostic)

Closes #361

## Test plan

- [x] All 786 unit tests pass
- [x] ESLint clean
- [x] Build succeeds
- [ ] E2e tests expected to fail until #362

https://claude.ai/code/session_01XBgsRKa21wjxFnz2VXsfJ4