### PR TITLE
Fix timeline perspective overflow beyond viewport width

### DIFF
--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -6,6 +6,12 @@
   position: relative;
   /* Prevent flex child from expanding beyond allocated space */
   min-height: 0;
+  /* Clip the perspective-magnified edges of the tilted timeline.
+     The rotateX tilt pushes far content toward the viewer (positive z),
+     which perspective projects wider than the viewport. overflow-x: clip
+     trims the projected overflow without creating a scroll container
+     or flattening the 3D rendering context. */
+  overflow-x: clip;
 }
 
 .scrubber__perspective {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -295,6 +295,7 @@ const baseTransformStyle = {
  * then rotateX. Because rotateX acts on the already-flipped content, a positive
  * angle tilts the visual top (future) away and the visual bottom (time=0) toward
  * the viewer — creating the runway perspective where near content is wider.
+ * The parent .scrubber clips the projected overflow with overflow-x: clip.
  */
 function getTimelineScrollStyle(timelineScaleFactor: number) {
   return {


### PR DESCRIPTION
## Summary
- Add `overflow-x: clip` on `.scrubber` to prevent the perspective-tilted timeline from extending beyond the viewport width
- The `rotateX(55deg)` tilt pushes far content toward the viewer (positive z), which perspective projects wider than the viewport — `overflow-x: clip` trims this projected overflow without creating a scroll container or flattening the 3D rendering context

## Test plan
- [x] All 788 unit tests pass
- [x] All 42 e2e tests pass (including visual regression and alignment tests)
- [ ] Verify on mobile that the timeline bottom edge no longer extends past the viewport

https://claude.ai/code/session_013Lv9nhajAq4KWh35mXAzL2