### PR TITLE
Tune runway perspective for horizontal road effect

### DIFF
--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -23,7 +23,7 @@ type UseScrubberOptions = {
 
 // How far (px) the near edge extends below the viewport for the
 // runway-emerging-from-screen effect. Reclaimed when the drawer opens.
-const RUNWAY_EXTENSION = 400;
+const RUNWAY_EXTENSION = 600;
 const SCROLL_DEBOUNCE_MS = 200;
 
 export function useScrubber({
@@ -295,8 +295,8 @@ export function useScrubber({
 }
 
 // Fallbacks if CSS custom properties are missing or unparseable
-const FALLBACK_PERSPECTIVE = 1000;
-const FALLBACK_TILT = 55;
+const FALLBACK_PERSPECTIVE = 1300;
+const FALLBACK_TILT = 80;
 
 const baseTransformStyle = {
   willChange: 'transform',

--- a/src/index.css
+++ b/src/index.css
@@ -116,8 +116,8 @@ html {
   /* Perspective tilt: runway depth effect on the timeline.
      Higher perspective = smoother foreshortening. Higher tilt = steeper angle.
      These two values control the entire runway feel. */
-  --timeline-perspective: 1000px;
-  --timeline-tilt: 55deg;
+  --timeline-perspective: 1300px;
+  --timeline-tilt: 80deg;
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Summary
- Updated `--timeline-tilt` from `55deg` to `80deg` for a nearly-horizontal road surface feel
- Updated `--timeline-perspective` from `1000px` to `1300px` so the apparent width at the cursor position is ~75% of screen width
- Increased `RUNWAY_EXTENSION` from `400px` to `600px` for more convincing below-viewport extension at 80deg tilt
- Updated JS fallback values in `useScrubber.ts` to match the new CSS custom properties

Closes #407

## Test plan
- [x] All 788 unit tests pass
- [x] Production build succeeds
- [ ] Verify visually that the timeline perspective feels like a horizontal road extending into the distance
- [ ] Confirm the near edge extends past both sides of the screen
- [ ] Confirm width at the cursor position is approximately 75% of screen width

https://claude.ai/code/session_01LwJKLTjm1vipD9MiB4Zjyf