### PR TITLE
Add explicit Node version to Netlify build config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[build.environment]
+  NODE_VERSION = "22"
+
 [[redirects]]
   from = "/models/*"
   to = "https://essentia.upf.edu/models/:splat"


### PR DESCRIPTION
## Summary
- The latest production deploy for commit d94f88b (#387) failed on Netlify with an "unavailable" error and no specific error message
- The PR preview deploy for the same commit succeeded, and the build works locally — pointing to a transient Netlify build environment issue
- Added explicit `NODE_VERSION = "22"` to `netlify.toml` `[build.environment]` to ensure consistent Node version selection and trigger a fresh production deploy

## Test plan
- [x] Verified `npm run build` succeeds locally
- [x] All 785 unit tests pass
- [ ] Verify Netlify preview deploy succeeds for this PR
- [ ] After merge, verify production deploy at https://mawimbi.netlify.app/ reflects latest master

https://claude.ai/code/session_01ScL486G3cseoKRc39M9aJd