### PR TITLE
Fix timeline shade gradient and cursor positioning

### DIFF
--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -40,7 +40,7 @@
 .scrubber__shade {
   position: absolute;
   top: 0;
-  bottom: 0;
+  /* bottom is set via inline style to match the drawer height */
   left: 0;
   right: 0;
   pointer-events: none;
@@ -49,7 +49,7 @@
 .scrubber__cursor {
   position: absolute;
   top: calc(
-    var(--timeline-scale-factor, 1) * (var(--cursor-position) * 100% - 120px)
+    var(--cursor-position) * (100% - var(--drawer-height, 0px)) - 120px
   );
   left: 0;
   right: 0;

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -42,23 +42,22 @@ it('does not pause playback when timeline is scrolled while paused', () => {
   expect(playbackService.isPlaying).toBe(false);
 });
 
-it('transforms timeline vertical scale when drawer is open', () => {
+it('positions shade bottom at drawer height instead of using scaleY', () => {
+  const drawerHeight = 120;
+
   const { container } = render(
-    <Scrubber {...{ ...defaultProps, drawerHeight: 120, isMixerOpen: true }} />,
+    <Scrubber {...{ ...defaultProps, drawerHeight }} />,
   );
 
-  const progressCursor = container.querySelector('.scrubber__cursor');
-  const timeline = container.querySelector('.scrubber__timeline');
+  const shade = container.querySelector('.scrubber__shade') as HTMLElement;
 
-  expect(timeline).toBeInTheDocument();
-  expect(progressCursor).toBeInTheDocument();
-
-  expect(progressCursor?.outerHTML).toEqual(
-    expect.stringContaining('transform: scaleY'),
-  );
+  // The shade should use direct bottom positioning to cover the visible area
+  // above the drawer, not scaleY which drifts when the viewport changes.
+  expect(shade.style.bottom).toBe(`${drawerHeight}px`);
+  expect(shade.style.transform).not.toContain('scaleY');
 });
 
-it('passes timeline scale factor as CSS variable to cursor for position alignment', () => {
+it('passes drawer height as CSS variable to cursor for position alignment', () => {
   const drawerHeight = 200;
 
   const { container } = render(
@@ -67,10 +66,11 @@ it('passes timeline scale factor as CSS variable to cursor for position alignmen
 
   const cursor = container.querySelector('.scrubber__cursor') as HTMLElement;
 
-  // The cursor element must expose --timeline-scale-factor so CSS can
-  // adjust the top position to stay aligned with the scaled scroll content.
-  const scaleVar = cursor.style.getPropertyValue('--timeline-scale-factor');
-  expect(scaleVar).toBeTruthy();
+  // The cursor element must expose --drawer-height so CSS can position the
+  // playhead within the visible area above the drawer.
+  const heightVar = cursor.style.getPropertyValue('--drawer-height');
+  expect(heightVar).toBe(`${drawerHeight}px`);
+  expect(cursor.style.transform).not.toContain('scaleY');
 });
 
 it('perspective wrapper handles wheel events for full hit-area coverage', () => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -248,8 +248,8 @@ export function useScrubber({
   }, [drawerHeight]);
 
   const timelineScrollStyle = getTimelineScrollStyle(timelineScaleFactor);
-  const timelineOverlayStyle = getTimelineOverlayStyle(timelineScaleFactor);
-  const cursorStyle = getCursorStyle(timelineScaleFactor);
+  const timelineOverlayStyle = getTimelineOverlayStyle(drawerHeight);
+  const cursorStyle = getCursorStyle(drawerHeight);
 
   const zoomControlsStyle = getZoomControlsStyle(
     drawerHeight,
@@ -304,30 +304,25 @@ function getTimelineScrollStyle(timelineScaleFactor: number) {
 }
 
 /**
- * Style for overlay elements (shade) that should NOT be flipped.
- * Only applies the drawer scaling.
+ * Style for the shade overlay. Uses direct `bottom` positioning so the
+ * gradient covers exactly the visible area above the drawer. This replaces
+ * the previous scaleY approach which drifted when the viewport height
+ * changed (e.g. mobile address bar show/hide).
  */
-function getTimelineOverlayStyle(timelineScaleFactor: number) {
+function getTimelineOverlayStyle(drawerHeight: number): CSSProperties {
   return {
-    ...baseTransformStyle,
-    transform: `scaleY(${timelineScaleFactor})`,
+    bottom: `${drawerHeight}px`,
   };
 }
 
 /**
- * Style for the cursor overlay. Extends the overlay transform with a CSS
- * variable that lets the cursor's `top` position scale proportionally.
- *
- * Without this, the cursor's percentage-based `top` resolves against the
- * un-scaled parent height while the scroll content is visually compressed
- * by scaleY. Multiplying `top` by the scale factor keeps the playhead
- * aligned with the scroll content at any drawer height.
+ * Style for the cursor overlay. Passes the drawer height as a CSS variable
+ * so the cursor's `top` position resolves against the visible area above
+ * the drawer. This replaces the previous scaleY approach.
  */
-function getCursorStyle(timelineScaleFactor: number): CSSProperties {
+function getCursorStyle(drawerHeight: number): CSSProperties {
   return {
-    ...baseTransformStyle,
-    transform: `scaleY(${timelineScaleFactor})`,
-    '--timeline-scale-factor': timelineScaleFactor,
+    '--drawer-height': `${drawerHeight}px`,
   } as React.CSSProperties;
 }
 


### PR DESCRIPTION
## Summary
- Replaced `scaleY(timelineScaleFactor)` on the shade overlay with direct `bottom: drawerHeight` positioning, so the gradient covers exactly the visible area above the drawer
- Replaced `scaleY` + `--timeline-scale-factor` on the cursor overlay with a `--drawer-height` CSS variable, so the playhead position resolves against the actual visible area
- Both overlays now track the drawer boundary directly instead of depending on a container height ratio that drifted when the viewport height changed (mobile address bar show/hide)

## Test plan
- [x] Updated unit tests verify shade uses `bottom` positioning (not scaleY) and cursor uses `--drawer-height` CSS variable
- [x] All 786 unit tests pass
- [x] All 42 e2e tests pass (including visual regression)
- [ ] Manual verification on mobile: open mixer bottom sheet, toggle browser address bar — gradient should fade smoothly without spectrogram peeking through

https://claude.ai/code/session_01SNafZA1527M7AhTReVhnD4