### PR TITLE
Upgrade Tone.js from v14 to v15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
         "throttle-debounce": "^5.0.2",
-        "tone": "^14.7.77",
+        "tone": "^15.1.22",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.57.0",
@@ -10551,9 +10551,9 @@
       }
     },
     "node_modules/tone": {
-      "version": "14.9.17",
-      "resolved": "https://registry.npmjs.org/tone/-/tone-14.9.17.tgz",
-      "integrity": "sha512-+Qb7M4NMua+tb5Z52+MEVmjye0fjJuIFBePx423pqr9E6/lHDqZAG+fUAvo+Ujm48q0s9bVLRAyT1ETJJglNtg==",
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
       "license": "MIT",
       "dependencies": {
         "standardized-audio-context": "^25.3.70",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
     "throttle-debounce": "^5.0.2",
-    "tone": "^14.7.77",
+    "tone": "^15.1.22",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.57.0",

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -41,7 +41,7 @@ class AudioService {
 
   private constructor() {
     const transport = Tone.getTransport();
-    const context = Tone.context;
+    const context = Tone.getContext();
 
     this.playbackService = new PlaybackService(transport);
     this.recordingService = new RecordingService(transport, context);
@@ -69,7 +69,7 @@ class AudioService {
 
   private async initializeWorkletAnalyser(): Promise<void> {
     try {
-      const rawContext = Tone.context.rawContext as AudioContext;
+      const rawContext = Tone.getContext().rawContext as AudioContext;
       if (!rawContext.audioWorklet) return;
       const nativeCtx =
         (rawContext as unknown as { _nativeContext?: AudioContext })

--- a/src/services/FrequencyVisualizer.ts
+++ b/src/services/FrequencyVisualizer.ts
@@ -46,7 +46,7 @@ class FrequencyVisualizer {
   ) {
     const opts = normalizeOptions(optionsOrAnalyser);
 
-    const toneCtx = source.context ?? Tone.context;
+    const toneCtx = source.context ?? Tone.getContext();
     const rawCtx = toneCtx.rawContext as AudioContext;
     const nativeCtx =
       (rawCtx as unknown as { _nativeContext?: AudioContext })._nativeContext ??
@@ -111,7 +111,7 @@ class FrequencyVisualizer {
     source: Tone.ToneAudioNode,
     sampleRate: number,
   ): void {
-    const toneCtx = source.context ?? Tone.context;
+    const toneCtx = source.context ?? Tone.getContext();
     const ctx = toneCtx.rawContext as AudioContext;
 
     // Use a large FFT size to get enough time-domain samples per read.

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -126,6 +126,7 @@ vi.mock('tone', () => {
     }),
     getDestination: vi.fn().mockReturnValue(makeNode()),
     context: contextMock,
+    getContext: vi.fn().mockReturnValue(contextMock),
     setContext: vi.fn(),
     // Must be a regular function (not arrow) to support `new`
     Context: vi.fn().mockImplementation(function () {}),


### PR DESCRIPTION
## Summary
- Upgraded `tone` dependency from `^14.7.77` to `^15.1.22`
- Replaced deprecated `Tone.context` singleton with `Tone.getContext()` getter in `AudioService.ts` and `FrequencyVisualizer.ts`
- Added `getContext` mock to test setup for v15 compatibility

Closes #399

## Test plan
- [x] All 788 unit tests pass
- [x] Production build succeeds
- [x] ESLint passes
- [ ] E2E tests (blocked by missing Playwright browsers in CI environment — not related to code changes)
- [ ] Manual smoke test: upload, playback, recording, mixing

https://claude.ai/code/session_01THxembZzJLTnBUjofcgwJe