### PR TITLE
Fix timeline runway transform when bottom sheet opens

### DIFF
--- a/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
+++ b/src/components/workstation/scrubber/__tests__/Scrubber.test.tsx
@@ -96,6 +96,55 @@ it('keeps perspective geometry stable when drawer height changes', () => {
   }
 });
 
+it('applies translateY and scaleY to perspective div when drawer is open', () => {
+  const containerHeight = 800;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight',
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return containerHeight;
+    },
+  });
+
+  const drawerHeight = 280;
+  const { container } = render(
+    <Scrubber {...defaultProps} drawerHeight={drawerHeight} />,
+  );
+
+  const perspective = container.querySelector(
+    '.scrubber__perspective',
+  ) as HTMLElement;
+
+  const visibleHeight = containerHeight - drawerHeight;
+  const expectedScaleY = visibleHeight / containerHeight;
+  const expectedTranslateY = -drawerHeight / 2;
+
+  expect(perspective.style.transform).toBe(
+    `translateY(${expectedTranslateY}px) scaleY(${expectedScaleY})`,
+  );
+
+  if (originalDescriptor) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      'offsetHeight',
+      originalDescriptor,
+    );
+  }
+});
+
+it('does not apply perspective transform when drawer is closed', () => {
+  const { container } = render(<Scrubber {...defaultProps} drawerHeight={0} />);
+
+  const perspective = container.querySelector(
+    '.scrubber__perspective',
+  ) as HTMLElement;
+
+  expect(perspective.style.transform).toBe('');
+});
+
 it('does not render a shade overlay', () => {
   const { container } = render(<Scrubber {...defaultProps} />);
 

--- a/src/components/workstation/scrubber/useScrubber.ts
+++ b/src/components/workstation/scrubber/useScrubber.ts
@@ -251,7 +251,11 @@ export function useScrubber({
   // the viewport. The depth is the distance from the origin to the far edge.
   const extendFactor = computeExtendFactor(runwayBottomY);
 
-  const perspectiveStyle = getPerspectiveStyle(runwayBottomY);
+  const perspectiveStyle = getPerspectiveStyle(
+    runwayBottomY,
+    drawerHeight,
+    containerHeight,
+  );
   const timelineScrollStyle = getTimelineScrollStyle(
     extendFactor,
     runwayBottomY,
@@ -311,10 +315,30 @@ function computeExtendFactor(runwayBottomY: number): number {
 /**
  * Style for the perspective wrapper. Places `perspective-origin` at the
  * runway bottom so the vanishing point matches the tilt pivot.
+ *
+ * When the drawer is open, `translateY` and `scaleY` reposition and shrink
+ * the runway to fit the visible area above the drawer — without touching
+ * the child timeline's own 3D transform or styling.
  */
-function getPerspectiveStyle(runwayBottomY: number): CSSProperties {
+function getPerspectiveStyle(
+  runwayBottomY: number,
+  drawerHeight: number,
+  containerHeight: number,
+): CSSProperties {
+  const hasDrawer = drawerHeight > 0 && containerHeight > 0;
+  const visibleHeight = containerHeight - drawerHeight;
+  const scaleY = hasDrawer ? visibleHeight / containerHeight : 1;
+  // With the default transform-origin (center), scaleY shifts the top edge
+  // downward by half the removed height. translateY compensates so the top
+  // stays at the viewport edge.
+  const translateY = hasDrawer ? -drawerHeight / 2 : 0;
+
   return {
     perspectiveOrigin: `center ${runwayBottomY}px`,
+    ...(hasDrawer && {
+      ...baseTransformStyle,
+      transform: `translateY(${translateY}px) scaleY(${scaleY})`,
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `translateY` / `scaleY` transform to the `scrubber__perspective` div so the timeline runway repositions and scales to fit the visible area when the mixer drawer opens or closes
- `scaleY` maps the full container height to the visible height (container minus drawer); `translateY` compensates for center-origin scaling to keep the top edge pinned
- Leaves the child timeline's own 3D perspective transform and CSS styling unchanged

## Test plan
- [x] All 792 unit tests pass
- [x] ESLint clean
- [x] New test verifies `translateY` and `scaleY` are applied when drawer is open
- [x] New test verifies no transform is applied when drawer is closed
- [ ] Visually verify the timeline runway moves/scales smoothly when opening/closing the mixer bottom sheet

https://claude.ai/code/session_01FFpncJgJP4T8GCLrYWmBqg