### PR TITLE
Lift timeline runway to center of screen and remove shade overlay

### DIFF
--- a/src/components/workstation/scrubber/Scrubber.css
+++ b/src/components/workstation/scrubber/Scrubber.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   min-height: 0;
   perspective: var(--timeline-perspective);
-  perspective-origin: center bottom;
+  /* perspective-origin is set via inline style (dynamic, drawer-aware) */
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -24,10 +24,8 @@
 }
 
 .scrubber__timeline {
-  /* Fill the perspective container, then the inline transform extends
-     height (scaleY) so the foreshortened far edge fills the visible top.
-     margin-bottom pushes the near edge below the viewport for an
-     immersive runway-emerging-from-screen effect. */
+  /* Fill the perspective container. The inline transform tilts and scales
+     the timeline for the runway perspective effect. */
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -41,15 +39,6 @@
   container-type: size;
 }
 
-.scrubber__shade {
-  position: absolute;
-  top: 0;
-  /* bottom is set via inline style to match the drawer height */
-  left: 0;
-  right: 0;
-  pointer-events: none;
-}
-
 .scrubber__cursor {
   position: absolute;
   top: calc(
@@ -59,22 +48,6 @@
   right: 0;
   height: 240px;
   pointer-events: none;
-}
-
-.shade {
-  width: 100%;
-  height: 100%;
-  /* Atmospheric fog gradient: heavier at the far end (top) to sell depth,
-     transparent around the cursor zone, then fading back to solid at the
-     near edge (bottom) for the edge vignette. */
-  background-image: linear-gradient(
-    to bottom,
-    rgb(var(--shade-color)),
-    rgba(var(--shade-color), 0.85) 15%,
-    rgba(var(--shade-color), 0) 30%,
-    rgba(var(--shade-color), 0.8) 75%,
-    rgb(var(--shade-color)) 100%
-  );
 }
 
 .plasma-playhead {

--- a/src/components/workstation/scrubber/Scrubber.tsx
+++ b/src/components/workstation/scrubber/Scrubber.tsx
@@ -25,8 +25,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     timelineScrollRef,
     cursorContainerRef,
     plasmaRef,
+    perspectiveStyle,
     timelineScrollStyle,
-    timelineOverlayStyle,
     cursorStyle,
     zoomControlsStyle,
     handleScroll,
@@ -57,6 +57,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     <div className="scrubber scrubber--firefox-scroll-fix">
       <div
         className="scrubber__perspective"
+        style={perspectiveStyle}
         onClick={handlePerspectiveClick}
         onWheel={handlePerspectiveWheel}
       >
@@ -71,9 +72,6 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         >
           {props.children}
         </div>
-      </div>
-      <div className="scrubber__shade" style={timelineOverlayStyle}>
-        <div className="shade"></div>
       </div>
       <div
         ref={cursorContainerRef}

--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -42,19 +42,26 @@ it('does not pause playback when timeline is scrolled while paused', () => {
   expect(playbackService.isPlaying).toBe(false);
 });
 
-it('positions shade bottom at drawer height instead of using scaleY', () => {
-  const drawerHeight = 120;
+it('positions perspective-origin and transform-origin at runway bottom', () => {
+  const { container } = render(<Scrubber {...defaultProps} />);
 
-  const { container } = render(
-    <Scrubber {...{ ...defaultProps, drawerHeight }} />,
-  );
+  const perspective = container.querySelector(
+    '.scrubber__perspective',
+  ) as HTMLElement;
+  const timeline = container.querySelector(
+    '.scrubber__timeline',
+  ) as HTMLElement;
 
-  const shade = container.querySelector('.scrubber__shade') as HTMLElement;
+  // Both origins should use the same Y coordinate (runway bottom).
+  // In jsdom offsetHeight is 0, so runwayBottomY = 0.75 * max(0 - 0, 0) = 0.
+  expect(perspective.style.perspectiveOrigin).toBe('center 0px');
+  expect(timeline.style.transformOrigin).toBe('center 0px');
+});
 
-  // The shade should use direct bottom positioning to cover the visible area
-  // above the drawer, not scaleY which drifts when the viewport changes.
-  expect(shade.style.bottom).toBe(`${drawerHeight}px`);
-  expect(shade.style.transform).not.toContain('scaleY');
+it('does not render a shade overlay', () => {
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  expect(container.querySelector('.scrubber__shade')).toBeNull();
 });
 
 it('passes drawer height as CSS variable to cursor for position alignment', () => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -21,9 +21,9 @@ type UseScrubberOptions = {
   pixelsPerSecond: number;
 };
 
-// How far (px) the near edge extends below the viewport for the
-// runway-emerging-from-screen effect. Reclaimed when the drawer opens.
-const RUNWAY_EXTENSION = 600;
+// The runway bottom sits at this fraction from the top of the visible area
+// (viewport minus drawer). 0.75 = bottom 25% of visible area is empty.
+const RUNWAY_BOTTOM_FRACTION = 0.75;
 const SCROLL_DEBOUNCE_MS = 200;
 
 export function useScrubber({
@@ -224,31 +224,15 @@ export function useScrubber({
     debouncedSetTransportTime();
   };
 
-  const [extendFactor, setExtendFactor] = useState(1.0);
+  const [containerHeight, setContainerHeight] = useState(0);
 
-  // Recalculate the scale factor when the timeline container resizes
-  // (e.g. entering/exiting fullscreen). The factor compensates for
-  // perspective foreshortening so the far edge (top) fills the viewport.
+  // Track the scroll container height so derived layout values
+  // (runway position, extendFactor) update on resize.
   useLayoutEffect(() => {
     const el = timelineScrollRef.current;
     if (!el) return;
 
-    const update = () => {
-      const timelineHeight = el.offsetHeight;
-      if (timelineHeight <= 0) return;
-
-      const style = getComputedStyle(document.documentElement);
-      const perspective =
-        parseFloat(style.getPropertyValue('--timeline-perspective')) ||
-        FALLBACK_PERSPECTIVE;
-      const tiltDeg =
-        parseFloat(style.getPropertyValue('--timeline-tilt')) || FALLBACK_TILT;
-      const tiltRad = (tiltDeg * Math.PI) / 180;
-      const depth = timelineHeight * Math.sin(tiltRad);
-      const projectionRatio = perspective / (perspective + depth);
-      setExtendFactor(1 / projectionRatio);
-    };
-
+    const update = () => setContainerHeight(el.offsetHeight);
     update();
 
     const observer = new ResizeObserver(() => update());
@@ -257,15 +241,21 @@ export function useScrubber({
     return () => observer.disconnect();
   }, []);
 
-  // Positive = push near edge below viewport (runway extension).
-  // Shrinks when the drawer opens to keep the near edge above it.
-  const runwayOffsetPx = RUNWAY_EXTENSION - drawerHeight;
+  // The runway bottom sits at RUNWAY_BOTTOM_FRACTION of the visible area
+  // (container minus drawer). Both perspective-origin and transform-origin
+  // are placed here so the tilt pivots at the runway bottom.
+  const visibleHeight = Math.max(containerHeight - drawerHeight, 0);
+  const runwayBottomY = RUNWAY_BOTTOM_FRACTION * visibleHeight;
 
+  // Compensate for perspective foreshortening so the far edge (top) fills
+  // the viewport. The depth is the distance from the origin to the far edge.
+  const extendFactor = computeExtendFactor(runwayBottomY);
+
+  const perspectiveStyle = getPerspectiveStyle(runwayBottomY);
   const timelineScrollStyle = getTimelineScrollStyle(
     extendFactor,
-    runwayOffsetPx,
+    runwayBottomY,
   );
-  const timelineOverlayStyle = getTimelineOverlayStyle(drawerHeight);
   const cursorStyle = getCursorStyle(drawerHeight);
 
   const zoomControlsStyle = getZoomControlsStyle(drawerHeight);
@@ -282,8 +272,8 @@ export function useScrubber({
     timelineScrollRef,
     cursorContainerRef,
     plasmaRef,
+    perspectiveStyle,
     timelineScrollStyle,
-    timelineOverlayStyle,
     cursorStyle,
     zoomControlsStyle,
     handleScroll,
@@ -304,39 +294,50 @@ const baseTransformStyle = {
 };
 
 /**
- * Style for the scroll container. The transform tilts the timeline into a
- * dramatic runway perspective:
- * - rotateX tilts the plane around the bottom edge
- * - scaleY(extendFactor) compensates for perspective foreshortening so the
- *   far edge (top) fills the viewport regardless of screen size
- * - translateY(runwayOffsetPx) pushes the near edge below the viewport,
- *   creating the runway-emerging-from-screen effect. The offset shrinks
- *   when the bottom sheet opens so the near edge stays above the drawer.
+ * Compensate for perspective foreshortening so the far edge (top) fills
+ * the viewport. `runwayBottomY` is the distance from the top of the
+ * container to the tilt origin — content above the origin is the visible
+ * runway that needs to fill the viewport width after foreshortening.
  */
-function getTimelineScrollStyle(extendFactor: number, runwayOffsetPx: number) {
+function computeExtendFactor(runwayBottomY: number): number {
+  if (runwayBottomY <= 0) return 1;
+
+  const tiltRad = (FALLBACK_TILT * Math.PI) / 180;
+  const depth = runwayBottomY * Math.sin(tiltRad);
+  const projectionRatio = FALLBACK_PERSPECTIVE / (FALLBACK_PERSPECTIVE + depth);
+  return 1 / projectionRatio;
+}
+
+/**
+ * Style for the perspective wrapper. Places `perspective-origin` at the
+ * runway bottom so the vanishing point matches the tilt pivot.
+ */
+function getPerspectiveStyle(runwayBottomY: number): CSSProperties {
   return {
-    ...baseTransformStyle,
-    transformOrigin: 'center bottom',
-    transform: `rotateX(var(--timeline-tilt, 0deg)) scaleY(${extendFactor}) translateY(${runwayOffsetPx}px)`,
+    perspectiveOrigin: `center ${runwayBottomY}px`,
   };
 }
 
 /**
- * Style for the shade overlay. Uses direct `bottom` positioning so the
- * gradient covers exactly the visible area above the drawer. This replaces
- * the previous scaleY approach which drifted when the viewport height
- * changed (e.g. mobile address bar show/hide).
+ * Style for the scroll container. The transform tilts the timeline into a
+ * dramatic runway perspective:
+ * - rotateX tilts the plane around the runway bottom
+ * - scaleY(extendFactor) compensates for perspective foreshortening so the
+ *   far edge (top) fills the viewport regardless of screen size
+ * - transformOrigin is placed at the runway bottom so the tilt pivots there
  */
-function getTimelineOverlayStyle(drawerHeight: number): CSSProperties {
+function getTimelineScrollStyle(extendFactor: number, runwayBottomY: number) {
   return {
-    bottom: `${drawerHeight}px`,
+    ...baseTransformStyle,
+    transformOrigin: `center ${runwayBottomY}px`,
+    transform: `rotateX(var(--timeline-tilt, 0deg)) scaleY(${extendFactor})`,
   };
 }
 
 /**
  * Style for the cursor overlay. Passes the drawer height as a CSS variable
  * so the cursor's `top` position resolves against the visible area above
- * the drawer. This replaces the previous scaleY approach.
+ * the drawer.
  */
 function getCursorStyle(drawerHeight: number): CSSProperties {
   return {

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,6 @@
   --color-surface: var(--surface);
   --color-foreground-muted: var(--foreground-muted);
   --color-foreground-faint: var(--foreground-faint);
-  --color-shade: var(--shade-color);
   --color-overlay-bg: var(--overlay-bg);
   --color-overlay-solid: var(--overlay-solid);
   --radius-sm: calc(var(--radius) - 4px);


### PR DESCRIPTION
## Summary
- Position the runway bottom at 75% from the top of the visible area (viewport minus drawer height) by dynamically computing `perspective-origin` and `transform-origin` at the same Y coordinate
- Replace the fixed `RUNWAY_EXTENSION` / `translateY` approach with a `RUNWAY_BOTTOM_FRACTION` constant that scales proportionally to the visible area
- When the bottom sheet opens, the runway bottom moves up proportionally to stay at 75% of the remaining visible space
- Remove the shade overlay (fog gradient) element, CSS classes (`.scrubber__shade`, `.shade`), and `getTimelineOverlayStyle` computation entirely
- Remove unused `--color-shade` CSS variable alias

## Test plan
- [x] All 789 unit tests pass
- [x] ESLint clean
- [x] Production build succeeds
- [ ] Verify visually that the runway bottom is positioned around the vertical 75% mark of the screen
- [ ] Verify the runway adjusts correctly when the mixer bottom sheet is opened/closed
- [ ] Verify the playhead cursor still aligns visually with the scroll position
- [ ] Verify e2e tests pass (Playwright not available in CI-less environment)
- [ ] Check visual regression snapshots if e2e visual tests are affected

https://claude.ai/code/session_01Ld9jkzyxKtQq3cnrjdCVyB