### PR TITLE
Bump uuid 9→13 and @dnd-kit/sortable 8→10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mawimbi",
       "version": "0.1.0",
       "dependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@eslint/js": "^9.39.4",
         "@huggingface/transformers": "^3.8.1",
@@ -23,7 +23,6 @@
         "@types/node": "^25.4.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^5.1.4",
         "class-variance-authority": "^0.7.1",
         "classnames": "^2.3.3",
@@ -56,7 +55,7 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.57.0",
-        "uuid": "^9.0.1",
+        "uuid": "^13.0.0",
         "vite": "^7.3.1",
         "vite-plugin-svgr": "^4.2.0",
         "vitest": "^4.0.18"
@@ -585,16 +584,16 @@
       }
     },
     "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/core": "^6.3.0",
         "react": ">=16.8.0"
       }
     },
@@ -4704,12 +4703,6 @@
       "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-pDzSNulqooSKvSNcksnV72nk8p7gRqN8As71Sp28nov1IgmPKWbOEIwAWvBME5pPTtaXJAvG3O4oc76HlQ4kqQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/webgl-ext": {
@@ -10879,16 +10872,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vehicles": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.1.0",
-    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@eslint/js": "^9.39.4",
     "@huggingface/transformers": "^3.8.1",
@@ -22,7 +22,6 @@
     "@types/node": "^25.4.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^5.1.4",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.3.3",
@@ -55,7 +54,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.57.0",
-    "uuid": "^9.0.1",
+    "uuid": "^13.0.0",
     "vite": "^7.3.1",
     "vite-plugin-svgr": "^4.2.0",
     "vitest": "^4.0.18"


### PR DESCRIPTION
## Summary

- **uuid 9→13**: Four major versions bumped. v13 is ESM-only (project already uses `"type": "module"`). Ships built-in TypeScript types, so `@types/uuid` is removed. The `import { v4 as uuidv4 } from 'uuid'` API is unchanged.
- **@dnd-kit/sortable 8→10**: Two major versions bumped. v10 requires `@dnd-kit/core ≥6.3.0` (bumped from `^6.1.0` to `^6.3.1`). No API changes — Mixer.tsx continues to work without modification. Key fix in v9: resolved a bug with sortable elements having `id` equal to `0`.
- **@types/uuid removed**: No longer needed since uuid v11+ is written in TypeScript and ships its own type declarations.

These were the two packages skipped in #398 (along with `tone`, already upgraded in #404).

## Test plan

- [x] All 788 unit tests pass (`npm test -- --run`)
- [x] Lint passes (`npm run lint`)
- [x] TypeScript compiles without errors (`tsc -b`)
- [ ] E2E tests (Playwright browsers not available in this environment)
- [ ] Manual smoke test: drag-and-drop reorder in Mixer still works

https://claude.ai/code/session_01QD4RnKFa7cdeyj4FxBdbuy