### PR TITLE
Fix drag-to-seek not pausing playback during active animation

### DIFF
--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -227,6 +227,46 @@ it('cancels count-in when phantom scroller is clicked during count-in', () => {
   expect(playbackService.isPlaying).toBe(true);
 });
 
+it('pauses playback when pointer-dragging the phantom scroller during playback animation', () => {
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+
+  // Mock scroll dimensions so the animation loop doesn't trigger rewind
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  // The animation loop sets isProgrammaticScrollRef = true when updating
+  // scroll position. Without pointer-down tracking, a subsequent user drag
+  // scroll event would be mistaken for a programmatic scroll and ignored.
+  act(() => {
+    rafCallback(0);
+  });
+
+  // Simulate a pointer drag: pointerdown → scroll
+  fireEvent.pointerDown(phantom);
+  fireEvent.scroll(phantom);
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
 it('does not pause playback when phantom scroller is scrolled during recording', () => {
   playbackService.play();
   recordingService.arm();

--- a/src/features/workstation/scrubber/PhantomScroller.tsx
+++ b/src/features/workstation/scrubber/PhantomScroller.tsx
@@ -4,6 +4,8 @@ type PhantomScrollerProps = PropsWithChildren<{
   spacerHeight: number;
   style?: CSSProperties;
   onClick: () => void;
+  onPointerDown: () => void;
+  onPointerUp: () => void;
   onScroll: () => void;
   onWheel: (e: React.WheelEvent) => void;
 }>;
@@ -21,13 +23,26 @@ type PhantomScrollerProps = PropsWithChildren<{
  * container had, enabling reliable touch scrolling on mobile.
  */
 const PhantomScroller = forwardRef<HTMLDivElement, PhantomScrollerProps>(
-  ({ spacerHeight, style, onClick, onScroll, onWheel }, ref) => {
+  (
+    {
+      spacerHeight,
+      style,
+      onClick,
+      onPointerDown,
+      onPointerUp,
+      onScroll,
+      onWheel,
+    },
+    ref,
+  ) => {
     return (
       <div
         ref={ref}
         className="scrubber__phantom"
         style={style}
         onClick={onClick}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
         onScroll={onScroll}
         onWheel={onWheel}
       >

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -44,7 +44,13 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   const { containerRef, viewportStyle, tiltStyle } =
     useScrubberGeometry(drawerHeight);
 
-  const { handleWheel, handleScroll, syncScrollToTime } = useScrubberScroll({
+  const {
+    handlePointerDown,
+    handlePointerUp,
+    handleWheel,
+    handleScroll,
+    syncScrollToTime,
+  } = useScrubberScroll({
     phantomRef,
     tiltRef: scrubberTiltRef,
     playheadRef,
@@ -89,6 +95,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         spacerHeight={spacerHeight}
         style={phantomStyle}
         onClick={handleTimelineClick}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
         onScroll={handleScroll}
         onWheel={handleWheel}
       />

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -51,6 +51,7 @@ export function useScrubberScroll({
 
   const isProgrammaticScrollRef = useRef(false);
   const shouldResumeRef = useRef(false);
+  const isPointerDownRef = useRef(false);
 
   /**
    * Ensure the phantom scroller's spacer height matches the tilt container's
@@ -197,6 +198,17 @@ export function useScrubberScroll({
     }
   };
 
+  // Pointer-down indicates a touch/mouse drag is starting. While the
+  // pointer is down, all scroll events are user-initiated — the
+  // programmatic flag from the animation loop must be ignored.
+  const handlePointerDown = () => {
+    isPointerDownRef.current = true;
+  };
+
+  const handlePointerUp = () => {
+    isPointerDownRef.current = false;
+  };
+
   // Wheel events always indicate user interaction — clear the programmatic
   // flag so the subsequent onscroll handler treats it as a user scroll.
   // Without this, the animation loop's programmatic flag could race with
@@ -213,6 +225,12 @@ export function useScrubberScroll({
   const handleScroll = () => {
     syncSpacerHeight();
     syncTiltScroll();
+
+    // When a pointer is down, the user is dragging — override the
+    // programmatic flag so the scroll is treated as user-initiated.
+    if (isPointerDownRef.current) {
+      isProgrammaticScrollRef.current = false;
+    }
 
     if (isProgrammaticScrollRef.current) {
       isProgrammaticScrollRef.current = false;
@@ -233,6 +251,8 @@ export function useScrubberScroll({
   );
 
   return {
+    handlePointerDown,
+    handlePointerUp,
     handleWheel,
     handleScroll,
     syncScrollToTime,


### PR DESCRIPTION
## Summary
- During playback, the animation loop sets `isProgrammaticScrollRef` before updating scroll position. When a user touch/pointer-drags the phantom scroller, the resulting scroll events were mistaken for programmatic scrolls and ignored — playback continued instead of pausing.
- Added `onPointerDown`/`onPointerUp` handlers to the PhantomScroller that track pointer state. While the pointer is down, `handleScroll` clears the programmatic flag so drag scroll events are correctly treated as user-initiated.
- Added a failing test that reproduces the race condition (animation loop + pointer drag) before implementing the fix.

## Test plan
- [x] New unit test: verifies playback pauses when pointer-dragging during active animation loop
- [x] All 797 unit tests pass
- [x] All 38 e2e tests pass
- [x] ESLint passes

https://claude.ai/code/session_01TrkGCRct2YbcUJHHGKLdfA