### PR TITLE
Add pure runwayProjection module for anchor-based runway geometry

### DIFF
--- a/src/features/workstation/scrubber/__tests__/runwayProjection.test.ts
+++ b/src/features/workstation/scrubber/__tests__/runwayProjection.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  planeToScreenY,
+  type RunwayConfig,
+  screenYToPlane,
+  solveGeometry,
+  widthAtPlane,
+} from '../runwayProjection';
+
+// Mirrors the pinned default preset from mawimbi#446.
+const noteHighway: RunwayConfig = {
+  tiltDeg: 70,
+  playheadFraction: 0.75,
+  playheadWidth: 0.65,
+  elevationFraction: 0.55,
+  runwayLengthPx: 1800,
+  overhangPx: 320,
+};
+
+// A shallower, subtler tilt for contrast — matches the #402-era "ramp" feel.
+const subtleRamp: RunwayConfig = {
+  tiltDeg: 30,
+  playheadFraction: 0.6,
+  playheadWidth: 0.9,
+  elevationFraction: 0.2,
+  runwayLengthPx: 1200,
+  overhangPx: 150,
+};
+
+describe('solveGeometry', () => {
+  it('solves noteHighway golden values at a 650px visible height', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: 650 });
+
+    expect(geometry.perspectivePx).toBeCloseTo(1511.113, 2);
+    expect(geometry.transformOriginY).toBeCloseTo(680, 3);
+    expect(geometry.perspectiveOriginY).toBeCloseTo(680, 3);
+    expect(geometry.rotateXDeg).toBe(70);
+    expect(geometry.horizonY).toBeCloseTo(130, 3);
+    expect(geometry.farEdgeS).toBeCloseTo(2665.896, 2);
+  });
+
+  it('solves subtleRamp golden values at an 800px visible height', () => {
+    const geometry = solveGeometry(subtleRamp, { width: 1000, height: 800 });
+
+    expect(geometry.perspectivePx).toBeCloseTo(102.64, 1);
+    expect(geometry.transformOriginY).toBeCloseTo(497.778, 2);
+    expect(geometry.horizonY).toBeCloseTo(320, 3);
+    expect(geometry.farEdgeS).toBeCloseTo(1222.809, 2);
+  });
+
+  it('places the horizon exactly elevationFraction above the playhead line', () => {
+    const visible = { width: 1000, height: 650 };
+    const geometry = solveGeometry(noteHighway, visible);
+    const playheadScreenY = noteHighway.playheadFraction * visible.height;
+    const expectedHorizonY =
+      playheadScreenY - noteHighway.elevationFraction * visible.height;
+
+    expect(geometry.horizonY).toBeCloseTo(expectedHorizonY, 6);
+  });
+});
+
+describe('projection invariants', () => {
+  const visible = { width: 1000, height: 650 };
+  const geometry = solveGeometry(noteHighway, visible);
+  const sPlayhead = screenYToPlane(
+    noteHighway.playheadFraction * visible.height,
+    geometry,
+  );
+
+  it('widthAtPlane at the playhead distance equals the configured playheadWidth', () => {
+    expect(widthAtPlane(sPlayhead, geometry)).toBeCloseTo(
+      noteHighway.playheadWidth,
+      6,
+    );
+  });
+
+  it('planeToScreenY at the playhead distance equals playheadFraction × height', () => {
+    const expectedY = noteHighway.playheadFraction * visible.height;
+
+    expect(planeToScreenY(sPlayhead, geometry)).toBeCloseTo(expectedY, 6);
+  });
+
+  it('round-trips screenYToPlane(planeToScreenY(s)) back to s across a sweep', () => {
+    const samples = [-500, -100, 0, 250, sPlayhead, 1000, 2000];
+
+    for (const s of samples) {
+      const y = planeToScreenY(s, geometry);
+      expect(screenYToPlane(y, geometry)).toBeCloseTo(s, 4);
+    }
+  });
+});
+
+describe('degenerate configs', () => {
+  it('falls back to flat identity geometry at tilt 0 instead of NaN', () => {
+    const flatConfig: RunwayConfig = { ...noteHighway, tiltDeg: 0 };
+    const geometry = solveGeometry(flatConfig, { width: 1000, height: 650 });
+
+    expect(geometry.rotateXDeg).toBe(0);
+    expect(Number.isNaN(geometry.perspectivePx)).toBe(false);
+    expect(Number.isNaN(geometry.transformOriginY)).toBe(false);
+    expect(Number.isNaN(geometry.horizonY)).toBe(false);
+    expect(Number.isNaN(geometry.farEdgeS)).toBe(false);
+  });
+
+  it('produces finite values at a near-edge-on tilt of 89.9deg', () => {
+    const steepConfig: RunwayConfig = { ...noteHighway, tiltDeg: 89.9 };
+    const geometry = solveGeometry(steepConfig, { width: 1000, height: 650 });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('clamps tilt values at or above 90deg instead of producing Infinity', () => {
+    const edgeOnConfig: RunwayConfig = { ...noteHighway, tiltDeg: 90 };
+    const geometry = solveGeometry(edgeOnConfig, { width: 1000, height: 650 });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('produces finite values for a tiny 1px container height', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: 1 });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+});

--- a/src/features/workstation/scrubber/runwayProjection.ts
+++ b/src/features/workstation/scrubber/runwayProjection.ts
@@ -1,0 +1,154 @@
+export type RunwayConfig = {
+  tiltDeg: number;
+  playheadFraction: number;
+  playheadWidth: number;
+  elevationFraction: number;
+  runwayLengthPx: number;
+  overhangPx: number;
+};
+
+export type VisibleBox = {
+  width: number;
+  height: number;
+};
+
+export type RunwayGeometry = {
+  perspectivePx: number;
+  perspectiveOriginY: number;
+  transformOriginY: number;
+  rotateXDeg: number;
+  horizonY: number;
+  farEdgeS: number;
+};
+
+// Below this tilt the plane is treated as flat: rotateX(0) is the identity
+// transform, so no perspective/origin math can (or needs to) apply.
+const FLAT_TILT_THRESHOLD_DEG = 0.01;
+
+// rotateX approaches an edge-on singularity at 90deg (tan/cot blow up).
+// Clamping keeps the solver finite while still reading as "nearly edge-on".
+const MAX_TILT_DEG = 89.9;
+
+// Large enough that rotateX(0deg)'s foreshortening is imperceptible, so the
+// flat fallback renders identically to a plane with no perspective at all.
+const FLAT_PERSPECTIVE_PX = 1_000_000;
+
+/**
+ * Solves the three CSS unknowns (perspective distance, and the shared
+ * transform/perspective origin) that satisfy the runway's screen-space
+ * anchors: apparent width at the playhead, the playhead's screen position,
+ * and the horizon's screen position.
+ *
+ * The projection model (see mawimbi#443 for the full derivation): a point
+ * on the tilted plane at distance `s` above the origin projects to
+ *
+ *   scale(s)   = p / (p + s·sin θ)
+ *   screenY(s) = yo + (y0 − s·cos θ − yo) · scale(s)
+ *   horizonY   = yo − p·cot θ   (limit as s → ∞)
+ *
+ * Setting the perspective-origin and transform-origin to the same point
+ * (yo = y0 = Y0) leaves three unknowns — perspective `p`, origin `Y0`, and
+ * the playhead's plane-space distance from that origin `sPlayhead` — solved
+ * in closed form from the three anchors. No iteration, no fallback
+ * heuristics: the same config always yields the same geometry.
+ */
+export function solveGeometry(
+  config: RunwayConfig,
+  visible: VisibleBox,
+): RunwayGeometry {
+  const tiltDeg = clampTilt(config.tiltDeg);
+  const playheadScreenY = config.playheadFraction * visible.height;
+
+  if (tiltDeg <= FLAT_TILT_THRESHOLD_DEG) {
+    return solveFlatGeometry(playheadScreenY, config.runwayLengthPx);
+  }
+
+  return solveTiltedGeometry(config, tiltDeg, playheadScreenY, visible.height);
+}
+
+function clampTilt(tiltDeg: number): number {
+  if (tiltDeg <= 0) return 0;
+  return Math.min(tiltDeg, MAX_TILT_DEG);
+}
+
+function solveFlatGeometry(
+  playheadScreenY: number,
+  runwayLengthPx: number,
+): RunwayGeometry {
+  return {
+    perspectivePx: FLAT_PERSPECTIVE_PX,
+    perspectiveOriginY: playheadScreenY,
+    transformOriginY: playheadScreenY,
+    rotateXDeg: 0,
+    horizonY: playheadScreenY - FLAT_PERSPECTIVE_PX,
+    farEdgeS: runwayLengthPx,
+  };
+}
+
+function solveTiltedGeometry(
+  config: RunwayConfig,
+  tiltDeg: number,
+  playheadScreenY: number,
+  visibleHeight: number,
+): RunwayGeometry {
+  const tiltRad = degToRad(tiltDeg);
+  const { playheadWidth, elevationFraction, runwayLengthPx } = config;
+  const elevationPx = elevationFraction * visibleHeight;
+
+  // Closed-form solution of the three anchor equations for p, Y0, sPlayhead
+  // (derivation in mawimbi#443's decision comment).
+  const perspectivePx = (elevationPx * Math.tan(tiltRad)) / playheadWidth;
+  const originY =
+    playheadScreenY + (elevationPx * (1 - playheadWidth)) / playheadWidth;
+  const sPlayhead =
+    (elevationPx * (1 - playheadWidth)) /
+    (playheadWidth * playheadWidth * Math.cos(tiltRad));
+
+  const horizonY = originY - perspectivePx / Math.tan(tiltRad);
+
+  return {
+    perspectivePx,
+    perspectiveOriginY: originY,
+    transformOriginY: originY,
+    rotateXDeg: tiltDeg,
+    horizonY,
+    farEdgeS: sPlayhead + runwayLengthPx,
+  };
+}
+
+function degToRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/** Scale factor (apparent-width ratio) at plane-space distance `s` from the origin. */
+export function widthAtPlane(s: number, geometry: RunwayGeometry): number {
+  const tiltRad = degToRad(geometry.rotateXDeg);
+  return (
+    geometry.perspectivePx / (geometry.perspectivePx + s * Math.sin(tiltRad))
+  );
+}
+
+/** Forward projection: plane-space distance `s` → screen Y coordinate. */
+export function planeToScreenY(s: number, geometry: RunwayGeometry): number {
+  const tiltRad = degToRad(geometry.rotateXDeg);
+  const scale = widthAtPlane(s, geometry);
+  return (
+    geometry.perspectiveOriginY +
+    (geometry.transformOriginY -
+      s * Math.cos(tiltRad) -
+      geometry.perspectiveOriginY) *
+      scale
+  );
+}
+
+/** Inverse projection: screen Y coordinate → plane-space distance `s`. */
+export function screenYToPlane(y: number, geometry: RunwayGeometry): number {
+  const tiltRad = degToRad(geometry.rotateXDeg);
+  const {
+    perspectivePx: p,
+    transformOriginY: y0,
+    perspectiveOriginY: yo,
+  } = geometry;
+  const denominator = p * Math.cos(tiltRad) + (y - yo) * Math.sin(tiltRad);
+  return (p * (y0 - y)) / denominator;
+}


### PR DESCRIPTION
Solves the tilted timeline runway's CSS perspective/transform-origin in
closed form from screen-space anchors (playhead width, playhead position,
horizon elevation) rather than tuning perspective/tilt by hand. No React,
no DOM reads — solveGeometry, planeToScreenY, screenYToPlane, and
widthAtPlane are pure functions with golden-value and invariant tests.

Unused by the UI so far; wiring it into the scrubber is tracked in #445.

Closes #444