### PR TITLE
Fix melody extraction not re-triggered after cached spectrogram load

### DIFF
--- a/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
+++ b/src/components/workstation/spectrogram/__tests__/useSpectrogramCache.test.ts
@@ -222,6 +222,9 @@ describe('useSpectrogramCache', () => {
     const storeData = toSpectrogramStoreData('track-1', MOCK_DATA);
     await saveSpectrogramData(storeData);
 
+    // Melody is missing from IndexedDB — extraction will be triggered
+    mockExtractMelodyInWorker.mockResolvedValue(MOCK_MELODY);
+
     const { result } = renderHook(() =>
       useSpectrogramCache('track-1', mockAudioBuffer(), COLOR),
     );
@@ -320,6 +323,35 @@ describe('useSpectrogramCache', () => {
     expect(stored).not.toBeNull();
     expect(stored!.trackId).toBe('track-1');
     expect(stored!.timeResolution).toBe(0.0029);
+  });
+
+  it('runs melody extraction when spectrogram is in IndexedDB but melody is not', async () => {
+    mockGetEntry
+      .mockReturnValueOnce(undefined) // initial check: not in memory
+      .mockReturnValue(MOCK_ENTRY); // after restore
+
+    // Only spectrogram is in IndexedDB — no melody data
+    const storeData = toSpectrogramStoreData('track-1', MOCK_DATA);
+    await saveSpectrogramData(storeData);
+
+    mockExtractMelodyInWorker.mockResolvedValue(MOCK_MELODY);
+
+    const buffer = mockAudioBuffer();
+    renderHook(() => useSpectrogramCache('track-1', buffer, COLOR));
+
+    // Should still trigger melody extraction even though spectrogram was cached
+    await waitFor(() => {
+      expect(mockExtractMelodyInWorker).toHaveBeenCalledWith(buffer);
+    });
+
+    await waitFor(() => {
+      expect(mockSetMelody).toHaveBeenCalledWith('track-1', MOCK_MELODY);
+    });
+
+    // Verify melody data was saved to IndexedDB
+    const stored = await loadMelodyData('track-1');
+    expect(stored).not.toBeNull();
+    expect(stored!.trackId).toBe('track-1');
   });
 
   it('does not fail when melody extraction errors', async () => {

--- a/src/components/workstation/spectrogram/useSpectrogramCache.ts
+++ b/src/components/workstation/spectrogram/useSpectrogramCache.ts
@@ -100,9 +100,16 @@ export function useSpectrogramCache(
             `[melody] Restored ${melody.notes.length} cached notes for track ${trackId} from IndexedDB`,
           );
         } else {
-          console.debug(
-            `[melody] No cached melody data for track ${trackId} in IndexedDB`,
-          );
+          // Melody data missing from IndexedDB — run extraction now.
+          // This happens when the page was closed before extraction
+          // completed, or the IndexedDB save failed on a prior load.
+          extractAndCacheMelody(audioService, trackId, audioBuffer, () => {
+            if (cancelled) return;
+            const updated = audioService.spectrogramCache.getEntry(trackId);
+            if (updated) {
+              setEntry({ ...updated });
+            }
+          });
         }
 
         setEntry(audioService.spectrogramCache.getEntry(trackId));

--- a/src/services/InstrumentClassificationService.ts
+++ b/src/services/InstrumentClassificationService.ts
@@ -299,9 +299,6 @@ class InstrumentClassificationService {
         // Handle download progress updates (service-level, not per-request)
         if (type === 'download-progress') {
           this._downloadProgress.value = event.data.progress;
-          console.debug(
-            `[classification] Model download progress: ${event.data.progress}%`,
-          );
           return;
         }
 

--- a/src/services/MelodyExtractor.ts
+++ b/src/services/MelodyExtractor.ts
@@ -180,12 +180,9 @@ export async function extractMelody(
       allOnsets.push(...onsets);
       allContours.push(...contours);
     },
-    (percent) => {
-      if (percent === 0 || percent === 1 || percent % 0.25 < 0.01) {
-        console.debug(
-          `[melody] Basic Pitch progress: ${(percent * 100).toFixed(0)}%`,
-        );
-      }
+    () => {
+      // Progress callback required by BasicPitch API but not logged —
+      // start/done/fail messages are sufficient.
     },
   );
 

--- a/src/services/TranscriptionService.ts
+++ b/src/services/TranscriptionService.ts
@@ -267,9 +267,6 @@ class TranscriptionService {
         // Handle download progress updates
         if (type === 'download-progress') {
           this._downloadProgress.value = event.data.progress;
-          console.debug(
-            `[transcription] Model download progress: ${event.data.progress}%`,
-          );
           return;
         }
 


### PR DESCRIPTION
## Summary
- **Fix**: When spectrogram data was restored from IndexedDB but melody data was missing (e.g. page closed before extraction completed, or IndexedDB save failed), melody extraction was never re-attempted on subsequent page loads. Now triggers extraction in the background when spectrogram is cached but melody data is absent.
- **Cleanup**: Removes verbose per-percentage model loading progress logs from `MelodyExtractor`, `InstrumentClassificationService`, and `TranscriptionService`. Start/done/fail messages are retained — progress is still tracked via signals for the UI.

## Test plan
- [x] New unit test: `runs melody extraction when spectrogram is in IndexedDB but melody is not` confirms extraction is triggered and results are saved
- [x] Existing unit tests (788 total) pass
- [x] E2e tests (42 total) pass
- [x] Lint and build pass

https://claude.ai/code/session_016oJVcz1AfhGcnm6fFfxy3J