### PR TITLE
Fix timeline not updating on rewind

### DIFF
--- a/src/features/workstation/FloatingToolbar.tsx
+++ b/src/features/workstation/FloatingToolbar.tsx
@@ -6,13 +6,14 @@ import './FloatingToolbar.css';
 
 type FloatingToolbarProps = {
   isEmpty: boolean;
+  onRewind: () => void;
   onToggleRecording: () => void;
 };
 
 const FloatingToolbar = (props: FloatingToolbarProps) => {
-  const { isPlaying, togglePlayback, rewind } = usePlaybackService();
+  const { isPlaying, togglePlayback } = usePlaybackService();
   const { isTransportLocked, recordingState } = useRecordingService();
-  const { isEmpty, onToggleRecording } = props;
+  const { isEmpty, onRewind, onToggleRecording } = props;
   const isRecordActive = recordingState !== 'idle';
 
   return (
@@ -22,7 +23,7 @@ const FloatingToolbar = (props: FloatingToolbarProps) => {
         size="icon"
         className="button"
         title="Rewind"
-        onClick={rewind}
+        onClick={onRewind}
         disabled={isEmpty || isTransportLocked}
       >
         <SkipBack />

--- a/src/features/workstation/ToolbarBottomSheet.tsx
+++ b/src/features/workstation/ToolbarBottomSheet.tsx
@@ -36,6 +36,7 @@ type ToolbarBottomSheetProps = {
   redo: () => void;
   canUndo: boolean;
   canRedo: boolean;
+  onRewind: () => void;
   onToggleRecording: () => void;
   /** Height of the active bottom sheet (mixer or lyrics) to lift above */
   sheetOffset: number;
@@ -57,6 +58,7 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
     redo,
     canUndo,
     canRedo,
+    onRewind,
     onToggleRecording,
     sheetOffset,
   } = props;
@@ -96,6 +98,7 @@ const ToolbarBottomSheet = (props: ToolbarBottomSheetProps) => {
     >
       <FloatingToolbar
         isEmpty={isEmpty}
+        onRewind={onRewind}
         onToggleRecording={onToggleRecording}
       />
       <div

--- a/src/features/workstation/Workstation.tsx
+++ b/src/features/workstation/Workstation.tsx
@@ -124,6 +124,13 @@ const Workstation = (props: WorkstationProps) => {
     setActiveSheet(open ? 'lyrics' : null);
   }, []);
 
+  const handleRewind = useCallback(() => {
+    playback.rewind();
+    scrubberRef.current?.syncScrollToTime(0);
+    // playback is a stable ref from context
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleLyricsSeekTo = useCallback(
     (time: number) => {
       playback.seekTo(time);
@@ -195,6 +202,7 @@ const Workstation = (props: WorkstationProps) => {
         redo={redo}
         canUndo={canUndo}
         canRedo={canRedo}
+        onRewind={handleRewind}
         onToggleRecording={toggleRecording}
         sheetOffset={bottomSheetHeight}
       />

--- a/src/features/workstation/__tests__/FloatingToolbar.test.tsx
+++ b/src/features/workstation/__tests__/FloatingToolbar.test.tsx
@@ -7,10 +7,12 @@ const audioService = AudioService.getInstance();
 const playbackService = audioService.playbackService;
 const recordingService = audioService.recordingService;
 
+const mockRewind = vi.fn();
 const mockToggleRecording = vi.fn();
 
 const defaultProps = {
   isEmpty: false,
+  onRewind: mockRewind,
   onToggleRecording: mockToggleRecording,
 };
 
@@ -77,6 +79,14 @@ it('disables transport buttons when tracks are empty', () => {
   expect(getByTitle('Play')).toBeDisabled();
   expect(getByTitle('Rewind')).toBeDisabled();
   expect(getByTitle('Record')).not.toBeDisabled();
+});
+
+it('calls onRewind when rewind button is clicked', () => {
+  const { getByTitle } = render(<FloatingToolbar {...defaultProps} />);
+
+  fireEvent.click(getByTitle('Rewind'));
+
+  expect(mockRewind).toHaveBeenCalledOnce();
 });
 
 it('applies floating-button-group class', () => {

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -367,6 +367,47 @@ it('scrolls to maxScrollTop when time is zero (beginning at bottom)', () => {
   expect(tilt.scrollTop).toBe(1500);
 });
 
+it('syncs scroll to beginning when rewinding while paused', () => {
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  const tilt = container.querySelector('.scrubber__tilt')!;
+
+  for (const el of [phantom, tilt]) {
+    Object.defineProperty(el, 'scrollHeight', {
+      value: 2000,
+      configurable: true,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      value: 500,
+      configurable: true,
+    });
+  }
+
+  // Play, then pause at a non-zero position
+  playbackService.seekTo(2.5);
+  act(() => {
+    playbackService.play();
+  });
+  act(() => {
+    playbackService.pause();
+  });
+
+  // After pause, scroll should be at transport time 2.5s
+  // maxScrollTop = 2000 - 500 = 1500
+  // scrollTop = 1500 - (2.5 * 200) = 1000
+  expect(phantom.scrollTop).toBe(1000);
+
+  // Rewind while paused
+  act(() => {
+    playbackService.rewind();
+  });
+
+  // Scroll should sync to time 0
+  // scrollTop = 1500 - (0 * 200) = 1500
+  expect(phantom.scrollTop).toBe(1500);
+});
+
 it('shrinks phantom scroller when drawer is open', () => {
   const drawerHeight = 280;
   const { container } = render(

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -48,6 +48,7 @@ export function useScrubberScroll({
   const trackHook = useTrackService();
   const audioService = useAudioService();
   const playing = playback.isPlaying;
+  const playbackState = playback.playbackState;
 
   const isProgrammaticScrollRef = useRef(false);
   const shouldResumeRef = useRef(false);
@@ -165,14 +166,16 @@ export function useScrubberScroll({
   }, [playing, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sync scroll position to transportTime when not playing (e.g. after rewind)
-  // and render the idle (static line) playhead frame
+  // and render the idle (static line) playhead frame.
+  // Depends on playbackState (not just isPlaying) so the effect fires on
+  // paused→stopped transitions — e.g. when rewind is pressed while paused.
   useEffect(() => {
     if (!playing) {
       setScrollPosition(playback.transportTime);
       playheadRef.current?.renderIdle();
     }
     // Hook objects reference stable service singletons via getters
-  }, [playing, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [playbackState, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const setTransportTimeFromScroll = () => {
     const el = phantomRef.current;


### PR DESCRIPTION
## Summary
- Fixed idle scroll sync effect in `useScrubberScroll` to depend on `playbackState` instead of just `isPlaying`, so it fires on paused→stopped transitions (e.g. rewind while paused)
- Threaded an `onRewind` callback from `Workstation` through `ToolbarBottomSheet` → `FloatingToolbar` that explicitly syncs the scroll position to time 0, following the existing `handleLyricsSeekTo` pattern
- Added regression tests for both the scroll sync and the rewind callback

## Test plan
- [x] Unit test: `syncs scroll to beginning when rewinding while paused` (Scrubber.test.tsx)
- [x] Unit test: `calls onRewind when rewind button is clicked` (FloatingToolbar.test.tsx)
- [x] All 799 unit tests pass
- [x] All 38 e2e tests pass
- [x] ESLint passes

https://claude.ai/code/session_016zUGSDCgbX3fUokZ5JVv6p