### PR TITLE
Fix mobile timeline scroll with viewport touch proxy

### DIFF
--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -331,3 +331,39 @@ it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
   // At time=0, scrollTop should be at max (beginning at bottom)
   expect(timeline.scrollTop).toBe(1500);
 });
+
+it('pauses playback when viewport is touch-swiped while playing', () => {
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  // Touch events on the viewport wrapper should scroll the tilt container.
+  // This enables mobile scrolling across the full rectangular area, not
+  // just the narrow trapezoid of the tilted scroll container.
+  const viewport = container.querySelector('.scrubber__viewport')!;
+  fireEvent.touchStart(viewport, {
+    touches: [{ clientX: 100, clientY: 300 }],
+  });
+  fireEvent.touchMove(viewport, {
+    touches: [{ clientX: 100, clientY: 250 }],
+  });
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
+it('does not pause playback on viewport tap (no swipe movement)', () => {
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const viewport = container.querySelector('.scrubber__viewport')!;
+  fireEvent.touchStart(viewport, {
+    touches: [{ clientX: 100, clientY: 300 }],
+  });
+  // Tiny movement below swipe threshold — should not trigger scroll
+  fireEvent.touchMove(viewport, {
+    touches: [{ clientX: 100, clientY: 298 }],
+  });
+
+  expect(playbackService.isPlaying).toBe(true);
+});

--- a/src/features/workstation/scrubber/Scrubber.css
+++ b/src/features/workstation/scrubber/Scrubber.css
@@ -17,6 +17,10 @@
   min-height: 0;
   perspective: var(--timeline-perspective);
   /* perspective-origin is set via inline style (dynamic, drawer-aware) */
+  /* Disable browser touch gestures so the viewport touch-scroll proxy can
+     translate swipe gestures into programmatic scroll on the tilt container.
+     The 3D tilt transform breaks native touch scrolling on mobile devices. */
+  touch-action: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -46,12 +46,17 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     handleWheel,
     handleTouchMove,
     handleViewportWheel,
+    handleViewportTouchStart,
+    handleViewportTouchMove,
+    isTouchScrollingRef,
     syncScrollToTime,
   } = useScrubberScroll({ scrollRef, playheadRef, pixelsPerSecond });
 
   useImperativeHandle(ref, () => ({ syncScrollToTime }), [syncScrollToTime]);
 
   const handleTimelineClick = () => {
+    // Suppress click synthesized after a touch-scroll swipe
+    if (isTouchScrollingRef.current) return;
     if (recording.isCountingIn || recording.isActivelyRecording) {
       onStopRecording();
       return;
@@ -62,6 +67,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   // Click handler for the viewport wrapper — catches clicks in the
   // dead-zone corners outside the tilted scroll container's trapezoid.
   const handleViewportClick = (e: React.MouseEvent) => {
+    if (isTouchScrollingRef.current) return;
     if (scrollRef.current?.contains(e.target as Node)) return;
     handleTimelineClick();
   };
@@ -83,6 +89,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         style={viewportStyle}
         onClick={handleViewportClick}
         onWheel={handleViewportWheel}
+        onTouchStart={handleViewportTouchStart}
+        onTouchMove={handleViewportTouchMove}
       >
         <ScrubberTilt
           ref={tiltRef}

--- a/src/features/workstation/scrubber/ScrubberViewport.tsx
+++ b/src/features/workstation/scrubber/ScrubberViewport.tsx
@@ -4,6 +4,8 @@ type ScrubberViewportProps = PropsWithChildren<{
   style: CSSProperties;
   onClick: (e: React.MouseEvent) => void;
   onWheel: (e: React.WheelEvent) => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
 }>;
 
 /**
@@ -15,13 +17,17 @@ type ScrubberViewportProps = PropsWithChildren<{
  * to fit the reduced viewport — without touching the child tilt
  * container's own 3D transform.
  *
- * Also catches click and wheel events in the dead-zone corners outside
- * the tilted scroll container's trapezoid.
+ * Also catches click, wheel, and touch events in the dead-zone corners
+ * outside the tilted scroll container's trapezoid. Touch events are
+ * translated into programmatic scroll on the tilt container, since the
+ * 3D tilt transform breaks native touch scrolling on mobile devices.
  */
 const ScrubberViewport = ({
   style,
   onClick,
   onWheel,
+  onTouchStart,
+  onTouchMove,
   children,
 }: ScrubberViewportProps) => {
   return (
@@ -30,6 +36,8 @@ const ScrubberViewport = ({
       style={style}
       onClick={onClick}
       onWheel={onWheel}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
     >
       {children}
     </div>

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -1,5 +1,6 @@
 import {
   type RefObject,
+  type TouchEvent as ReactTouchEvent,
   type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
@@ -15,6 +16,7 @@ import FrequencyVisualizer from '../../spectrogram/FrequencyVisualizer';
 import { type PlayheadHandle } from './Playhead';
 
 const SCROLL_DEBOUNCE_MS = 200;
+const SWIPE_THRESHOLD_PX = 5;
 
 type UseScrubberScrollOptions = {
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -194,6 +196,45 @@ export function useScrubberScroll({
     debouncedSetTransportTime();
   };
 
+  // --- Viewport touch-scroll proxy for mobile ---
+  // The 3D tilt transform on the scroll container breaks native touch
+  // scrolling on mobile devices — the heavily rotated element has a narrow
+  // trapezoidal hit-test area. These handlers capture single-finger swipe
+  // gestures on the full-rectangle viewport wrapper and translate them into
+  // programmatic scroll on the tilt container.
+  const touchStartYRef = useRef(0);
+  const touchScrollTopRef = useRef(0);
+  const isTouchScrollingRef = useRef(false);
+
+  const handleViewportTouchStart = (e: ReactTouchEvent) => {
+    if (e.touches.length !== 1) return;
+    touchStartYRef.current = e.touches[0].clientY;
+    touchScrollTopRef.current = scrollRef.current?.scrollTop ?? 0;
+    isTouchScrollingRef.current = false;
+  };
+
+  const handleViewportTouchMove = (e: ReactTouchEvent) => {
+    if (e.touches.length !== 1) return;
+    if (isPinchingRef.current) return;
+
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const deltaY = touchStartYRef.current - e.touches[0].clientY;
+
+    if (!isTouchScrollingRef.current) {
+      if (Math.abs(deltaY) < SWIPE_THRESHOLD_PX) return;
+      isTouchScrollingRef.current = true;
+    }
+
+    isProgrammaticScrollRef.current = true;
+    el.scrollTop = touchScrollTopRef.current + deltaY;
+
+    if (recording.isActivelyRecording) return;
+    pauseForUserScroll();
+    debouncedSetTransportTime();
+  };
+
   const handleScroll = () => {
     if (isProgrammaticScrollRef.current) {
       isProgrammaticScrollRef.current = false;
@@ -218,6 +259,9 @@ export function useScrubberScroll({
     handleWheel,
     handleTouchMove,
     handleViewportWheel,
+    handleViewportTouchStart,
+    handleViewportTouchMove,
+    isTouchScrollingRef,
     syncScrollToTime,
   };
 }


### PR DESCRIPTION
## Summary
- The 3D tilt transform (`rotateX(80deg)`) on the scroll container creates a narrow trapezoidal hit-test area that breaks native touch scrolling on mobile devices
- Added a touch-scroll proxy on the untransformed viewport wrapper that captures single-finger swipe gestures across the full rectangular surface and translates them into programmatic scroll on the tilt container
- Applied `touch-action: none` CSS to the viewport to prevent browser touch gesture interference, with a 5px swipe threshold to preserve tap-to-toggle-playback behavior

## Test plan
- [x] Unit tests pass (798/798), including two new tests for viewport touch scroll behavior
- [x] E2e tests pass (38/38), including visual regression tests
- [ ] Verify on a mobile touch device that swiping the timeline area scrolls smoothly
- [ ] Verify that tapping (without swiping) still toggles playback
- [ ] Verify that two-finger pinch-to-zoom still works on mobile

https://claude.ai/code/session_01Fe6xpxb88svrvzYc9z5DuM