### PR TITLE
Adjust timeline perspective and viewport transform

### DIFF
--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -114,13 +114,7 @@ it('applies translateY and scaleY to viewport div when drawer is open', () => {
     '.scrubber__viewport',
   ) as HTMLElement;
 
-  const visibleHeight = containerHeight - drawerHeight;
-  const expectedScaleY = visibleHeight / containerHeight;
-  const expectedTranslateY = -drawerHeight / 2;
-
-  expect(viewport.style.transform).toBe(
-    `translateY(${expectedTranslateY}px) scaleY(${expectedScaleY})`,
-  );
+  expect(viewport.style.transform).toBe(`translateY(-100px) scaleY(0.5)`);
 
   if (originalDescriptor) {
     Object.defineProperty(
@@ -138,7 +132,7 @@ it('does not apply viewport transform when drawer is closed', () => {
     '.scrubber__viewport',
   ) as HTMLElement;
 
-  expect(viewport.style.transform).toBe('');
+  expect(viewport.style.transform).toBe('translateY(-100px) scaleY(1)');
 });
 
 it('does not render a shade overlay', () => {

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -5,8 +5,8 @@ import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
 const SCRUBBER_BOTTOM_FRACTION = 0.75;
 
 // Fallbacks if CSS custom properties are missing or unparseable
-const FALLBACK_PERSPECTIVE = 1300;
-const FALLBACK_TILT = 80;
+const FALLBACK_PERSPECTIVE = 500;
+const FALLBACK_TILT = 75;
 
 const baseTransformStyle = {
   willChange: 'transform',
@@ -92,19 +92,12 @@ function getViewportStyle(
   containerHeight: number,
 ): CSSProperties {
   const hasDrawer = drawerHeight > 0 && containerHeight > 0;
-  const visibleHeight = containerHeight - drawerHeight;
-  const scaleY = hasDrawer ? visibleHeight / containerHeight : 1;
-  // With the default transform-origin (center), scaleY shifts the top edge
-  // downward by half the removed height. translateY compensates so the top
-  // stays at the viewport edge.
-  const translateY = hasDrawer ? -drawerHeight / 2 : 0;
+  const scaleY = hasDrawer ? 0.5 : 1;
 
   return {
     perspectiveOrigin: `center ${scrubberBottomY}px`,
-    ...(hasDrawer && {
-      ...baseTransformStyle,
-      transform: `translateY(${translateY}px) scaleY(${scaleY})`,
-    }),
+    ...baseTransformStyle,
+    transform: `translateY(-100px) scaleY(${scaleY})`,
   };
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -115,8 +115,8 @@ html {
   /* Perspective tilt: scrubber depth effect on the timeline.
      Higher perspective = smoother foreshortening. Higher tilt = steeper angle.
      These two values control the entire scrubber feel. */
-  --timeline-perspective: 1300px;
-  --timeline-tilt: 80deg;
+  --timeline-perspective: 500px;
+  --timeline-tilt: 75deg;
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
## Summary
- Changed `--timeline-perspective` from `1300px` to `500px` and `--timeline-tilt` from `80deg` to `75deg` for a more dramatic, slightly less steep scrubber effect
- Viewport now always applies `translateY(-100px) scaleY(1)` when the bottom sheet is closed, and `translateY(-100px) scaleY(0.5)` when open
- Updated fallback constants in `useScrubberGeometry.ts` and corresponding unit tests

## Test plan
- [x] All 18 Scrubber unit tests pass
- [x] All 38 e2e tests pass (including visual regression)
- [x] Build succeeds

https://claude.ai/code/session_019pm7Jj3wGBSXc3Ags7HnSt