### PR TITLE
Fix bottom sheet UI: fullscreen spacing and toolbar hiding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Create music, easy and intuitive" />
     <link rel="manifest" href="/manifest.json" />

--- a/src/components/workstation/BottomSheet.css
+++ b/src/components/workstation/BottomSheet.css
@@ -65,4 +65,10 @@
 
 .bottom-sheet__content {
   overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Extra spacing in fullscreen to clear the native device drawer handle */
+.fullscreen-enabled .bottom-sheet__content {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
 }

--- a/src/components/workstation/ToolbarBottomSheet.css
+++ b/src/components/workstation/ToolbarBottomSheet.css
@@ -18,6 +18,10 @@
   transition: height 0.25s ease-out;
 }
 
+.toolbar-sheet--hidden {
+  pointer-events: none;
+}
+
 .toolbar-sheet__header {
   display: flex;
   flex-direction: column;
@@ -34,6 +38,12 @@
 
 .toolbar-sheet__content {
   overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Extra spacing in fullscreen to clear the native device drawer handle */
+.fullscreen-enabled .toolbar-sheet__content {
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
 }
 
 .toolbar-sheet__row {

--- a/src/components/workstation/ToolbarBottomSheet.tsx
+++ b/src/components/workstation/ToolbarBottomSheet.tsx
@@ -77,6 +77,7 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
       onHeightChange: handleHeightChange,
     });
 
+  const isContentSheetOpen = isMixerOpen || isLyricsOpen;
   const totalHeight = contentHeight + HEADER_HEIGHT;
   const lyricsIconClass = classNames({ 'show-lyrics': isLyricsOpen });
   const mixerIconClass = classNames('custom-icon', {
@@ -96,9 +97,11 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
         onToggleRecording={onToggleRecording}
       />
       <div
-        className="toolbar-sheet"
+        className={classNames('toolbar-sheet', {
+          'toolbar-sheet--hidden': isContentSheetOpen,
+        })}
         style={{
-          height: totalHeight,
+          height: isContentSheetOpen ? 0 : totalHeight,
           transition: isDraggingRef.current ? 'none' : undefined,
         }}
       >


### PR DESCRIPTION
## Summary
- Add extra bottom padding (16px) to all bottom sheets when in fullscreen mode, preventing collision with the native device drawer handle
- Enable `viewport-fit=cover` in the viewport meta tag to activate `env(safe-area-inset-bottom)` on devices with notches/home indicators
- Collapse the toolbar bottom sheet (height → 0, pointer-events: none) when the mixer or lyrics sheet opens, so it doesn't visually compete with the active content sheet

## Test plan
- [ ] Open the app on a mobile device, enter fullscreen, verify bottom sheets have visible spacing above the device drawer handle
- [ ] Open the toolbar sheet, then tap Mixer — verify the toolbar sheet collapses behind the mixer sheet
- [ ] Open the toolbar sheet, then tap Lyrics — verify the toolbar sheet collapses behind the lyrics sheet
- [ ] Close the mixer/lyrics sheet — verify the toolbar sheet reappears
- [ ] Visual regression tests pass (confirmed in CI)

https://claude.ai/code/session_01VG2ftYkNkLJ8ob67dWCSwY