### PR TITLE
Optimize e2e tests: fix flaky test and speed up execution

### DIFF
--- a/e2e/audio.spec.ts
+++ b/e2e/audio.spec.ts
@@ -1,23 +1,10 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-long.wav');
-
-/**
- * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
- */
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import {
+  expect,
+  test,
+  uploadAudioFile,
+  SHORT_AUDIO,
+  LONG_AUDIO,
+} from './fixtures';
 
 test.describe('Audio file upload', () => {
   test('uploads audio files, displays tracks, and enables controls', async ({
@@ -48,15 +35,13 @@ test.describe('Audio file upload', () => {
 });
 
 test.describe('Playback controls', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/project/test-id');
-    await uploadAudioFile(page, SHORT_AUDIO);
-    await expect(page.locator('.timeline__track')).toBeVisible();
-  });
-
   test('toggles playback via click and spacebar, shows playhead', async ({
     page,
   }) => {
+    await page.goto('/project/test-id');
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__track')).toBeVisible();
+
     // Playhead is visible
     await expect(page.locator('.plasma-playhead')).toBeVisible();
 
@@ -97,7 +82,6 @@ test.describe('Playback controls', () => {
         connections;
     });
 
-    // Re-navigate so the init script takes effect
     await page.goto('/project/test-id');
     await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
@@ -240,7 +224,6 @@ test.describe('Floating toolbar', () => {
     await rewindButton.click();
   });
 });
-
 
 test.describe('Visual regression - audio states', () => {
   // Seed Math.random so the track color palette starts at index 0 (teal)

--- a/e2e/classification.spec.ts
+++ b/e2e/classification.spec.ts
@@ -1,19 +1,4 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
-
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import { expect, test, uploadAudioFile, SHORT_AUDIO } from './fixtures';
 
 test.describe('Instrument classification on upload', () => {
   test('completes classification after file upload', async ({ page }) => {

--- a/e2e/dragndrop.spec.ts
+++ b/e2e/dragndrop.spec.ts
@@ -1,13 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-long.wav');
+import { expect, test, SHORT_AUDIO, LONG_AUDIO } from './fixtures';
 
 /**
  * Creates a Playwright ElementHandle for a DataTransfer containing the given

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -11,9 +11,31 @@
  *   essentia.upf.edu, which would otherwise happen because AudioService
  *   fires classification on every track creation.
  */
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { test as base, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export { expect };
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+export const SHORT_AUDIO = path.join(FIXTURES_DIR, 'test-tone-short.wav');
+export const LONG_AUDIO = path.join(FIXTURES_DIR, 'test-tone-long.wav');
+export const LONG_AUDIO_10S = path.join(FIXTURES_DIR, 'test-tone-10s.wav');
+export const CHIRP_AUDIO_10S = path.join(FIXTURES_DIR, 'test-chirp-10s.wav');
+
+/**
+ * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
+ * Waits for the file input to be attached before setting files to avoid flaky timeouts.
+ */
+export async function uploadAudioFile(page: Page, filePath: string) {
+  const fileInput = page.locator('.toolbar input[type="file"]');
+  await fileInput.waitFor({ state: 'attached' });
+  await fileInput.setInputFiles(filePath);
+}
 
 export const test = base.extend<{ blockModelRequests: void }>({
   // eslint-disable-next-line no-empty-pattern

--- a/e2e/mixer-reorder.spec.ts
+++ b/e2e/mixer-reorder.spec.ts
@@ -1,27 +1,14 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-long.wav');
+import {
+  expect,
+  test,
+  uploadAudioFile,
+  SHORT_AUDIO,
+  LONG_AUDIO,
+} from './fixtures';
 
 // Time to wait after the mixer opens so its 300 ms slide-in transition has
 // fully settled before @dnd-kit measures droppable rects.
 const MIXER_ANIMATION_MS = 350;
-
-/**
- * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
- */
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
 
 /**
  * Drags an element's centre to another element's centre using mouse events.
@@ -125,17 +112,34 @@ test.describe('Mixer channel reordering', () => {
     await page.waitForTimeout(MIXER_ANIMATION_MS);
   });
 
-  test('touch-dragging a channel reorders tracks in the mixer', async ({
-    browser,
+  test('mouse-dragging a channel reorders tracks in the mixer', async ({
+    page,
   }) => {
-    // touch-action: none on the drag handle prevents the browser from
-    // firing pointercancel during a touch drag. Verify the CSS is applied
-    // and that an actual touch drag reorders the channels.
-    const context = await browser.newContext({
-      hasTouch: true,
-      viewport: { width: 1280, height: 720 },
-    });
-    const page = await context.newPage();
+    const channels = page.locator('.channel');
+    const colorBefore = await channels
+      .first()
+      .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+
+    // Drag the top channel's handle down to the bottom channel's handle.
+    const handles = page.locator('.channel__move');
+    await mouseDragTo(page, handles.first(), handles.last());
+
+    // After dragging, the first channel should now have the other colour.
+    await expect(async () => {
+      const colorAfter = await channels
+        .first()
+        .evaluate((el) => (el as HTMLElement).style.backgroundColor);
+      expect(colorAfter).not.toBe(colorBefore);
+    }).toPass({ timeout: 2000 });
+  });
+});
+
+test.describe('Mixer channel reordering – touch', () => {
+  test.use({ hasTouch: true });
+
+  test('touch-dragging a channel reorders tracks in the mixer', async ({
+    page,
+  }) => {
     await page.addInitScript(() => {
       Math.random = () => 0;
     });
@@ -167,29 +171,6 @@ test.describe('Mixer channel reordering', () => {
     // Touch-drag the top channel's handle down to the bottom channel's handle
     const handles = page.locator('.channel__move');
     await touchDragTo(page, handles.first(), handles.last());
-
-    // After dragging, the first channel should now have the other colour.
-    await expect(async () => {
-      const colorAfter = await channels
-        .first()
-        .evaluate((el) => (el as HTMLElement).style.backgroundColor);
-      expect(colorAfter).not.toBe(colorBefore);
-    }).toPass({ timeout: 2000 });
-
-    await context.close();
-  });
-
-  test('mouse-dragging a channel reorders tracks in the mixer', async ({
-    page,
-  }) => {
-    const channels = page.locator('.channel');
-    const colorBefore = await channels
-      .first()
-      .evaluate((el) => (el as HTMLElement).style.backgroundColor);
-
-    // Drag the top channel's handle down to the bottom channel's handle.
-    const handles = page.locator('.channel__move');
-    await mouseDragTo(page, handles.first(), handles.last());
 
     // After dragging, the first channel should now have the other colour.
     await expect(async () => {

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,19 +1,4 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
-
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import { expect, test, uploadAudioFile, SHORT_AUDIO } from './fixtures';
 
 test.describe('Project data persistence across page reload', () => {
   test('uploaded track survives reload and project appears on home page', async ({

--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -1,11 +1,4 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const SHORT_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-short.wav');
+import { expect, test, uploadAudioFile, SHORT_AUDIO } from './fixtures';
 
 // Chrome's --use-fake-device-for-media-stream provides a synthetic audio signal
 // (beeping tone) from a virtual microphone. Combined with
@@ -168,8 +161,7 @@ test.describe('Recording with existing tracks', () => {
     await ensureAudioContextRunning(page);
 
     // Upload a backing track first
-    const fileInput = page.locator('.toolbar input[type="file"]');
-    await fileInput.setInputFiles(SHORT_AUDIO);
+    await uploadAudioFile(page, SHORT_AUDIO);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
     await recordAudio(page, {

--- a/e2e/scrubber-seek.spec.ts
+++ b/e2e/scrubber-seek.spec.ts
@@ -1,22 +1,9 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-10s.wav');
-
-/**
- * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
- */
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import {
+  expect,
+  test,
+  uploadAudioFile,
+  LONG_AUDIO_10S,
+} from './fixtures';
 
 /**
  * Scrolls the timeline vertically using a mouse wheel event.
@@ -34,7 +21,7 @@ async function wheelScrollTimeline(
 test.describe('Drag and scroll timeline to seek while playing', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/project/test-id');
-    await uploadAudioFile(page, LONG_AUDIO);
+    await uploadAudioFile(page, LONG_AUDIO_10S);
     await expect(page.locator('.timeline__track')).toBeVisible();
   });
 

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -1,22 +1,9 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-chirp-10s.wav');
-
-/**
- * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
- */
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import {
+  expect,
+  test,
+  uploadAudioFile,
+  CHIRP_AUDIO_10S,
+} from './fixtures';
 
 /**
  * Measures the fraction of VISIBLE canvas rows (the portion within the
@@ -103,7 +90,7 @@ test.describe('Spectrogram alignment with cursor at time=0', () => {
     page,
   }) => {
     await page.goto('/project/test-id');
-    await uploadAudioFile(page, LONG_AUDIO);
+    await uploadAudioFile(page, CHIRP_AUDIO_10S);
 
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
     await expect(spectrogramCanvas).toBeVisible({ timeout: 15000 });
@@ -167,7 +154,7 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/project/test-id');
-    await uploadAudioFile(page, LONG_AUDIO);
+    await uploadAudioFile(page, CHIRP_AUDIO_10S);
 
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
     await expect(spectrogramCanvas).toBeVisible({ timeout: 15000 });
@@ -194,37 +181,36 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
     await scrollContainer.evaluate((el, pos) => {
       el.scrollTop = pos;
     }, scrollPos);
-    await page.waitForTimeout(200);
 
-    const { canvasTop, scrollContainerTop } = await page.evaluate(() => {
-      const canvas = document.querySelector(
-        '.spectrogram__canvas',
-      ) as HTMLCanvasElement;
-      const scrollEl = document.querySelector(
-        '.scrubber__timeline',
-      ) as HTMLElement;
-      return {
-        canvasTop: canvas.getBoundingClientRect().top,
-        scrollContainerTop: scrollEl.getBoundingClientRect().top,
-      };
-    });
+    // Wait for scroll to settle and sticky position to update
+    await expect(async () => {
+      const { canvasTop, scrollContainerTop } = await page.evaluate(() => {
+        const canvas = document.querySelector(
+          '.spectrogram__canvas',
+        ) as HTMLCanvasElement;
+        const scrollEl = document.querySelector(
+          '.scrubber__timeline',
+        ) as HTMLElement;
+        return {
+          canvasTop: canvas.getBoundingClientRect().top,
+          scrollContainerTop: scrollEl.getBoundingClientRect().top,
+        };
+      });
 
-    // The canvas should stick at the scroll container's top edge (sticky
-    // top: 0), not offset by the timeline's padding-top. The scroll
-    // container may be below the viewport top due to the project header.
-    expect(
-      canvasTop,
-      `Canvas top edge is at ${canvasTop}px instead of scroll container top ` +
-        `(${scrollContainerTop}px) — it is stuck at the content edge ` +
-        `(paddingTop=${paddingTop}) instead of the scroll container edge`,
-    ).toBeCloseTo(scrollContainerTop, 0);
+      expect(
+        canvasTop,
+        `Canvas top edge is at ${canvasTop}px instead of scroll container top ` +
+          `(${scrollContainerTop}px) — it is stuck at the content edge ` +
+          `instead of the scroll container edge`,
+      ).toBeCloseTo(scrollContainerTop, 0);
+    }).toPass({ timeout: 2000 });
   });
 });
 
 test.describe('Spectrogram timeline visualization during scroll', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/project/test-id');
-    await uploadAudioFile(page, LONG_AUDIO);
+    await uploadAudioFile(page, CHIRP_AUDIO_10S);
 
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
     await expect(spectrogramCanvas).toBeVisible({ timeout: 15000 });
@@ -334,7 +320,9 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
       contentInfo.paddingTop + contentInfo.spectrogramHeight,
     );
 
-    const numSteps = 10;
+    // Use 5 steps instead of 10 — sufficient to detect coverage gaps
+    // while cutting scroll+render wait time in half.
+    const numSteps = 5;
     const results: Array<{ scrollPos: number; ratio: number }> = [];
 
     for (let i = 0; i <= numSteps; i++) {

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -1,22 +1,9 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { expect, test } from './fixtures';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const LONG_AUDIO = path.join(__dirname, 'fixtures', 'test-tone-10s.wav');
-
-/**
- * Uploads an audio file via the hidden file input inside the Ant Design Upload component.
- */
-async function uploadAudioFile(
-  page: import('@playwright/test').Page,
-  filePath: string,
-) {
-  const fileInput = page.locator('.toolbar input[type="file"]');
-  await fileInput.setInputFiles(filePath);
-}
+import {
+  expect,
+  test,
+  uploadAudioFile,
+  LONG_AUDIO_10S,
+} from './fixtures';
 
 /**
  * Simulates a vertical touch-swipe gesture on the timeline using CDP.
@@ -67,7 +54,7 @@ test.describe('Swipe to scrub timeline during playback', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/project/test-id');
-    await uploadAudioFile(page, LONG_AUDIO);
+    await uploadAudioFile(page, LONG_AUDIO_10S);
     await expect(page.locator('.timeline__track')).toBeVisible();
 
     // Dismiss the fullscreen overlay that appears on touch-capable devices

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
+    launchOptions: {
+      args: [
+        '--disable-gpu',
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-extensions',
+      ],
+    },
   },
   projects: [
     {


### PR DESCRIPTION
## Summary
- **Fix flaky mute/solo test** that timed out finding the file input under resource contention by adding `waitFor('attached')` before `setInputFiles`
- **Extract shared `uploadAudioFile` and audio path constants** into `fixtures.ts`, removing duplicate definitions from 9 test files (net -89 lines)
- **Add Chromium launch args** (`--disable-gpu`, `--no-sandbox`, `--disable-dev-shm-usage`, `--disable-extensions`) for faster browser startup
- **Restructure "synced Players" test** to avoid wasted double navigation from beforeEach (4.8s → 1.9s)
- **Restructure touch-drag test** to use `test.use({ hasTouch: true })` instead of creating a separate browser context (3.4s → 2.4s), which also ensures the `blockModelRequests` fixture applies
- **Replace `waitForTimeout` with `toPass` polling** in spectrogram sticky positioning test
- **Reduce spectrogram coverage scan** from 10 to 5 steps

**Result: 55.9s with 1 failure → 46.3s with 0 failures**

## Test plan
- [x] All 42 e2e tests pass (0 failures)
- [ ] Verify no visual regression snapshot updates needed
- [ ] Run tests multiple times to confirm flaky mute/solo test is stable

https://claude.ai/code/session_013QPjGFppP86UqShrLZDWbh