### PR TITLE
Fix window ReferenceError in spectrogram worker

### DIFF
--- a/src/services/__tests__/workerWindowPolyfill.test.ts
+++ b/src/services/__tests__/workerWindowPolyfill.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('applyWorkerWindowPolyfill', () => {
+  it('sets globalThis.window to self when window is undefined', async () => {
+    // Simulate a Web Worker environment: window is undefined, self exists
+    vi.stubGlobal('window', undefined);
+    const selfRef = globalThis.self;
+
+    // Re-import to trigger the polyfill with fresh module state
+    const { applyWorkerWindowPolyfill } =
+      await import('../workerWindowPolyfill');
+    applyWorkerWindowPolyfill();
+
+    expect(globalThis.window).toBe(selfRef);
+  });
+
+  it('does not overwrite window when it is already defined', async () => {
+    const originalWindow = globalThis.window;
+
+    const { applyWorkerWindowPolyfill } =
+      await import('../workerWindowPolyfill');
+    applyWorkerWindowPolyfill();
+
+    expect(globalThis.window).toBe(originalWindow);
+  });
+});

--- a/src/services/spectrogram.worker.ts
+++ b/src/services/spectrogram.worker.ts
@@ -1,3 +1,6 @@
+// Polyfill `window` for TF.js — must be first import (before Basic Pitch)
+import './workerWindowPolyfill';
+
 import { type TrackColor } from '../types/track';
 import { analyseCQT } from './CQTAnalyser';
 import {

--- a/src/services/workerWindowPolyfill.ts
+++ b/src/services/workerWindowPolyfill.ts
@@ -1,0 +1,17 @@
+/**
+ * Polyfill `window` in Web Worker environments.
+ *
+ * TensorFlow.js (used by @spotify/basic-pitch) references `window` internally
+ * for its custom setTimeout mechanism. Web Workers don't have `window` — their
+ * global scope is `self`. This polyfill aliases `window` to `self` so TF.js
+ * can run without throwing "ReferenceError: window is not defined".
+ *
+ * MUST be imported before any TF.js / Basic Pitch imports.
+ */
+export function applyWorkerWindowPolyfill(): void {
+  if (typeof window === 'undefined' && typeof self !== 'undefined') {
+    (globalThis as Record<string, unknown>).window = self;
+  }
+}
+
+applyWorkerWindowPolyfill();


### PR DESCRIPTION
## Summary
- TensorFlow.js (transitive dep of `@spotify/basic-pitch`) references `window` in its custom setTimeout mechanism, which doesn't exist in Web Worker scope
- Added `workerWindowPolyfill.ts` that aliases `globalThis.window = self` when running in a worker environment
- Imported the polyfill at the top of `spectrogram.worker.ts` before any TF.js code loads

## Test plan
- [x] Unit tests for `applyWorkerWindowPolyfill` verify the polyfill applies when `window` is undefined and is a no-op when `window` exists
- [x] All 788 existing tests pass
- [x] Production build succeeds
- [ ] Manual: upload an audio file, verify no "window is not defined" error in devtools console during melody extraction

https://claude.ai/code/session_01MF3z2QsD9Mf5ihEVpNTvMo