### PR TITLE
Render timeline top-down with CSS flip to fix track placement

### DIFF
--- a/src/components/workstation/Timeline.css
+++ b/src/components/workstation/Timeline.css
@@ -4,8 +4,8 @@
   grid-template-rows: 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
-  padding-top: calc(var(--cursor-position) * 100cqh);
-  padding-bottom: calc((1 - var(--cursor-position)) * 100cqh);
+  padding-top: calc((1 - var(--cursor-position)) * 100cqh);
+  padding-bottom: calc(var(--cursor-position) * 100cqh);
 }
 
 .timeline__track {

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -29,7 +29,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     cursorContainerRef,
     plasmaRef,
     isRewindButtonHidden,
-    timelineScaleStyle,
+    timelineScrollStyle,
+    timelineOverlayStyle,
     rewindButtonStyle,
     handleScroll,
     handleWheel,
@@ -57,7 +58,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
       <div
         ref={timelineScrollRef}
         className="scrubber__timeline"
-        style={timelineScaleStyle}
+        style={timelineScrollStyle}
         onClick={handleTimelineClick}
         onScroll={handleScroll}
         onWheel={handleWheel}
@@ -65,13 +66,13 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
       >
         {props.children}
       </div>
-      <div className="scrubber__shade" style={timelineScaleStyle}>
+      <div className="scrubber__shade" style={timelineOverlayStyle}>
         <div className="shade"></div>
       </div>
       <div
         ref={cursorContainerRef}
         className="scrubber__cursor"
-        style={timelineScaleStyle}
+        style={timelineOverlayStyle}
       >
         <PlasmaPlayhead ref={plasmaRef} width={0} />
       </div>

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -219,7 +219,7 @@ it('does not update transportTime during count-in', () => {
   expect(playbackService.transportTime).toBe(5.0);
 });
 
-it('syncs timeline scroll position via imperative handle (inverted scroll)', () => {
+it('syncs timeline scroll position via imperative handle', () => {
   const ref = createRef<ScrubberHandle>();
 
   const { container } = render(<Scrubber ref={ref} {...defaultProps} />);
@@ -240,13 +240,12 @@ it('syncs timeline scroll position via imperative handle (inverted scroll)', () 
     ref.current!.syncScrollToTime(2.5);
   });
 
-  // Inverted scroll: scrollTop = maxScrollTop - time * pixelsPerSecond
-  // maxScrollTop = 2000 - 500 = 1500
-  // scrollTop = 1500 - (2.5 * 200) = 1500 - 500 = 1000
-  expect(timeline.scrollTop).toBe(1000);
+  // Top-down scroll: scrollTop = time * pixelsPerSecond
+  // scrollTop = 2.5 * 200 = 500
+  expect(timeline.scrollTop).toBe(500);
 });
 
-it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
+it('scrolls to zero when time is zero (beginning at top)', () => {
   const ref = createRef<ScrubberHandle>();
 
   const { container } = render(<Scrubber ref={ref} {...defaultProps} />);
@@ -266,6 +265,6 @@ it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
     ref.current!.syncScrollToTime(0);
   });
 
-  // At time=0, scrollTop should be at max (beginning at bottom)
-  expect(timeline.scrollTop).toBe(1500);
+  // At time=0, scrollTop should be 0 (beginning at top in DOM, flipped to bottom visually)
+  expect(timeline.scrollTop).toBe(0);
 });

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -37,8 +37,7 @@ export function useScrubber({
   const [isRewindButtonHidden, setIsRewindButtonHidden] = useState(true);
 
   const isNearBeginning = (el: HTMLDivElement) => {
-    const maxScrollTop = el.scrollHeight - el.clientHeight;
-    return maxScrollTop - el.scrollTop < 10;
+    return el.scrollTop < 10;
   };
 
   const timelineScrollRef = useRef<HTMLDivElement>(null);
@@ -74,9 +73,7 @@ export function useScrubber({
     (time: number) => {
       const el = timelineScrollRef.current;
       if (el) {
-        const maxScrollTop = el.scrollHeight - el.clientHeight;
-        const scrollPosition =
-          maxScrollTop - Math.trunc(time * pixelsPerSecond);
+        const scrollPosition = Math.trunc(time * pixelsPerSecond);
         if (el.scrollTop !== scrollPosition) {
           isProgrammaticScrollRef.current = true;
           el.scrollTop = scrollPosition;
@@ -133,9 +130,10 @@ export function useScrubber({
         // can momentarily equal clientHeight before new content is laid out.
         // Stopping playback here would freeze transportTime updates and halt
         // the live spectrogram scroll.
-        // In inverted scroll, end of track is at scrollTop=0 (top of scroll area)
         if (timelineScrollRef.current && !recording.isActivelyRecording) {
-          const isEndOfScroll = timelineScrollRef.current.scrollTop <= 0;
+          const el = timelineScrollRef.current;
+          const maxScrollTop = el.scrollHeight - el.clientHeight;
+          const isEndOfScroll = el.scrollTop >= maxScrollTop;
           if (isEndOfScroll) {
             playback.rewind();
             return;
@@ -165,8 +163,7 @@ export function useScrubber({
   const setTransportTimeFromScroll = () => {
     const el = timelineScrollRef.current;
     if (el) {
-      const maxScrollTop = el.scrollHeight - el.clientHeight;
-      const time = (maxScrollTop - el.scrollTop) / pixelsPerSecond;
+      const time = el.scrollTop / pixelsPerSecond;
       playback.seekTo(time);
     }
     if (shouldResumeRef.current) {
@@ -249,7 +246,8 @@ export function useScrubber({
     return () => observer.disconnect();
   }, [drawerHeight]);
 
-  const timelineScaleStyle = getTimelineStyle(timelineScaleFactor);
+  const timelineScrollStyle = getTimelineScrollStyle(timelineScaleFactor);
+  const timelineOverlayStyle = getTimelineOverlayStyle(timelineScaleFactor);
 
   const rewindButtonStyle = getRewindButtonStyle(
     drawerHeight,
@@ -269,7 +267,8 @@ export function useScrubber({
     cursorContainerRef,
     plasmaRef,
     isRewindButtonHidden,
-    timelineScaleStyle,
+    timelineScrollStyle,
+    timelineOverlayStyle,
     rewindButtonStyle,
     handleScroll,
     handleWheel,
@@ -285,7 +284,23 @@ const baseTransformStyle = {
   transition: 'transform 0.25s ease-out',
 };
 
-function getTimelineStyle(timelineScaleFactor: number) {
+/**
+ * Style for the scroll container: flips content vertically via scaleY(-1)
+ * so that top-down DOM content appears bottom-up visually (time=0 at bottom).
+ * The translateY(-100%) compensates for the flip with transformOrigin: top left.
+ */
+function getTimelineScrollStyle(timelineScaleFactor: number) {
+  return {
+    ...baseTransformStyle,
+    transform: `scaleY(${-timelineScaleFactor}) translateY(-100%)`,
+  };
+}
+
+/**
+ * Style for overlay elements (shade, cursor) that should NOT be flipped.
+ * Only applies the drawer scaling.
+ */
+function getTimelineOverlayStyle(timelineScaleFactor: number) {
   return {
     ...baseTransformStyle,
     transform: `scaleY(${timelineScaleFactor})`,

--- a/src/components/workstation/spectrogram/Spectrogram.tsx
+++ b/src/components/workstation/spectrogram/Spectrogram.tsx
@@ -144,7 +144,7 @@ const Spectrogram = ({
   // For recording tracks, height is updated in the rAF loop directly on the
   // DOM node to avoid React re-renders at 60fps.
   const containerHeight = isRecordingTrack ? 0 : duration * pixelsPerSecond;
-  const containerMarginBottom = startTime * pixelsPerSecond;
+  const containerMarginTop = startTime * pixelsPerSecond;
 
   return (
     <div
@@ -153,7 +153,7 @@ const Spectrogram = ({
       style={{
         opacity,
         height: containerHeight,
-        marginBottom: containerMarginBottom,
+        marginTop: containerMarginTop,
       }}
     >
       <canvas ref={canvasRef} className="spectrogram__canvas" />
@@ -188,7 +188,7 @@ function drawRecordingFrame(
 
   // Update container height and offset directly to avoid React re-renders
   container.style.height = `${contentHeight}px`;
-  container.style.marginBottom = `${recordingStartTime * pixelsPerSecond}px`;
+  container.style.marginTop = `${recordingStartTime * pixelsPerSecond}px`;
 
   // Accumulate a new frame while recording is active
   if (isRecActive) {
@@ -198,16 +198,10 @@ function drawRecordingFrame(
 
   if (buffer.frameCount === 0) return;
 
-  const { viewportWidth, viewportHeight, contentOffset, maxContentOffset } =
-    getViewportInfo(container, contentHeight);
-
-  // Flip: map DOM content offset to inverted content offset
-  const flippedOffset = maxContentOffset - contentOffset;
-
-  // When content is shorter than the viewport, shift drawing up (in flipped
-  // coords) so content stays within the container bounds instead of being
-  // rendered at the canvas bottom (which extends past the container).
-  const drawYOffset = Math.max(0, viewportHeight - contentHeight);
+  const { viewportWidth, viewportHeight, contentOffset } = getViewportInfo(
+    container,
+    contentHeight,
+  );
 
   const needsResize =
     canvas.width !== viewportWidth || canvas.height !== viewportHeight;
@@ -220,9 +214,6 @@ function drawRecordingFrame(
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  ctx.save();
-  flipCanvasY(ctx, viewportHeight);
-
   // Map buffer frames (1 frame = 1 pixel in the buffer) to display pixels.
   // bufferFrames maps to contentHeight display pixels.
   const framesPerPixel = buffer.frameCount / contentHeight;
@@ -230,30 +221,27 @@ function drawRecordingFrame(
   // actual content area. Without this, when the recording is shorter than
   // the viewport the buffer was drawn across the full viewport height,
   // making the spectrogram appear to move faster than existing tracks.
-  const destHeight = Math.min(viewportHeight, contentHeight - flippedOffset);
-  const srcY = Math.floor(flippedOffset * framesPerPixel);
+  const destHeight = Math.min(viewportHeight, contentHeight - contentOffset);
+  const srcY = Math.floor(contentOffset * framesPerPixel);
   const srcHeight = Math.min(
     Math.ceil(destHeight * framesPerPixel),
     buffer.frameCount - srcY,
   );
 
-  buffer.drawTo(ctx, srcY, srcHeight, drawYOffset, destHeight, viewportWidth);
-
-  ctx.restore();
+  buffer.drawTo(ctx, srcY, srcHeight, 0, destHeight, viewportWidth);
 }
 
 type ViewportInfo = {
   viewportWidth: number;
   viewportHeight: number;
   contentOffset: number;
-  maxContentOffset: number;
 };
 
 /**
  * Computes viewport dimensions and content offset for a spectrogram container.
- * The content offset measures how far into the DOM content the viewport's top
- * edge has scrolled. With marginBottom positioning, all containers start at
- * the grid cell top (paddingTop) — no top margin to subtract.
+ * The content offset measures how far into this spectrogram's content the
+ * viewport's top edge has scrolled. Each spectrogram starts at
+ * paddingTop + marginTop from the scroll container's top edge.
  */
 function getViewportInfo(
   container: HTMLDivElement,
@@ -268,22 +256,14 @@ function getViewportInfo(
   const paddingTop = timeline
     ? parseFloat(getComputedStyle(timeline).paddingTop) || 0
     : 0;
+  const containerMarginTop = parseFloat(container.style.marginTop) || 0;
   const maxContentOffset = Math.max(0, contentLength - viewportHeight);
   const contentOffset = Math.min(
-    Math.max(0, scrollTop - paddingTop),
+    Math.max(0, scrollTop - paddingTop - containerMarginTop),
     maxContentOffset,
   );
 
-  return { viewportWidth, viewportHeight, contentOffset, maxContentOffset };
-}
-
-/**
- * Flips the canvas Y-axis so that y=0 draws at the bottom of the canvas.
- * This makes time=0 content appear at the bottom (beginning at the bottom).
- */
-function flipCanvasY(ctx: CanvasRenderingContext2D, viewportHeight: number) {
-  ctx.translate(0, viewportHeight);
-  ctx.scale(1, -1);
+  return { viewportWidth, viewportHeight, contentOffset };
 }
 
 function drawTilesFrame(
@@ -302,17 +282,10 @@ function drawTilesFrame(
   }>,
 ): void {
   const contentLength = duration * pixelsPerSecond;
-  const { viewportWidth, viewportHeight, contentOffset, maxContentOffset } =
-    getViewportInfo(container, contentLength);
-
-  // Flip: map DOM content offset to inverted content offset so that
-  // tile 0 (beginning) draws at the bottom of the canvas.
-  const flippedOffset = maxContentOffset - contentOffset;
-
-  // When content is shorter than the viewport, shift drawing up (in flipped
-  // coords) so content stays within the container bounds instead of being
-  // rendered at the canvas bottom (which extends past the container).
-  const drawYOffset = Math.max(0, viewportHeight - contentLength);
+  const { viewportWidth, viewportHeight, contentOffset } = getViewportInfo(
+    container,
+    contentLength,
+  );
 
   const needsResize =
     canvas.width !== viewportWidth || canvas.height !== viewportHeight;
@@ -320,13 +293,13 @@ function drawTilesFrame(
   const last = lastDrawnRef.current;
   if (
     !needsResize &&
-    flippedOffset === last.offset &&
+    contentOffset === last.offset &&
     pixelsPerSecond === last.pps &&
     tiles.length === last.tileCount
   ) {
     return;
   }
-  last.offset = flippedOffset;
+  last.offset = contentOffset;
   last.pps = pixelsPerSecond;
   last.tileCount = tiles.length;
 
@@ -339,18 +312,15 @@ function drawTilesFrame(
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  ctx.save();
-  flipCanvasY(ctx, viewportHeight);
-
-  const firstTile = Math.max(0, Math.floor(flippedOffset / tileDisplayHeight));
+  const firstTile = Math.max(0, Math.floor(contentOffset / tileDisplayHeight));
   const lastTile = Math.min(
     tiles.length - 1,
-    Math.floor((flippedOffset + viewportHeight) / tileDisplayHeight),
+    Math.floor((contentOffset + viewportHeight) / tileDisplayHeight),
   );
 
   for (let t = firstTile; t <= lastTile; t++) {
     const tileTopPx = t * tileDisplayHeight;
-    const drawY = tileTopPx - flippedOffset + drawYOffset;
+    const drawY = tileTopPx - contentOffset;
     const isLastTile = t === tiles.length - 1;
     const tileFrameCount = isLastTile
       ? totalFrames - t * TILE_FRAMES
@@ -359,8 +329,6 @@ function drawTilesFrame(
 
     ctx.drawImage(tiles[t], 0, drawY, viewportWidth, drawHeight);
   }
-
-  ctx.restore();
 }
 
 function drawMelodyOverlay(
@@ -381,15 +349,10 @@ function drawMelodyOverlay(
   }>,
 ): void {
   const contentLength = duration * pixelsPerSecond;
-  const { viewportWidth, viewportHeight, contentOffset, maxContentOffset } =
-    getViewportInfo(container, contentLength);
-
-  // Flip: map DOM content offset to inverted content offset
-  const flippedOffset = maxContentOffset - contentOffset;
-
-  // When content is shorter than the viewport, shift drawing up (in flipped
-  // coords) so content stays within the container bounds.
-  const drawYOffset = Math.max(0, viewportHeight - contentLength);
+  const { viewportWidth, viewportHeight, contentOffset } = getViewportInfo(
+    container,
+    contentLength,
+  );
 
   const needsResize =
     canvas.width !== viewportWidth || canvas.height !== viewportHeight;
@@ -400,13 +363,13 @@ function drawMelodyOverlay(
   if (
     !isPlaying &&
     !needsResize &&
-    flippedOffset === last.offset &&
+    contentOffset === last.offset &&
     pixelsPerSecond === last.pps &&
     notes.length === last.noteCount
   ) {
     return;
   }
-  last.offset = flippedOffset;
+  last.offset = contentOffset;
   last.pps = pixelsPerSecond;
   last.noteCount = notes.length;
 
@@ -419,15 +382,12 @@ function drawMelodyOverlay(
   if (!ctx) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  ctx.save();
-  flipCanvasY(ctx, viewportHeight);
-
   // Playhead time relative to this track's start time
   const trackPlayheadTime = playheadTime - startTime;
 
   const viewport: PianoRollViewport = {
     pixelsPerSecond,
-    contentOffset: flippedOffset - drawYOffset,
+    contentOffset,
     viewportHeight,
     canvasWidth: viewportWidth,
     frequencyBinCount,
@@ -435,8 +395,6 @@ function drawMelodyOverlay(
   };
 
   drawPianoRoll(ctx, notes, color, viewport);
-
-  ctx.restore();
 }
 
 export default Spectrogram;

--- a/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
+++ b/src/components/workstation/spectrogram/__tests__/Spectrogram.test.tsx
@@ -258,7 +258,7 @@ it('sets container height from duration and pixelsPerSecond', () => {
   expect(spectrogram).toHaveStyle({ height: '500px' });
 });
 
-it('offsets container by startTime using marginBottom for inverted timeline', () => {
+it('offsets container by startTime using marginTop', () => {
   const duration = 2.5;
   const startTime = 3.0;
   const audioBuffer = { duration } as AudioBuffer;
@@ -268,10 +268,10 @@ it('offsets container by startTime using marginBottom for inverted timeline', ()
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  // marginBottom = startTime * pixelsPerSecond = 3.0 * 200 = 600
-  // Uses marginBottom (not marginTop) because the inverted timeline has
-  // beginning at the bottom — startTime offsets from the bottom.
-  expect(spectrogram).toHaveStyle({ marginBottom: '600px' });
+  // marginTop = startTime * pixelsPerSecond = 3.0 * 200 = 600
+  // Uses marginTop because the timeline renders top-down (time=0 at DOM top)
+  // and a CSS transform flips the visual output.
+  expect(spectrogram).toHaveStyle({ marginTop: '600px' });
 });
 
 it('has no margin offset for tracks starting at position zero', () => {
@@ -283,7 +283,7 @@ it('has no margin offset for tracks starting at position zero', () => {
   const { container } = render(<Spectrogram {...defaultProps} />);
 
   const spectrogram = container.querySelector('.spectrogram');
-  expect(spectrogram).toHaveStyle({ marginBottom: '0px' });
+  expect(spectrogram).toHaveStyle({ marginTop: '0px' });
 });
 
 it('sets container height to zero when no audio buffer', () => {
@@ -368,8 +368,8 @@ describe('recording mode', () => {
     callback?.();
 
     const spectrogram = container.querySelector('.spectrogram');
-    // marginBottom = recordingStartTime * pixelsPerSecond = 3.0 * 200 = 600
-    expect(spectrogram).toHaveStyle({ marginBottom: '600px' });
+    // marginTop = recordingStartTime * pixelsPerSecond = 3.0 * 200 = 600
+    expect(spectrogram).toHaveStyle({ marginTop: '600px' });
 
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary

- Fix track placement bug: new tracks appeared at the end of the timeline instead of the beginning because `marginBottom` doesn't reposition grid items from the bottom — they all start at the grid cell top regardless
- Refactor from bottom-up scroll math to top-down DOM rendering with `scaleY(-1)` CSS transform on the scroll container, eliminating 11 inversion points across `useScrubber.ts` and `Spectrogram.tsx`
- Split timeline transform styles: scroll container gets the flip (`scaleY(-scaleFactor) translateY(-100%)`), overlay elements (shade, cursor) get drawer scaling only

## Changes

| File | What changed |
|------|-------------|
| `useScrubber.ts` | Simplified scroll math (`scrollTop = time * pps`), split `timelineScaleStyle` into `timelineScrollStyle` + `timelineOverlayStyle` |
| `Scrubber.tsx` | Apply flip style to scroll container only, overlay style to shade/cursor |
| `Timeline.css` | Swap padding-top/padding-bottom to match flipped orientation |
| `Spectrogram.tsx` | `marginBottom` → `marginTop`, removed `flipCanvasY()`, `flippedOffset`, `drawYOffset`; `getViewportInfo()` accounts for per-container `marginTop` |

## Test plan

- [x] All 786 unit tests pass
- [x] ESLint clean
- [x] Production build succeeds
- [ ] Verify track placement: upload a file — spectrogram should appear at the beginning (visual bottom) of the timeline
- [ ] Verify scroll direction: scroll wheel down should move forward in time
- [ ] Verify recording spectrogram grows correctly during overdub
- [ ] Verify mixer drawer scaling still works (timeline shrinks when mixer opens)

https://claude.ai/code/session_01AVDC5q2ana7xP6kCAfTtZB