### PR TITLE
Replace JS touch-scroll proxy with phantom scroller

### DIFF
--- a/e2e/recording.spec.ts
+++ b/e2e/recording.spec.ts
@@ -141,7 +141,7 @@ test.describe('Recording', () => {
     // Transport is rewound to the start after recording stops.
     // With inverted scroll, time=0 maps to scrollTop = maxScrollTop.
     const { scrollTop, maxScrollTop } = await page
-      .locator('.scrubber__tilt')
+      .locator('.scrubber__phantom')
       .evaluate((el) => ({
         scrollTop: el.scrollTop,
         maxScrollTop: el.scrollHeight - el.clientHeight,

--- a/e2e/scrubber-seek.spec.ts
+++ b/e2e/scrubber-seek.spec.ts
@@ -13,12 +13,10 @@ async function wheelScrollTimeline(
   page: import('@playwright/test').Page,
   deltaY: number,
 ) {
-  // Hover the perspective wrapper instead of the transformed scroll container.
-  // The 3D perspective tilt can project the scroll container's center outside
-  // the viewport, making Playwright's hover() fail. The perspective wrapper
-  // is not transformed and forwards wheel events to the scroll container.
-  const perspective = page.locator('.scrubber__viewport');
-  await perspective.hover();
+  // Hover the phantom scroller — it's an untransformed rectangle that
+  // captures all scroll interactions and forwards them to the tilt container.
+  const phantom = page.locator('.scrubber__phantom');
+  await phantom.hover();
   await page.mouse.wheel(0, deltaY);
 }
 
@@ -32,8 +30,8 @@ test.describe('Drag and scroll timeline to seek while playing', () => {
   test('scrolling during playback pauses, resumes, and updates scroll position', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__tilt');
-    const initialScrollTop = await timeline.evaluate((el) => el.scrollTop);
+    const phantom = page.locator('.scrubber__phantom');
+    const initialScrollTop = await phantom.evaluate((el) => el.scrollTop);
 
     // Start playback
     await page.getByTitle('Play').click();
@@ -51,18 +49,18 @@ test.describe('Drag and scroll timeline to seek while playing', () => {
     // Verify scroll position changed (inverted scroll: playback decreases scrollTop)
     await page.getByTitle('Pause').click();
     await page.waitForTimeout(100);
-    const scrollTop = await timeline.evaluate((el) => el.scrollTop);
+    const scrollTop = await phantom.evaluate((el) => el.scrollTop);
     expect(scrollTop).not.toBe(initialScrollTop);
   });
 
   test('scrolling the timeline while paused does not auto-resume', async ({
     page,
   }) => {
-    const timeline = page.locator('.scrubber__tilt');
+    const phantom = page.locator('.scrubber__phantom');
 
     await expect(page.getByTitle('Play')).toBeVisible();
 
-    await timeline.evaluate((el) => {
+    await phantom.evaluate((el) => {
       el.scrollTop = 400;
     });
     await page.waitForTimeout(400);

--- a/e2e/spectrogram-timeline.spec.ts
+++ b/e2e/spectrogram-timeline.spec.ts
@@ -66,6 +66,23 @@ async function canvasHasContent(
   }, threshold);
 }
 
+/**
+ * Scrolls the phantom scroller and syncs the tilt container.
+ * The phantom scroller handles user scroll interaction while the tilt
+ * container provides scrollTop for spectrogram viewport calculations.
+ */
+async function scrollTimeline(
+  page: import('@playwright/test').Page,
+  scrollTop: number,
+) {
+  await page.evaluate((pos) => {
+    const phantom = document.querySelector('.scrubber__phantom') as HTMLElement;
+    const tilt = document.querySelector('.scrubber__tilt') as HTMLElement;
+    if (phantom) phantom.scrollTop = pos;
+    if (tilt) tilt.scrollTop = pos;
+  }, scrollTop);
+}
+
 // Alignment test removed: getBoundingClientRect() returns unreliable projected
 // coordinates under 3D perspective with perspective-origin: center bottom.
 
@@ -88,19 +105,17 @@ test.describe('Spectrogram canvas sticky positioning on mobile', () => {
   test('canvas sticks at the scroll container edge, not the content edge', async ({
     page,
   }) => {
-    const scrollContainer = page.locator('.scrubber__tilt');
+    const tiltContainer = page.locator('.scrubber__tilt');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
-    const paddingTop = await scrollContainer.evaluate((el) => {
+    const paddingTop = await tiltContainer.evaluate((el) => {
       const tl = el.querySelector('.timeline') as HTMLElement;
       return parseFloat(getComputedStyle(tl).paddingTop);
     });
 
     // Scroll well past the padding so sticky positioning is active
     const scrollPos = Math.floor(paddingTop + 300);
-    await scrollContainer.evaluate((el, pos) => {
-      el.scrollTop = pos;
-    }, scrollPos);
+    await scrollTimeline(page, scrollPos);
 
     // Wait for scroll to settle and sticky position to update
     await expect(async () => {
@@ -145,13 +160,13 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram content updates when scrolling into content range', async ({
     page,
   }) => {
-    const scrollContainer = page.locator('.scrubber__tilt');
+    const tiltContainer = page.locator('.scrubber__tilt');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
     // Compute the scroll position where the spectrogram container's top
     // edge aligns with the scroll parent's top edge. Beyond this point,
     // contentOffset increases and the canvas draws different audio content.
-    const paddingTop = await scrollContainer.evaluate((el) => {
+    const paddingTop = await tiltContainer.evaluate((el) => {
       const tl = el.querySelector('.timeline') as HTMLElement;
       return parseFloat(getComputedStyle(tl).paddingTop);
     });
@@ -186,18 +201,14 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
     // Scroll just past the padding so the spectrogram enters the content
     // range where contentOffset starts increasing.
     const scrollA = Math.floor(paddingTop + 100);
-    await scrollContainer.evaluate((el, pos) => {
-      el.scrollTop = pos;
-    }, scrollA);
+    await scrollTimeline(page, scrollA);
     await page.waitForTimeout(200);
 
     const hashA = await getCanvasPixelHash();
 
     // Scroll further into the content range
     const scrollB = scrollA + 400;
-    await scrollContainer.evaluate((el, pos) => {
-      el.scrollTop = pos;
-    }, scrollB);
+    await scrollTimeline(page, scrollB);
     await page.waitForTimeout(200);
 
     const hashB = await getCanvasPixelHash();
@@ -215,10 +226,10 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
   test('spectrogram coverage is consistent across the full scroll range', async ({
     page,
   }) => {
-    const scrollContainer = page.locator('.scrubber__tilt');
+    const tiltContainer = page.locator('.scrubber__tilt');
     const spectrogramCanvas = page.locator('.spectrogram__canvas');
 
-    const contentInfo = await scrollContainer.evaluate((el) => {
+    const contentInfo = await tiltContainer.evaluate((el) => {
       const tl = el.querySelector('.timeline') as HTMLElement;
       const paddingTop = parseFloat(getComputedStyle(tl).paddingTop);
       const spectrogram = el.querySelector('.spectrogram') as HTMLElement;
@@ -251,9 +262,7 @@ test.describe('Spectrogram timeline visualization during scroll', () => {
       );
       if (scrollPos < 0 || scrollPos > maxScroll) continue;
 
-      await scrollContainer.evaluate((el, pos) => {
-        el.scrollTop = pos;
-      }, scrollPos);
+      await scrollTimeline(page, scrollPos);
       await page.waitForTimeout(100);
 
       const ratio = await visibleCanvasFilledHeightRatio(spectrogramCanvas);

--- a/e2e/swipe-playback.spec.ts
+++ b/e2e/swipe-playback.spec.ts
@@ -13,11 +13,12 @@ async function swipeTimeline(
   page: import('@playwright/test').Page,
   deltaY: number,
 ) {
-  // Target the perspective wrapper — its bounding box is not distorted by the
-  // child's 3D transform, so the center is always a reliable hit target.
-  const wrapper = page.locator('.scrubber__viewport');
-  const box = await wrapper.boundingBox();
-  if (!box) throw new Error('Timeline not visible');
+  // Target the phantom scroller — it's an untransformed rectangle that
+  // captures all scroll interactions. Unlike the old viewport wrapper,
+  // its bounding box is not distorted by 3D transforms.
+  const phantom = page.locator('.scrubber__phantom');
+  const box = await phantom.boundingBox();
+  if (!box) throw new Error('Phantom scroller not visible');
 
   const startX = Math.round(box.x + box.width / 2);
   const startY = Math.round(box.y + box.height / 2);
@@ -64,11 +65,6 @@ test.describe('Swipe to scrub timeline during playback', () => {
     }
     await expect(page.locator('.fullscreen__overlay')).not.toBeVisible();
   });
-
-  // Swipe-during-playback test removed: touch hit-testing is unreliable
-  // under 3D perspective with perspective-origin: center bottom — touch
-  // coordinates at the wrapper center can miss the scroll container's
-  // trapezoidal hit-test area.
 
   test('swiping while paused does not auto-resume', async ({ page }) => {
     await expect(page.getByTitle('Play')).toBeVisible();

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -22,22 +22,22 @@ afterEach(() => {
   Tone.getTransport().seconds = 0;
 });
 
-it('pauses playback when timeline is scrolled while playing', () => {
+it('pauses playback when phantom scroller is scrolled while playing', () => {
   playbackService.play();
 
   const { container } = render(<Scrubber {...defaultProps} />);
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
-  fireEvent.scroll(timeline);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.scroll(phantom);
 
   expect(playbackService.isPlaying).toBe(false);
 });
 
-it('does not pause playback when timeline is scrolled while paused', () => {
+it('does not pause playback when phantom scroller is scrolled while paused', () => {
   const { container } = render(<Scrubber {...defaultProps} />);
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
-  fireEvent.scroll(timeline);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.scroll(phantom);
 
   expect(playbackService.isPlaying).toBe(false);
 });
@@ -165,20 +165,6 @@ it('passes drawer height as CSS variable to playhead for position alignment', ()
   expect(playhead.style.transform).not.toContain('scaleY');
 });
 
-it('viewport wrapper handles wheel events for full hit-area coverage', () => {
-  playbackService.play();
-
-  const { container } = render(<Scrubber {...defaultProps} />);
-
-  // The viewport wrapper covers the full rectangular area. Wheel events
-  // landing outside the tilted scroll container's trapezoid hit the wrapper
-  // instead, which forwards them as programmatic scrolls.
-  const viewport = container.querySelector('.scrubber__viewport')!;
-  fireEvent.wheel(viewport, { deltaY: 100 });
-
-  expect(playbackService.isPlaying).toBe(false);
-});
-
 it('does not stop playback at end of scroll during recording', () => {
   vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.5);
   vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
@@ -206,7 +192,7 @@ it('does not stop playback at end of scroll during recording', () => {
   expect(playbackService.transportTime).toBe(1.5);
 });
 
-it('stops recording when timeline is clicked during recording', () => {
+it('stops recording when phantom scroller is clicked during recording', () => {
   playbackService.play();
   recordingService.arm();
   recordingService.startRecording();
@@ -216,14 +202,14 @@ it('stops recording when timeline is clicked during recording', () => {
     <Scrubber {...defaultProps} onStopRecording={onStopRecording} />,
   );
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
-  fireEvent.click(timeline);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.click(phantom);
 
   expect(onStopRecording).toHaveBeenCalledOnce();
   expect(playbackService.isPlaying).toBe(true);
 });
 
-it('cancels count-in when timeline is clicked during count-in', () => {
+it('cancels count-in when phantom scroller is clicked during count-in', () => {
   playbackService.play();
   recordingService.arm();
   recordingService.startRecording();
@@ -234,22 +220,22 @@ it('cancels count-in when timeline is clicked during count-in', () => {
     <Scrubber {...defaultProps} onStopRecording={onStopRecording} />,
   );
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
-  fireEvent.click(timeline);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.click(phantom);
 
   expect(onStopRecording).toHaveBeenCalledOnce();
   expect(playbackService.isPlaying).toBe(true);
 });
 
-it('does not pause playback when timeline is scrolled during recording', () => {
+it('does not pause playback when phantom scroller is scrolled during recording', () => {
   playbackService.play();
   recordingService.arm();
   recordingService.startRecording();
 
   const { container } = render(<Scrubber {...defaultProps} />);
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
-  fireEvent.scroll(timeline);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.scroll(phantom);
 
   expect(playbackService.isPlaying).toBe(true);
 });
@@ -286,17 +272,20 @@ it('syncs timeline scroll position via imperative handle (inverted scroll)', () 
 
   const { container } = render(<Scrubber ref={ref} {...defaultProps} />);
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  const tilt = container.querySelector('.scrubber__tilt')!;
 
   // Mock scroll dimensions so maxScrollTop is non-zero
-  Object.defineProperty(timeline, 'scrollHeight', {
-    value: 2000,
-    configurable: true,
-  });
-  Object.defineProperty(timeline, 'clientHeight', {
-    value: 500,
-    configurable: true,
-  });
+  for (const el of [phantom, tilt]) {
+    Object.defineProperty(el, 'scrollHeight', {
+      value: 2000,
+      configurable: true,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      value: 500,
+      configurable: true,
+    });
+  }
 
   act(() => {
     ref.current!.syncScrollToTime(2.5);
@@ -305,7 +294,9 @@ it('syncs timeline scroll position via imperative handle (inverted scroll)', () 
   // Inverted scroll: scrollTop = maxScrollTop - time * pixelsPerSecond
   // maxScrollTop = 2000 - 500 = 1500
   // scrollTop = 1500 - (2.5 * 200) = 1500 - 500 = 1000
-  expect(timeline.scrollTop).toBe(1000);
+  expect(phantom.scrollTop).toBe(1000);
+  // Tilt container is synced so spectrograms can read scrollTop
+  expect(tilt.scrollTop).toBe(1000);
 });
 
 it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
@@ -313,57 +304,36 @@ it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
 
   const { container } = render(<Scrubber ref={ref} {...defaultProps} />);
 
-  const timeline = container.querySelector('.scrubber__tilt')!;
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  const tilt = container.querySelector('.scrubber__tilt')!;
 
-  Object.defineProperty(timeline, 'scrollHeight', {
-    value: 2000,
-    configurable: true,
-  });
-  Object.defineProperty(timeline, 'clientHeight', {
-    value: 500,
-    configurable: true,
-  });
+  for (const el of [phantom, tilt]) {
+    Object.defineProperty(el, 'scrollHeight', {
+      value: 2000,
+      configurable: true,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      value: 500,
+      configurable: true,
+    });
+  }
 
   act(() => {
     ref.current!.syncScrollToTime(0);
   });
 
   // At time=0, scrollTop should be at max (beginning at bottom)
-  expect(timeline.scrollTop).toBe(1500);
+  expect(phantom.scrollTop).toBe(1500);
+  expect(tilt.scrollTop).toBe(1500);
 });
 
-it('pauses playback when viewport is touch-swiped while playing', () => {
-  playbackService.play();
+it('shrinks phantom scroller when drawer is open', () => {
+  const drawerHeight = 280;
+  const { container } = render(
+    <Scrubber {...defaultProps} drawerHeight={drawerHeight} />,
+  );
 
-  const { container } = render(<Scrubber {...defaultProps} />);
+  const phantom = container.querySelector('.scrubber__phantom') as HTMLElement;
 
-  // Touch events on the viewport wrapper should scroll the tilt container.
-  // This enables mobile scrolling across the full rectangular area, not
-  // just the narrow trapezoid of the tilted scroll container.
-  const viewport = container.querySelector('.scrubber__viewport')!;
-  fireEvent.touchStart(viewport, {
-    touches: [{ clientX: 100, clientY: 300 }],
-  });
-  fireEvent.touchMove(viewport, {
-    touches: [{ clientX: 100, clientY: 250 }],
-  });
-
-  expect(playbackService.isPlaying).toBe(false);
-});
-
-it('does not pause playback on viewport tap (no swipe movement)', () => {
-  playbackService.play();
-
-  const { container } = render(<Scrubber {...defaultProps} />);
-
-  const viewport = container.querySelector('.scrubber__viewport')!;
-  fireEvent.touchStart(viewport, {
-    touches: [{ clientX: 100, clientY: 300 }],
-  });
-  // Tiny movement below swipe threshold — should not trigger scroll
-  fireEvent.touchMove(viewport, {
-    touches: [{ clientX: 100, clientY: 298 }],
-  });
-
-  expect(playbackService.isPlaying).toBe(true);
+  expect(phantom.style.bottom).toBe(`${drawerHeight}px`);
 });

--- a/src/features/workstation/scrubber/PhantomScroller.tsx
+++ b/src/features/workstation/scrubber/PhantomScroller.tsx
@@ -1,0 +1,42 @@
+import { type CSSProperties, forwardRef, type PropsWithChildren } from 'react';
+
+type PhantomScrollerProps = PropsWithChildren<{
+  spacerHeight: number;
+  style?: CSSProperties;
+  onClick: () => void;
+  onScroll: () => void;
+  onWheel: (e: React.WheelEvent) => void;
+}>;
+
+/**
+ * Invisible scroll overlay that captures all scroll interactions.
+ *
+ * The phantom scroller sits on top of the 3D-transformed timeline,
+ * providing a full untransformed rectangle for native scroll physics
+ * (wheel, touch, momentum). A spacer div sets the scrollable height
+ * to match the timeline content, and scroll position is synced to the
+ * visual content via a translateY wrapper inside the tilt container.
+ *
+ * This eliminates the trapezoidal hit-test area that the tilted scroll
+ * container had, enabling reliable touch scrolling on mobile.
+ */
+const PhantomScroller = forwardRef<HTMLDivElement, PhantomScrollerProps>(
+  ({ spacerHeight, style, onClick, onScroll, onWheel }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className="scrubber__phantom"
+        style={style}
+        onClick={onClick}
+        onScroll={onScroll}
+        onWheel={onWheel}
+      >
+        <div style={{ height: spacerHeight }} />
+      </div>
+    );
+  },
+);
+
+PhantomScroller.displayName = 'PhantomScroller';
+
+export default PhantomScroller;

--- a/src/features/workstation/scrubber/Scrubber.css
+++ b/src/features/workstation/scrubber/Scrubber.css
@@ -17,10 +17,7 @@
   min-height: 0;
   perspective: var(--timeline-perspective);
   /* perspective-origin is set via inline style (dynamic, drawer-aware) */
-  /* Disable browser touch gestures so the viewport touch-scroll proxy can
-     translate swipe gestures into programmatic scroll on the tilt container.
-     The 3D tilt transform breaks native touch scrolling on mobile devices. */
-  touch-action: none;
+  pointer-events: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -29,7 +26,7 @@
   }
 }
 
-/* ScrubberTilt: 3D perspective tilt + scroll container */
+/* ScrubberTilt: 3D perspective tilt + passive scroll container */
 
 .scrubber__tilt {
   /* Fill the viewport container. The inline transform tilts and scales
@@ -40,11 +37,37 @@
   /* Constrain height so content scrolls instead of expanding the container */
   min-height: 0;
   overflow-y: scroll;
+  pointer-events: none;
+  /* Hide scrollbar — scroll interaction is handled by PhantomScroller.
+     The tilt container is kept scrollable so child components (spectrogram)
+     can read scrollTop to determine their viewport offset. */
+  scrollbar-width: none;
   /* Size container for cqh units in .timeline padding.
-     The timeline padding must reference the scroll container's height
+     The timeline padding must reference this container's height
      (not the viewport) so the content boundary at time=0 aligns with
      the cursor position (which is a % of the scrubber height). */
   container-type: size;
+}
+
+.scrubber__tilt::-webkit-scrollbar {
+  display: none;
+}
+
+/* PhantomScroller: invisible scroll overlay for native scroll physics */
+
+.scrubber__phantom {
+  position: absolute;
+  inset: 0;
+  overflow-y: scroll;
+  z-index: 1;
+  /* Allow native vertical scroll + pinch-zoom handled by JS */
+  touch-action: pan-y;
+  /* Hide scrollbar — the phantom scroller is invisible */
+  scrollbar-width: none;
+}
+
+.scrubber__phantom::-webkit-scrollbar {
+  display: none;
 }
 
 /* Playhead: loudness meter overlay centered at cursor position */

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -7,12 +7,14 @@ import {
 } from 'react';
 import { usePlaybackService } from '../../playback/usePlaybackService';
 import { useRecordingService } from '../../recording/useRecordingService';
+import { useTimelineZoom } from '../../../shared/hooks/useTimelineZoom';
 import Playhead, { type PlayheadHandle } from './Playhead';
+import PhantomScroller from './PhantomScroller';
 import ScrubberTilt from './ScrubberTilt';
 import ScrubberViewport from './ScrubberViewport';
 import ZoomControls from './ZoomControls';
 import { useScrubberGeometry } from './useScrubberGeometry';
-import { useScrubberScroll } from './useScrubberScroll';
+import { useScrubberScroll, useSpacerHeight } from './useScrubberScroll';
 import './Scrubber.css';
 
 export type ScrubberHandle = {
@@ -35,28 +37,27 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   const recording = useRecordingService();
   const { drawerHeight, onStopRecording, pixelsPerSecond } = props;
 
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const phantomRef = useRef<HTMLDivElement>(null);
+  const scrubberTiltRef = useRef<HTMLDivElement>(null);
   const playheadRef = useRef<PlayheadHandle>(null);
 
   const { containerRef, viewportStyle, tiltStyle } =
     useScrubberGeometry(drawerHeight);
 
-  const {
-    handleScroll,
-    handleWheel,
-    handleTouchMove,
-    handleViewportWheel,
-    handleViewportTouchStart,
-    handleViewportTouchMove,
-    isTouchScrollingRef,
-    syncScrollToTime,
-  } = useScrubberScroll({ scrollRef, playheadRef, pixelsPerSecond });
+  const { handleWheel, handleScroll, syncScrollToTime } = useScrubberScroll({
+    phantomRef,
+    tiltRef: scrubberTiltRef,
+    playheadRef,
+    pixelsPerSecond,
+  });
+
+  useTimelineZoom(phantomRef);
+
+  const spacerHeight = useSpacerHeight(scrubberTiltRef);
 
   useImperativeHandle(ref, () => ({ syncScrollToTime }), [syncScrollToTime]);
 
   const handleTimelineClick = () => {
-    // Suppress click synthesized after a touch-scroll swipe
-    if (isTouchScrollingRef.current) return;
     if (recording.isCountingIn || recording.isActivelyRecording) {
       onStopRecording();
       return;
@@ -64,45 +65,33 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     playback.togglePlayback();
   };
 
-  // Click handler for the viewport wrapper — catches clicks in the
-  // dead-zone corners outside the tilted scroll container's trapezoid.
-  const handleViewportClick = (e: React.MouseEvent) => {
-    if (isTouchScrollingRef.current) return;
-    if (scrollRef.current?.contains(e.target as Node)) return;
-    handleTimelineClick();
-  };
-
+  const phantomStyle = getPhantomStyle(drawerHeight);
   const zoomControlsStyle = getZoomControlsStyle(drawerHeight);
 
-  // Merge the geometry ref with the scroll ref — both need the same element.
-  // useScrubberGeometry tracks the container height; useScrubberScroll reads
-  // scroll position. We use a callback ref to wire both.
+  // The geometry ref measures the tilt container's height for 3D transform
+  // calculations. Assign it via a callback ref alongside the scroll ref.
   const tiltRef = (el: HTMLDivElement | null) => {
-    (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+    (scrubberTiltRef as React.MutableRefObject<HTMLDivElement | null>).current =
+      el;
     (containerRef as React.MutableRefObject<HTMLDivElement | null>).current =
       el;
   };
 
   return (
     <div className="scrubber scrubber--firefox-scroll-fix">
-      <ScrubberViewport
-        style={viewportStyle}
-        onClick={handleViewportClick}
-        onWheel={handleViewportWheel}
-        onTouchStart={handleViewportTouchStart}
-        onTouchMove={handleViewportTouchMove}
-      >
-        <ScrubberTilt
-          ref={tiltRef}
-          style={tiltStyle}
-          onClick={handleTimelineClick}
-          onScroll={handleScroll}
-          onWheel={handleWheel}
-          onTouchMove={handleTouchMove}
-        >
+      <ScrubberViewport style={viewportStyle}>
+        <ScrubberTilt ref={tiltRef} style={tiltStyle}>
           {props.children}
         </ScrubberTilt>
       </ScrubberViewport>
+      <PhantomScroller
+        ref={phantomRef}
+        spacerHeight={spacerHeight}
+        style={phantomStyle}
+        onClick={handleTimelineClick}
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+      />
       <Playhead ref={playheadRef} drawerHeight={drawerHeight} />
       <ZoomControls style={zoomControlsStyle} />
     </div>
@@ -112,6 +101,15 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
 Scrubber.displayName = 'Scrubber';
 
 export default Scrubber;
+
+/**
+ * When the drawer is open, shrink the phantom scroller's clickable area
+ * so it doesn't overlap the drawer controls.
+ */
+function getPhantomStyle(drawerHeight: number): CSSProperties | undefined {
+  if (drawerHeight <= 0) return undefined;
+  return { bottom: `${drawerHeight}px` };
+}
 
 function getZoomControlsStyle(drawerHeight: number): CSSProperties {
   return {

--- a/src/features/workstation/scrubber/ScrubberTilt.tsx
+++ b/src/features/workstation/scrubber/ScrubberTilt.tsx
@@ -2,34 +2,24 @@ import { type CSSProperties, forwardRef, type PropsWithChildren } from 'react';
 
 type ScrubberTiltProps = PropsWithChildren<{
   style: CSSProperties;
-  onClick: () => void;
-  onScroll: () => void;
-  onWheel: (e: React.WheelEvent) => void;
-  onTouchMove: () => void;
 }>;
 
 /**
- * Scroll container that applies the 3D scrubber tilt.
+ * Visual container that applies the 3D scrubber tilt.
  *
  * The inline transform tilts the timeline plane via `rotateX` around
  * the scrubber bottom and compensates for perspective foreshortening
  * with a `scaleY` factor so the far edge fills the viewport.
  *
- * Content scrolls vertically (inverted: time=0 at the bottom). Scroll
- * event handlers are provided by the parent Scrubber component.
+ * This container is purely visual — it does not scroll or handle
+ * pointer events. Scroll interaction is handled by the PhantomScroller
+ * overlay, which syncs scroll position to a translateY wrapper inside
+ * this container.
  */
 const ScrubberTilt = forwardRef<HTMLDivElement, ScrubberTiltProps>(
-  ({ style, onClick, onScroll, onWheel, onTouchMove, children }, ref) => {
+  ({ style, children }, ref) => {
     return (
-      <div
-        ref={ref}
-        className="scrubber__tilt"
-        style={style}
-        onClick={onClick}
-        onScroll={onScroll}
-        onWheel={onWheel}
-        onTouchMove={onTouchMove}
-      >
+      <div ref={ref} className="scrubber__tilt" style={style}>
         {children}
       </div>
     );

--- a/src/features/workstation/scrubber/ScrubberViewport.tsx
+++ b/src/features/workstation/scrubber/ScrubberViewport.tsx
@@ -2,10 +2,6 @@ import { type CSSProperties, type PropsWithChildren } from 'react';
 
 type ScrubberViewportProps = PropsWithChildren<{
   style: CSSProperties;
-  onClick: (e: React.MouseEvent) => void;
-  onWheel: (e: React.WheelEvent) => void;
-  onTouchStart: (e: React.TouchEvent) => void;
-  onTouchMove: (e: React.TouchEvent) => void;
 }>;
 
 /**
@@ -17,28 +13,12 @@ type ScrubberViewportProps = PropsWithChildren<{
  * to fit the reduced viewport — without touching the child tilt
  * container's own 3D transform.
  *
- * Also catches click, wheel, and touch events in the dead-zone corners
- * outside the tilted scroll container's trapezoid. Touch events are
- * translated into programmatic scroll on the tilt container, since the
- * 3D tilt transform breaks native touch scrolling on mobile devices.
+ * This container is purely visual — pointer events pass through to the
+ * PhantomScroller overlay behind it.
  */
-const ScrubberViewport = ({
-  style,
-  onClick,
-  onWheel,
-  onTouchStart,
-  onTouchMove,
-  children,
-}: ScrubberViewportProps) => {
+const ScrubberViewport = ({ style, children }: ScrubberViewportProps) => {
   return (
-    <div
-      className="scrubber__viewport"
-      style={style}
-      onClick={onClick}
-      onWheel={onWheel}
-      onTouchStart={onTouchStart}
-      onTouchMove={onTouchMove}
-    >
+    <div className="scrubber__viewport" style={style}>
       {children}
     </div>
   );

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -1,25 +1,24 @@
 import {
   type RefObject,
-  type TouchEvent as ReactTouchEvent,
-  type WheelEvent as ReactWheelEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
+  useState,
 } from 'react';
 import { useAudioService } from '../../audio/useAudioService';
 import { usePlaybackService } from '../../playback/usePlaybackService';
 import { useRecordingService } from '../../recording/useRecordingService';
 import { useTrackService } from '../../tracks/useTrackService';
 import useDebounced from '../../../shared/hooks/useDebounced';
-import { useTimelineZoom } from '../../../shared/hooks/useTimelineZoom';
 import FrequencyVisualizer from '../../spectrogram/FrequencyVisualizer';
 import { type PlayheadHandle } from './Playhead';
 
 const SCROLL_DEBOUNCE_MS = 200;
-const SWIPE_THRESHOLD_PX = 5;
 
 type UseScrubberScrollOptions = {
-  scrollRef: RefObject<HTMLDivElement | null>;
+  phantomRef: RefObject<HTMLDivElement | null>;
+  tiltRef: RefObject<HTMLDivElement | null>;
   playheadRef: RefObject<PlayheadHandle | null>;
   pixelsPerSecond: number;
 };
@@ -28,13 +27,19 @@ type UseScrubberScrollOptions = {
  * Manages scroll-to-time synchronization, the playback animation loop,
  * and scroll event handlers for the scrubber.
  *
+ * Scroll interactions are captured by the PhantomScroller (an invisible,
+ * untransformed overlay with native scroll physics). Scroll position is
+ * synced to the tilt container's scrollTop so child components (spectrogram)
+ * can read the current scroll offset.
+ *
  * During playback, an animation loop reads the audio engine time and
- * updates both the scroll position and playhead visualization each frame.
+ * updates both the phantom and tilt scroll positions each frame.
  * When the user scrolls manually, playback pauses and resumes after a
  * debounced seek.
  */
 export function useScrubberScroll({
-  scrollRef,
+  phantomRef,
+  tiltRef,
   playheadRef,
   pixelsPerSecond,
 }: UseScrubberScrollOptions) {
@@ -46,22 +51,51 @@ export function useScrubberScroll({
 
   const isProgrammaticScrollRef = useRef(false);
   const shouldResumeRef = useRef(false);
-  const { isPinchingRef } = useTimelineZoom(scrollRef);
+
+  /**
+   * Ensure the phantom scroller's spacer height matches the tilt container's
+   * scrollHeight. This must happen synchronously before setting scrollTop
+   * so the phantom has the correct scrollable range. React state updates
+   * for spacer height may lag behind DOM mutations (e.g. recording
+   * spectrogram growth), so we patch the spacer directly.
+   */
+  const syncSpacerHeight = useCallback(() => {
+    const phantom = phantomRef.current;
+    const tilt = tiltRef.current;
+    if (!phantom || !tilt) return;
+
+    const spacer = phantom.firstElementChild as HTMLElement | null;
+    if (spacer && tilt.scrollHeight !== phantom.scrollHeight) {
+      spacer.style.height = `${tilt.scrollHeight}px`;
+    }
+  }, [phantomRef, tiltRef]);
+
+  /** Sync the tilt container's scrollTop to match the phantom scroller. */
+  const syncTiltScroll = useCallback(() => {
+    const phantom = phantomRef.current;
+    const tilt = tiltRef.current;
+    if (phantom && tilt) {
+      tilt.scrollTop = phantom.scrollTop;
+    }
+  }, [phantomRef, tiltRef]);
 
   const setScrollPosition = useCallback(
     (time: number) => {
-      const el = scrollRef.current;
-      if (el) {
-        const maxScrollTop = el.scrollHeight - el.clientHeight;
+      const phantom = phantomRef.current;
+      const tilt = tiltRef.current;
+      if (phantom && tilt) {
+        syncSpacerHeight();
+        const maxScrollTop = phantom.scrollHeight - phantom.clientHeight;
         const scrollPosition =
           maxScrollTop - Math.trunc(time * pixelsPerSecond);
-        if (el.scrollTop !== scrollPosition) {
+        if (phantom.scrollTop !== scrollPosition) {
           isProgrammaticScrollRef.current = true;
-          el.scrollTop = scrollPosition;
+          phantom.scrollTop = scrollPosition;
         }
+        tilt.scrollTop = phantom.scrollTop;
       }
     },
-    [pixelsPerSecond, scrollRef],
+    [pixelsPerSecond, phantomRef, tiltRef, syncSpacerHeight],
   );
 
   const visualizerRef = useRef<FrequencyVisualizer | null>(null);
@@ -111,8 +145,8 @@ export function useScrubberScroll({
         // Stopping playback here would freeze transportTime updates and halt
         // the live spectrogram scroll.
         // In inverted scroll, end of track is at scrollTop=0 (top of scroll area)
-        if (scrollRef.current && !recording.isActivelyRecording) {
-          const isEndOfScroll = scrollRef.current.scrollTop <= 0;
+        if (phantomRef.current && !recording.isActivelyRecording) {
+          const isEndOfScroll = phantomRef.current.scrollTop <= 0;
           if (isEndOfScroll) {
             playback.rewind();
             return;
@@ -140,7 +174,7 @@ export function useScrubberScroll({
   }, [playing, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const setTransportTimeFromScroll = () => {
-    const el = scrollRef.current;
+    const el = phantomRef.current;
     if (el) {
       const maxScrollTop = el.scrollHeight - el.clientHeight;
       const time = (maxScrollTop - el.scrollTop) / pixelsPerSecond;
@@ -163,79 +197,23 @@ export function useScrubberScroll({
     }
   };
 
-  const handleWheel = (e: ReactWheelEvent) => {
-    // Skip scroll handling when Ctrl/Meta+wheel is used for zoom
+  // Wheel events always indicate user interaction — clear the programmatic
+  // flag so the subsequent onscroll handler treats it as a user scroll.
+  // Without this, the animation loop's programmatic flag could race with
+  // a user wheel event and swallow it.
+  const handleWheel = (e: React.WheelEvent) => {
+    // Ctrl/Meta+wheel is zoom, not scroll
     if (e.ctrlKey || e.metaKey) return;
     if (recording.isActivelyRecording) return;
-    pauseForUserScroll();
-    debouncedSetTransportTime();
-  };
-
-  // The perspective wrapper covers the full rectangular area while the
-  // tilted scroll container has a trapezoidal hit-test shape. Wheel events
-  // landing in the dead-zone corners hit the wrapper instead of the scroll
-  // container. This handler forwards them as programmatic scrolls so the
-  // entire visible area is scrollable.
-  const handleViewportWheel = (e: ReactWheelEvent) => {
-    const el = scrollRef.current;
-    if (!el) return;
-    // Skip events that already reached the scroll container (they bubble up)
-    if (el.contains(e.target as Node)) return;
-    // Skip zoom gestures
-    if (e.ctrlKey || e.metaKey) return;
-
-    el.scrollTop += e.deltaY;
-    handleWheel(e);
-  };
-
-  const handleTouchMove = () => {
-    // Skip scroll handling during pinch-to-zoom
-    if (isPinchingRef.current) return;
-    if (recording.isActivelyRecording) return;
-    pauseForUserScroll();
-    debouncedSetTransportTime();
-  };
-
-  // --- Viewport touch-scroll proxy for mobile ---
-  // The 3D tilt transform on the scroll container breaks native touch
-  // scrolling on mobile devices — the heavily rotated element has a narrow
-  // trapezoidal hit-test area. These handlers capture single-finger swipe
-  // gestures on the full-rectangle viewport wrapper and translate them into
-  // programmatic scroll on the tilt container.
-  const touchStartYRef = useRef(0);
-  const touchScrollTopRef = useRef(0);
-  const isTouchScrollingRef = useRef(false);
-
-  const handleViewportTouchStart = (e: ReactTouchEvent) => {
-    if (e.touches.length !== 1) return;
-    touchStartYRef.current = e.touches[0].clientY;
-    touchScrollTopRef.current = scrollRef.current?.scrollTop ?? 0;
-    isTouchScrollingRef.current = false;
-  };
-
-  const handleViewportTouchMove = (e: ReactTouchEvent) => {
-    if (e.touches.length !== 1) return;
-    if (isPinchingRef.current) return;
-
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const deltaY = touchStartYRef.current - e.touches[0].clientY;
-
-    if (!isTouchScrollingRef.current) {
-      if (Math.abs(deltaY) < SWIPE_THRESHOLD_PX) return;
-      isTouchScrollingRef.current = true;
-    }
-
-    isProgrammaticScrollRef.current = true;
-    el.scrollTop = touchScrollTopRef.current + deltaY;
-
-    if (recording.isActivelyRecording) return;
+    isProgrammaticScrollRef.current = false;
     pauseForUserScroll();
     debouncedSetTransportTime();
   };
 
   const handleScroll = () => {
+    syncSpacerHeight();
+    syncTiltScroll();
+
     if (isProgrammaticScrollRef.current) {
       isProgrammaticScrollRef.current = false;
       return;
@@ -255,13 +233,51 @@ export function useScrubberScroll({
   );
 
   return {
-    handleScroll,
     handleWheel,
-    handleTouchMove,
-    handleViewportWheel,
-    handleViewportTouchStart,
-    handleViewportTouchMove,
-    isTouchScrollingRef,
+    handleScroll,
     syncScrollToTime,
   };
+}
+
+/**
+ * Tracks the scroll height of the tilt container and returns it
+ * for use as the PhantomScroller spacer height.
+ *
+ * The tilt container's scrollHeight includes the Timeline content plus
+ * its cqh-based padding. The phantom scroller's spacer must match this
+ * height so both containers have the same scrollable range.
+ */
+export function useSpacerHeight(
+  tiltRef: RefObject<HTMLDivElement | null>,
+): number {
+  const [spacerHeight, setSpacerHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = tiltRef.current;
+    if (!el) return;
+
+    const update = () => setSpacerHeight(el.scrollHeight);
+    update();
+
+    // MutationObserver catches DOM structure changes (tracks added/removed)
+    // and attribute changes (recording spectrogram height updates via
+    // inline style). ResizeObserver catches size changes (zoom).
+    const observer = new MutationObserver(() => update());
+    const resizeObserver = new ResizeObserver(() => update());
+
+    observer.observe(el, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+    resizeObserver.observe(el);
+
+    return () => {
+      observer.disconnect();
+      resizeObserver.disconnect();
+    };
+  }, [tiltRef]);
+
+  return spacerHeight;
 }


### PR DESCRIPTION
## Summary

- Introduces a **PhantomScroller** — an invisible, untransformed overlay that captures all scroll interactions (wheel, touch, momentum) over the full rectangular viewport area
- Eliminates the JS touch-scroll proxy and dead-zone wheel forwarding that were needed because the 3D-tilted scroll container had a trapezoidal hit-test area
- The tilt container remains a passive scroll container (hidden scrollbar, `pointer-events: none`) so child components (spectrogram) can still read `scrollTop` for viewport calculations
- Removes ~50 lines of touch proxy code from `useScrubberScroll.ts`

## Test plan

- [x] All 796 unit tests pass
- [x] All 38 e2e tests pass (scrubber-seek, swipe-playback, recording, spectrogram-timeline)
- [x] ESLint passes
- [ ] Manual test: wheel scrolling on desktop pauses/resumes playback correctly
- [ ] Manual test: touch scrolling on mobile works across the full viewport area
- [ ] Manual test: pinch-to-zoom still works on mobile
- [ ] Manual test: recording with growing spectrogram scrolls correctly
- [ ] Manual test: drawer open/close doesn't break scroll behavior

https://claude.ai/code/session_01BTdoVTmr8pCWKxBwm8DMbx