### PR TITLE
Fix timeline width changing when bottom sheet opens

### DIFF
--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -53,9 +53,47 @@ it('positions perspective-origin and transform-origin at runway bottom', () => {
   ) as HTMLElement;
 
   // Both origins should use the same Y coordinate (runway bottom).
-  // In jsdom offsetHeight is 0, so runwayBottomY = 0.75 * max(0 - 0, 0) = 0.
+  // In jsdom offsetHeight is 0, so runwayBottomY = 0.75 * 0 = 0.
   expect(perspective.style.perspectiveOrigin).toBe('center 0px');
   expect(timeline.style.transformOrigin).toBe('center 0px');
+});
+
+it('keeps perspective geometry stable when drawer height changes', () => {
+  // Mock offsetHeight so the layout effect reads a non-zero container height
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight',
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return 800;
+    },
+  });
+
+  const { container, rerender } = render(<Scrubber {...defaultProps} />);
+
+  const timeline = container.querySelector(
+    '.scrubber__timeline',
+  ) as HTMLElement;
+
+  const transformWithoutDrawer = timeline.style.transform;
+
+  // Open the drawer — the perspective geometry should NOT change
+  rerender(<Scrubber {...defaultProps} drawerHeight={280} />);
+
+  const transformWithDrawer = timeline.style.transform;
+
+  expect(transformWithDrawer).toBe(transformWithoutDrawer);
+
+  // Restore
+  if (originalDescriptor) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetHeight',
+      originalDescriptor,
+    );
+  }
 });
 
 it('does not render a shade overlay', () => {

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -241,11 +241,11 @@ export function useScrubber({
     return () => observer.disconnect();
   }, []);
 
-  // The runway bottom sits at RUNWAY_BOTTOM_FRACTION of the visible area
-  // (container minus drawer). Both perspective-origin and transform-origin
-  // are placed here so the tilt pivots at the runway bottom.
-  const visibleHeight = Math.max(containerHeight - drawerHeight, 0);
-  const runwayBottomY = RUNWAY_BOTTOM_FRACTION * visibleHeight;
+  // The runway bottom sits at RUNWAY_BOTTOM_FRACTION of the full container.
+  // Using the full height (not visible height) keeps the perspective geometry
+  // stable when the bottom sheet opens — the 3D transform and scaleY
+  // compensation stay constant, preventing the timeline from appearing wider.
+  const runwayBottomY = RUNWAY_BOTTOM_FRACTION * containerHeight;
 
   // Compensate for perspective foreshortening so the far edge (top) fills
   // the viewport. The depth is the distance from the origin to the far edge.


### PR DESCRIPTION
## Summary
- Compute the runway bottom position from the full container height instead of the visible height (container minus drawer)
- This keeps the 3D perspective geometry (scaleY compensation, transform-origin, perspective-origin) stable when the bottom sheet opens, preventing the timeline from appearing wider
- Add a regression test verifying the transform stays constant across drawer height changes

## Test plan
- [x] All 790 unit tests pass
- [x] ESLint clean
- [x] New test verifies perspective geometry is stable when drawer height changes
- [ ] Visually verify the timeline width stays consistent when opening/closing the mixer bottom sheet
- [ ] E2e tests (Playwright browser not available in this environment)

https://claude.ai/code/session_01Hu37p6o9RHSPCKQnbdfjz6