### PR TITLE
Fix bottom sheet UI: hide toolbar when content sheet opens, add safe area padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Create music, easy and intuitive" />
     <link rel="manifest" href="/manifest.json" />

--- a/src/components/workstation/BottomSheet.css
+++ b/src/components/workstation/BottomSheet.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   transition: height 0.25s ease-out;
   pointer-events: auto;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .bottom-sheet__header {

--- a/src/components/workstation/BottomSheet.css
+++ b/src/components/workstation/BottomSheet.css
@@ -9,7 +9,6 @@
   overflow: hidden;
   transition: height 0.25s ease-out;
   pointer-events: auto;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .bottom-sheet__header {
@@ -66,4 +65,10 @@
 
 .bottom-sheet__content {
   overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Extra spacing in fullscreen to clear the native device drawer handle */
+.fullscreen-enabled .bottom-sheet__content {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
 }

--- a/src/components/workstation/ToolbarBottomSheet.css
+++ b/src/components/workstation/ToolbarBottomSheet.css
@@ -2,7 +2,7 @@
    the floating toolbar. Shifts up via `bottom` when a content sheet opens. */
 .toolbar-dock {
   position: fixed;
-  bottom: calc(var(--offset, 0px) + env(safe-area-inset-bottom, 0px));
+  bottom: var(--offset, 0px);
   left: 0;
   right: 0;
   z-index: 2;
@@ -16,6 +16,10 @@
   border-radius: 12px 12px 0 0;
   overflow: hidden;
   transition: height 0.25s ease-out;
+}
+
+.toolbar-sheet--hidden {
+  pointer-events: none;
 }
 
 .toolbar-sheet__header {
@@ -34,6 +38,12 @@
 
 .toolbar-sheet__content {
   overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Extra spacing in fullscreen to clear the native device drawer handle */
+.fullscreen-enabled .toolbar-sheet__content {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
 }
 
 .toolbar-sheet__row {

--- a/src/components/workstation/ToolbarBottomSheet.css
+++ b/src/components/workstation/ToolbarBottomSheet.css
@@ -2,7 +2,7 @@
    the floating toolbar. Shifts up via `bottom` when a content sheet opens. */
 .toolbar-dock {
   position: fixed;
-  bottom: 0;
+  bottom: calc(var(--offset, 0px) + env(safe-area-inset-bottom, 0px));
   left: 0;
   right: 0;
   z-index: 2;

--- a/src/components/workstation/ToolbarBottomSheet.tsx
+++ b/src/components/workstation/ToolbarBottomSheet.tsx
@@ -77,7 +77,8 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
       onHeightChange: handleHeightChange,
     });
 
-  const totalHeight = contentHeight + HEADER_HEIGHT;
+  const isContentSheetOpen = sheetOffset > 0;
+  const totalHeight = isContentSheetOpen ? 0 : contentHeight + HEADER_HEIGHT;
   const lyricsIconClass = classNames({ 'show-lyrics': isLyricsOpen });
   const mixerIconClass = classNames('custom-icon', {
     'show-mixer': isMixerOpen,
@@ -86,10 +87,12 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
   return (
     <div
       className="toolbar-dock"
-      style={{
-        bottom: sheetOffset,
-        transition: isDraggingRef.current ? 'none' : undefined,
-      }}
+      style={
+        {
+          '--offset': `${sheetOffset}px`,
+          transition: isDraggingRef.current ? 'none' : undefined,
+        } as React.CSSProperties
+      }
     >
       <FloatingToolbar
         isEmpty={isEmpty}

--- a/src/components/workstation/ToolbarBottomSheet.tsx
+++ b/src/components/workstation/ToolbarBottomSheet.tsx
@@ -99,7 +99,9 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
         onToggleRecording={onToggleRecording}
       />
       <div
-        className="toolbar-sheet"
+        className={classNames('toolbar-sheet', {
+          'toolbar-sheet--hidden': isContentSheetOpen,
+        })}
         style={{
           height: totalHeight,
           transition: isDraggingRef.current ? 'none' : undefined,


### PR DESCRIPTION
## Summary
- Collapse the toolbar bottom sheet when the mixer or lyrics sheet is open, preventing the two sheets from overlapping
- Add `env(safe-area-inset-bottom)` spacing to all bottom sheets and the toolbar dock so they don't collide with the native device drawer handle in fullscreen mode
- Set `viewport-fit=cover` on the viewport meta tag to enable safe area CSS environment variables

## Test plan
- [ ] Open a project with tracks on a mobile device in fullscreen mode — verify the toolbar and mixer sheets have spacing above the device home indicator
- [ ] Open the mixer sheet — verify the toolbar sheet buttons are hidden (only the floating play/pause/rewind/record controls remain visible)
- [ ] Close the mixer sheet — verify the toolbar sheet reappears with its buttons
- [ ] Repeat with the lyrics sheet
- [ ] Verify all 42 e2e tests pass (including visual regression)
- [ ] Verify all 785 unit tests pass

https://claude.ai/code/session_01RCBGM8RyyJiQHDMM44cfrk