### PR TITLE
Drive scrubber transforms from the runway projection module

### DIFF
--- a/e2e/runway-geometry.spec.ts
+++ b/e2e/runway-geometry.spec.ts
@@ -20,6 +20,8 @@ import { expect, test, uploadAudioFile, SHORT_AUDIO } from './fixtures';
 
 const MIXER_ANIMATION_MS = 350;
 const ALIGNMENT_TOLERANCE_PX = 40;
+const ALIGNMENT_POLL_TIMEOUT_MS = 2000;
+const CONTENT_SETTLE_WAIT_MS = 1000;
 
 /**
  * The on-screen Y of the boundary between actual audio content and the
@@ -68,7 +70,7 @@ async function expectContentAlignedToPlayhead(
     expect(Math.abs(contentBoundaryY - playheadLineY)).toBeLessThanOrEqual(
       ALIGNMENT_TOLERANCE_PX,
     );
-  }).toPass({ timeout: 2000 });
+  }).toPass({ timeout: ALIGNMENT_POLL_TIMEOUT_MS });
 }
 
 test.describe('Runway alignment invariant', () => {
@@ -78,7 +80,7 @@ test.describe('Runway alignment invariant', () => {
     await expect(page.locator('.timeline__track')).toBeVisible();
     // Let the spectrogram cache finish sizing the scrollable content before
     // establishing the time=0 reference position.
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(CONTENT_SETTLE_WAIT_MS);
   });
 
   test('content at time 0 renders on the playhead line with the drawer closed', async ({

--- a/e2e/runway-geometry.spec.ts
+++ b/e2e/runway-geometry.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test, uploadAudioFile, SHORT_AUDIO } from './fixtures';
+
+/**
+ * Runway geometry invariants — assertions that the tilted timeline's
+ * screen-space anchors (mawimbi#443) actually hold in a real browser.
+ *
+ * This file currently covers the alignment invariant required by #445
+ * (the bug class behind #391/#411/#412: content scrolled to a given time
+ * must render on the playhead line). The full invariant suite planned in
+ * #448 (width anchor, drawer stability, reduced motion) extends this file.
+ *
+ * Tolerance note: a small residual drift (a few px with the drawer closed,
+ * up to ~35px with the mixer open) is expected here and tracked separately
+ * in #450 — `.scrubber__tilt`'s own scrollTop gets silently clamped by the
+ * browser to its (undiminished) box's scrollable range whenever the drawer
+ * is open, short of what `.scrubber__phantom` (which does shrink) asks for.
+ * That's a pre-existing scroll-mechanics issue from #419/#420, orthogonal to
+ * the projection math this file is validating.
+ */
+
+const MIXER_ANIMATION_MS = 350;
+const ALIGNMENT_TOLERANCE_PX = 40;
+
+/**
+ * The on-screen Y of the boundary between actual audio content and the
+ * timeline's bottom padding — i.e. the "time = 0" content point, since
+ * `.timeline__track` elements are pinned to the bottom of their shared grid
+ * area (`align-items: end`). `getBoundingClientRect()` reflects the
+ * post-3D-transform position, so this is a legitimate on-screen measurement
+ * despite the tilt (unlike inferring visibility from arbitrary interior
+ * canvas coordinates, which the projection does distort).
+ */
+async function getContentBoundaryY(
+  page: import('@playwright/test').Page,
+): Promise<number> {
+  return page
+    .locator('.timeline__track')
+    .first()
+    .evaluate((el) => el.getBoundingClientRect().bottom);
+}
+
+/** The on-screen Y of the playhead line — the vertical center of the playhead overlay. */
+async function getPlayheadLineY(
+  page: import('@playwright/test').Page,
+): Promise<number> {
+  return page.locator('.scrubber__playhead').evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    return rect.top + rect.height / 2;
+  });
+}
+
+/**
+ * Forces an explicit resync to time 0. The initial scroll position right
+ * after upload can be transiently stale while the spectrogram cache is
+ * still growing the scrollable content (see useSpacerHeight), so tests
+ * rewind explicitly rather than trusting the just-uploaded scroll position.
+ */
+async function rewindToStart(page: import('@playwright/test').Page) {
+  await page.locator('.floating-toolbar').getByTitle('Rewind').click();
+}
+
+async function expectContentAlignedToPlayhead(
+  page: import('@playwright/test').Page,
+) {
+  await expect(async () => {
+    const contentBoundaryY = await getContentBoundaryY(page);
+    const playheadLineY = await getPlayheadLineY(page);
+    expect(Math.abs(contentBoundaryY - playheadLineY)).toBeLessThanOrEqual(
+      ALIGNMENT_TOLERANCE_PX,
+    );
+  }).toPass({ timeout: 2000 });
+}
+
+test.describe('Runway alignment invariant', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/project/test-id');
+    await uploadAudioFile(page, SHORT_AUDIO);
+    await expect(page.locator('.timeline__track')).toBeVisible();
+    // Let the spectrogram cache finish sizing the scrollable content before
+    // establishing the time=0 reference position.
+    await page.waitForTimeout(1000);
+  });
+
+  test('content at time 0 renders on the playhead line with the drawer closed', async ({
+    page,
+  }) => {
+    await rewindToStart(page);
+    await expectContentAlignedToPlayhead(page);
+  });
+
+  test('content at time 0 renders on the playhead line with the drawer open', async ({
+    page,
+  }) => {
+    // Opening the mixer re-solves the runway geometry for the smaller
+    // visible area (mawimbi#443's drawer decision) — alignment must still
+    // hold against the new geometry, not the pre-drawer one.
+    await page.getByTitle('Show mixer').click();
+    await expect(page.locator('.channel')).toHaveCount(1);
+    await page.waitForTimeout(MIXER_ANIMATION_MS);
+
+    await rewindToStart(page);
+    await expectContentAlignedToPlayhead(page);
+  });
+});

--- a/src/features/workstation/Timeline.css
+++ b/src/features/workstation/Timeline.css
@@ -5,8 +5,12 @@
   grid-column-gap: 0px;
   grid-row-gap: 0px;
   align-items: end;
-  padding-top: calc(var(--cursor-position) * 100cqh);
-  padding-bottom: calc((1 - var(--cursor-position)) * 100cqh);
+  /* Projection-corrected padding computed by useScrubberGeometry — the
+     mapping between pre-transform layout position and on-screen position is
+     nonlinear under perspective, so these can't be expressed as a simple
+     fraction of the container here; see getTimelinePadding()'s comment. */
+  padding-top: var(--timeline-padding-top);
+  padding-bottom: var(--timeline-padding-bottom);
 }
 
 .timeline__track {

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { createRef } from 'react';
 import * as Tone from 'tone';
 import AudioService from '../../audio/AudioService';
+import { activeRunwayConfig } from '../scrubber/runwayConfig';
+import { solveGeometry } from '../scrubber/runwayProjection';
 import Scrubber, { type ScrubberHandle } from '../scrubber/Scrubber';
 
 const audioService = AudioService.getInstance();
@@ -21,6 +23,38 @@ afterEach(() => {
   recordingService.reset();
   Tone.getTransport().seconds = 0;
 });
+
+/**
+ * jsdom's offsetHeight always reads 0, so geometry tests that need a
+ * realistic container size mock it on the prototype (matching the pattern
+ * `useScrubberGeometry` measures in real browsers).
+ */
+function mockOffsetHeight(height: number): () => void {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight',
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return height;
+    },
+  });
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetHeight',
+        originalDescriptor,
+      );
+    }
+  };
+}
+
+/** Extracts the trailing `<number>px` token from a `center <y>px` origin string. */
+function parseOriginY(origin: string): number {
+  return parseFloat(origin.split(' ')[1]);
+}
 
 it('pauses playback when phantom scroller is scrolled while playing', () => {
   playbackService.play();
@@ -42,7 +76,10 @@ it('does not pause playback when phantom scroller is scrolled while paused', () 
   expect(playbackService.isPlaying).toBe(false);
 });
 
-it('positions perspective-origin and transform-origin at scrubber bottom', () => {
+it('derives perspective and tilt styles from the active runway config', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+
   const { container } = render(<Scrubber {...defaultProps} />);
 
   const viewport = container.querySelector(
@@ -50,89 +87,86 @@ it('positions perspective-origin and transform-origin at scrubber bottom', () =>
   ) as HTMLElement;
   const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
 
-  // Both origins should use the same Y coordinate (scrubber bottom).
-  // In jsdom offsetHeight is 0, so scrubberBottomY = 0.75 * 0 = 0.
-  expect(viewport.style.perspectiveOrigin).toBe('center 0px');
-  expect(tilt.style.transformOrigin).toBe('center 0px');
+  const geometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight,
+  });
+
+  expect(parseFloat(viewport.style.perspective)).toBeCloseTo(
+    geometry.perspectivePx,
+    6,
+  );
+  expect(parseOriginY(viewport.style.perspectiveOrigin)).toBeCloseTo(
+    geometry.perspectiveOriginY,
+    6,
+  );
+  expect(parseOriginY(tilt.style.transformOrigin)).toBeCloseTo(
+    geometry.transformOriginY,
+    6,
+  );
+  expect(tilt.style.transform).toBe(`rotateX(${geometry.rotateXDeg}deg)`);
+
+  restoreOffsetHeight();
 });
 
-it('keeps perspective geometry stable when drawer height changes', () => {
-  // Mock offsetHeight so the layout effect reads a non-zero container height
-  const originalDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    'offsetHeight',
-  );
-  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-    configurable: true,
-    get() {
-      return 800;
-    },
-  });
+it('re-solves perspective geometry for the smaller visible area when the drawer opens', () => {
+  const containerHeight = 800;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
 
   const { container, rerender } = render(<Scrubber {...defaultProps} />);
-
   const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
 
-  const transformWithoutDrawer = tilt.style.transform;
-
-  // Open the drawer — the perspective geometry should NOT change
-  rerender(<Scrubber {...defaultProps} drawerHeight={280} />);
-
-  const transformWithDrawer = tilt.style.transform;
-
-  expect(transformWithDrawer).toBe(transformWithoutDrawer);
-
-  // Restore
-  if (originalDescriptor) {
-    Object.defineProperty(
-      HTMLElement.prototype,
-      'offsetHeight',
-      originalDescriptor,
-    );
-  }
-});
-
-it('applies translateY and scaleY to viewport div when drawer is open', () => {
-  const containerHeight = 800;
-  const originalDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    'offsetHeight',
-  );
-  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
-    configurable: true,
-    get() {
-      return containerHeight;
-    },
+  const closedGeometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight,
   });
-
-  const drawerHeight = 280;
-  const { container } = render(
-    <Scrubber {...defaultProps} drawerHeight={drawerHeight} />,
+  expect(parseOriginY(tilt.style.transformOrigin)).toBeCloseTo(
+    closedGeometry.transformOriginY,
+    6,
   );
 
-  const viewport = container.querySelector(
-    '.scrubber__viewport',
-  ) as HTMLElement;
+  // Open the drawer — geometry re-solves for the smaller visible area
+  // (container height minus drawer height), so the origin moves.
+  const drawerHeight = 280;
+  rerender(<Scrubber {...defaultProps} drawerHeight={drawerHeight} />);
 
-  expect(viewport.style.transform).toBe(`translateY(-100px) scaleY(0.5)`);
+  const openGeometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight - drawerHeight,
+  });
+  expect(parseOriginY(tilt.style.transformOrigin)).toBeCloseTo(
+    openGeometry.transformOriginY,
+    6,
+  );
+  expect(openGeometry.transformOriginY).not.toBeCloseTo(
+    closedGeometry.transformOriginY,
+    0,
+  );
 
-  if (originalDescriptor) {
-    Object.defineProperty(
-      HTMLElement.prototype,
-      'offsetHeight',
-      originalDescriptor,
-    );
-  }
+  restoreOffsetHeight();
 });
 
-it('does not apply viewport transform when drawer is closed', () => {
-  const { container } = render(<Scrubber {...defaultProps} drawerHeight={0} />);
+it('disables the 3D tilt when prefers-reduced-motion is set', () => {
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
 
-  const viewport = container.querySelector(
-    '.scrubber__viewport',
-  ) as HTMLElement;
+  const restoreOffsetHeight = mockOffsetHeight(650);
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
 
-  expect(viewport.style.transform).toBe('translateY(-100px) scaleY(1)');
+  expect(tilt.style.transform).toBe('rotateX(0deg)');
+
+  restoreOffsetHeight();
+  window.matchMedia = originalMatchMedia;
 });
 
 it('does not render a shade overlay', () => {

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -114,6 +114,9 @@ it('re-solves perspective geometry for the smaller visible area when the drawer 
   const restoreOffsetHeight = mockOffsetHeight(containerHeight);
 
   const { container, rerender } = render(<Scrubber {...defaultProps} />);
+  const viewport = container.querySelector(
+    '.scrubber__viewport',
+  ) as HTMLElement;
   const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
 
   const closedGeometry = solveGeometry(activeRunwayConfig, {
@@ -122,6 +125,14 @@ it('re-solves perspective geometry for the smaller visible area when the drawer 
   });
   expect(parseOriginY(tilt.style.transformOrigin)).toBeCloseTo(
     closedGeometry.transformOriginY,
+    6,
+  );
+  expect(parseFloat(viewport.style.perspective)).toBeCloseTo(
+    closedGeometry.perspectivePx,
+    6,
+  );
+  expect(parseOriginY(viewport.style.perspectiveOrigin)).toBeCloseTo(
+    closedGeometry.perspectiveOriginY,
     6,
   );
 
@@ -142,6 +153,49 @@ it('re-solves perspective geometry for the smaller visible area when the drawer 
     closedGeometry.transformOriginY,
     0,
   );
+  // The viewport's own perspective/perspective-origin must also re-solve —
+  // not just the tilt element — since both derive from the same geometry.
+  expect(parseFloat(viewport.style.perspective)).toBeCloseTo(
+    openGeometry.perspectivePx,
+    6,
+  );
+  expect(parseOriginY(viewport.style.perspectiveOrigin)).toBeCloseTo(
+    openGeometry.perspectiveOriginY,
+    6,
+  );
+  expect(openGeometry.perspectivePx).not.toBeCloseTo(
+    closedGeometry.perspectivePx,
+    0,
+  );
+
+  restoreOffsetHeight();
+});
+
+it('exposes playhead fraction and timeline padding as CSS custom properties on the scrubber element', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const scrubberEl = container.querySelector('.scrubber') as HTMLElement;
+  const geometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight,
+  });
+  const expectedSPlayhead =
+    geometry.farEdgeS - activeRunwayConfig.runwayLengthPx;
+  const expectedPlayheadLocalY = geometry.transformOriginY - expectedSPlayhead;
+  const expectedPaddingBottom = containerHeight - expectedPlayheadLocalY;
+
+  expect(
+    parseFloat(scrubberEl.style.getPropertyValue('--playhead-fraction')),
+  ).toBeCloseTo(activeRunwayConfig.playheadFraction, 6);
+  expect(scrubberEl.style.getPropertyValue('--timeline-padding-top')).toBe(
+    `${activeRunwayConfig.runwayLengthPx}px`,
+  );
+  expect(
+    parseFloat(scrubberEl.style.getPropertyValue('--timeline-padding-bottom')),
+  ).toBeCloseTo(expectedPaddingBottom, 6);
 
   restoreOffsetHeight();
 });
@@ -175,7 +229,9 @@ it('does not render a shade overlay', () => {
   expect(container.querySelector('.scrubber__shade')).toBeNull();
 });
 
-it('passes drawer height as CSS variable to playhead for position alignment', () => {
+it('passes drawer-adjusted visible height as CSS variable to playhead for position alignment', () => {
+  const containerHeight = 800;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
   const drawerHeight = 200;
 
   const { container } = render(
@@ -186,11 +242,15 @@ it('passes drawer height as CSS variable to playhead for position alignment', ()
     '.scrubber__playhead',
   ) as HTMLElement;
 
-  // The playhead element must expose --drawer-height so CSS can position the
-  // playhead within the visible area above the drawer.
-  const heightVar = playhead.style.getPropertyValue('--drawer-height');
-  expect(heightVar).toBe(`${drawerHeight}px`);
+  // The playhead element must expose --available-height — the same
+  // drawer-adjusted visibleHeight useScrubberGeometry solves the runway
+  // transform against — computed once in JS rather than re-derived via a
+  // separate calc(100% - drawer-height) in CSS.
+  const heightVar = playhead.style.getPropertyValue('--available-height');
+  expect(heightVar).toBe(`${containerHeight - drawerHeight}px`);
   expect(playhead.style.transform).not.toContain('scaleY');
+
+  restoreOffsetHeight();
 });
 
 it('does not stop playback at end of scroll during recording', () => {

--- a/src/features/workstation/scrubber/Playhead.tsx
+++ b/src/features/workstation/scrubber/Playhead.tsx
@@ -13,22 +13,26 @@ export type PlayheadHandle = {
 };
 
 type PlayheadProps = {
-  drawerHeight: number;
+  visibleHeight: number;
 };
 
 /**
  * Playhead overlay that shows the current playback position.
  *
  * Renders a `LoudnessMeterPlayhead` canvas and keeps the canvas size
- * in sync with the container via ResizeObserver. Receives `drawerHeight`
- * to offset the playhead position within the visible area above the
- * bottom sheet.
+ * in sync with the container via ResizeObserver. Receives `visibleHeight`
+ * (the same drawer-adjusted height useScrubberGeometry solves the runway
+ * transform against) so the playhead's on-screen position and the 3D
+ * geometry are always derived from one JS computation, rather than each
+ * independently re-deriving "visible height" through a different
+ * mechanism (this used to be a `calc(100% - drawer-height)` CSS
+ * expression here, computed separately from the JS geometry).
  *
  * Exposes `render` and `renderIdle` via imperative handle so the
  * animation loop can drive the loudness meter visualization each frame.
  */
 const Playhead = forwardRef<PlayheadHandle, PlayheadProps>(
-  ({ drawerHeight }, ref) => {
+  ({ visibleHeight }, ref) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const meterRef =
       useRef<React.ComponentRef<typeof LoudnessMeterPlayhead>>(null);
@@ -68,7 +72,7 @@ const Playhead = forwardRef<PlayheadHandle, PlayheadProps>(
     }));
 
     const style: CSSProperties = {
-      '--drawer-height': `${drawerHeight}px`,
+      '--available-height': `${visibleHeight}px`,
     } as CSSProperties;
 
     return (

--- a/src/features/workstation/scrubber/Scrubber.css
+++ b/src/features/workstation/scrubber/Scrubber.css
@@ -63,7 +63,11 @@
 /* Playhead: loudness meter overlay centered at the playhead position */
 
 .scrubber__playhead {
-  --available-height: calc(100% - var(--drawer-height, 0px));
+  /* --available-height is set directly (in px) via inline style from
+     Playhead.tsx, using the same visibleHeight value useScrubberGeometry
+     solves the runway transform against — not recomputed here via
+     calc(100% - drawer-height), so there is exactly one derivation of
+     "visible height" instead of two that could silently drift apart. */
   --meter-height: calc(var(--available-height) * 0.4);
   position: absolute;
   top: calc(

--- a/src/features/workstation/scrubber/Scrubber.css
+++ b/src/features/workstation/scrubber/Scrubber.css
@@ -8,22 +8,17 @@
   min-height: 0;
 }
 
-/* ScrubberViewport: perspective positioning/scaling when drawer opens */
+/* ScrubberViewport: perspective wrapper for the 3D tilt */
 
 .scrubber__viewport {
   flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
-  perspective: var(--timeline-perspective);
-  /* perspective-origin is set via inline style (dynamic, drawer-aware) */
+  /* perspective + perspective-origin are set via inline style by
+     useScrubberGeometry (solved from RunwayConfig; disabled entirely,
+     not just visually, when prefers-reduced-motion is set) */
   pointer-events: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .scrubber__viewport {
-    perspective: none;
-  }
 }
 
 /* ScrubberTilt: 3D perspective tilt + passive scroll container */
@@ -42,11 +37,6 @@
      The tilt container is kept scrollable so child components (spectrogram)
      can read scrollTop to determine their viewport offset. */
   scrollbar-width: none;
-  /* Size container for cqh units in .timeline padding.
-     The timeline padding must reference this container's height
-     (not the viewport) so the content boundary at time=0 aligns with
-     the cursor position (which is a % of the scrubber height). */
-  container-type: size;
 }
 
 .scrubber__tilt::-webkit-scrollbar {
@@ -70,14 +60,14 @@
   display: none;
 }
 
-/* Playhead: loudness meter overlay centered at cursor position */
+/* Playhead: loudness meter overlay centered at the playhead position */
 
 .scrubber__playhead {
   --available-height: calc(100% - var(--drawer-height, 0px));
   --meter-height: calc(var(--available-height) * 0.4);
   position: absolute;
   top: calc(
-    var(--cursor-position) * var(--available-height) - var(--meter-height) / 2
+    var(--playhead-fraction) * var(--available-height) - var(--meter-height) / 2
   );
   left: 0;
   right: 0;

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -46,6 +46,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     viewportStyle,
     tiltStyle,
     playheadFraction,
+    visibleHeight,
     timelinePaddingTopPx,
     timelinePaddingBottomPx,
   } = useScrubberGeometry(drawerHeight);
@@ -114,7 +115,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         onScroll={handleScroll}
         onWheel={handleWheel}
       />
-      <Playhead ref={playheadRef} drawerHeight={drawerHeight} />
+      <Playhead ref={playheadRef} visibleHeight={visibleHeight} />
       <ZoomControls style={zoomControlsStyle} />
     </div>
   );

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -41,8 +41,14 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   const scrubberTiltRef = useRef<HTMLDivElement>(null);
   const playheadRef = useRef<PlayheadHandle>(null);
 
-  const { containerRef, viewportStyle, tiltStyle } =
-    useScrubberGeometry(drawerHeight);
+  const {
+    containerRef,
+    viewportStyle,
+    tiltStyle,
+    playheadFraction,
+    timelinePaddingTopPx,
+    timelinePaddingBottomPx,
+  } = useScrubberGeometry(drawerHeight);
 
   const {
     handlePointerDown,
@@ -73,6 +79,11 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
 
   const phantomStyle = getPhantomStyle(drawerHeight);
   const zoomControlsStyle = getZoomControlsStyle(drawerHeight);
+  const scrubberStyle = getScrubberStyle(
+    playheadFraction,
+    timelinePaddingTopPx,
+    timelinePaddingBottomPx,
+  );
 
   // The geometry ref measures the tilt container's height for 3D transform
   // calculations. Assign it via a callback ref alongside the scroll ref.
@@ -84,7 +95,10 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   };
 
   return (
-    <div className="scrubber scrubber--firefox-scroll-fix">
+    <div
+      className="scrubber scrubber--firefox-scroll-fix"
+      style={scrubberStyle}
+    >
       <ScrubberViewport style={viewportStyle}>
         <ScrubberTilt ref={tiltRef} style={tiltStyle}>
           {props.children}
@@ -124,4 +138,23 @@ function getZoomControlsStyle(drawerHeight: number): CSSProperties {
     ...baseTransformStyle,
     transform: `translateY(-${drawerHeight}px)`,
   };
+}
+
+/**
+ * Exposes the playhead's screen-space position and the timeline's
+ * projection-corrected content padding as CSS custom properties on the
+ * shared ancestor. Timeline.css and the playhead overlay both inherit
+ * these, so layout (where "now" is scrolled to) and geometry (the 3D
+ * transform) stay anchored to the same runway instead of drifting apart.
+ */
+function getScrubberStyle(
+  playheadFraction: number,
+  timelinePaddingTopPx: number,
+  timelinePaddingBottomPx: number,
+): CSSProperties {
+  return {
+    '--playhead-fraction': playheadFraction,
+    '--timeline-padding-top': `${timelinePaddingTopPx}px`,
+    '--timeline-padding-bottom': `${timelinePaddingBottomPx}px`,
+  } as CSSProperties;
 }

--- a/src/features/workstation/scrubber/ScrubberTilt.tsx
+++ b/src/features/workstation/scrubber/ScrubberTilt.tsx
@@ -7,9 +7,11 @@ type ScrubberTiltProps = PropsWithChildren<{
 /**
  * Visual container that applies the 3D scrubber tilt.
  *
- * The inline transform tilts the timeline plane via `rotateX` around
- * the scrubber bottom and compensates for perspective foreshortening
- * with a `scaleY` factor so the far edge fills the viewport.
+ * The inline transform tilts the timeline plane via `rotateX`, pivoting at
+ * the transform-origin solved by `runwayProjection.solveGeometry()`. The
+ * far edge is filled by content extent (runway length + timeline padding),
+ * not by scaling the plane — the rendered tilt always matches the
+ * configured tilt.
  *
  * This container is purely visual — it does not scroll or handle
  * pointer events. Scroll interaction is handled by the PhantomScroller

--- a/src/features/workstation/scrubber/ScrubberViewport.tsx
+++ b/src/features/workstation/scrubber/ScrubberViewport.tsx
@@ -5,13 +5,13 @@ type ScrubberViewportProps = PropsWithChildren<{
 }>;
 
 /**
- * Perspective wrapper that positions and scales the scrubber to fit the
- * visible area above the bottom sheet.
+ * Perspective wrapper for the 3D tilt.
  *
- * Sets the CSS `perspective` property for the 3D tilt effect and applies
- * `translateY`/`scaleY` when the drawer is open so the scrubber shrinks
- * to fit the reduced viewport — without touching the child tilt
- * container's own 3D transform.
+ * Sets the CSS `perspective` and `perspective-origin` solved by
+ * `runwayProjection.solveGeometry()` for the current visible area
+ * (container minus drawer height) — geometry re-solves when the drawer
+ * opens or closes, so no separate drawer-compensating transform is needed
+ * here.
  *
  * This container is purely visual — pointer events pass through to the
  * PhantomScroller overlay behind it.

--- a/src/features/workstation/scrubber/__tests__/runwayProjection.test.ts
+++ b/src/features/workstation/scrubber/__tests__/runwayProjection.test.ts
@@ -38,6 +38,7 @@ describe('solveGeometry', () => {
     expect(geometry.rotateXDeg).toBe(70);
     expect(geometry.horizonY).toBeCloseTo(130, 3);
     expect(geometry.farEdgeS).toBeCloseTo(2665.896, 2);
+    expect(geometry.nearEdgeS).toBeCloseTo(545.896, 2);
   });
 
   it('solves subtleRamp golden values at an 800px visible height', () => {
@@ -47,6 +48,7 @@ describe('solveGeometry', () => {
     expect(geometry.transformOriginY).toBeCloseTo(497.778, 2);
     expect(geometry.horizonY).toBeCloseTo(320, 3);
     expect(geometry.farEdgeS).toBeCloseTo(1222.809, 2);
+    expect(geometry.nearEdgeS).toBeCloseTo(-127.191, 2);
   });
 
   it('places the horizon exactly elevationFraction above the playhead line', () => {
@@ -60,23 +62,33 @@ describe('solveGeometry', () => {
   });
 });
 
-describe('projection invariants', () => {
-  const visible = { width: 1000, height: 650 };
-  const geometry = solveGeometry(noteHighway, visible);
+describe.each([
+  {
+    name: 'noteHighway',
+    config: noteHighway,
+    visible: { width: 1000, height: 650 },
+  },
+  {
+    name: 'subtleRamp',
+    config: subtleRamp,
+    visible: { width: 1000, height: 800 },
+  },
+])('projection invariants ($name)', ({ config, visible }) => {
+  const geometry = solveGeometry(config, visible);
   const sPlayhead = screenYToPlane(
-    noteHighway.playheadFraction * visible.height,
+    config.playheadFraction * visible.height,
     geometry,
   );
 
   it('widthAtPlane at the playhead distance equals the configured playheadWidth', () => {
     expect(widthAtPlane(sPlayhead, geometry)).toBeCloseTo(
-      noteHighway.playheadWidth,
+      config.playheadWidth,
       6,
     );
   });
 
   it('planeToScreenY at the playhead distance equals playheadFraction × height', () => {
-    const expectedY = noteHighway.playheadFraction * visible.height;
+    const expectedY = config.playheadFraction * visible.height;
 
     expect(planeToScreenY(sPlayhead, geometry)).toBeCloseTo(expectedY, 6);
   });
@@ -89,6 +101,11 @@ describe('projection invariants', () => {
       expect(screenYToPlane(y, geometry)).toBeCloseTo(s, 4);
     }
   });
+
+  it('sPlayhead matches farEdgeS/nearEdgeS minus their respective config offsets', () => {
+    expect(geometry.farEdgeS - config.runwayLengthPx).toBeCloseTo(sPlayhead, 6);
+    expect(geometry.nearEdgeS + config.overhangPx).toBeCloseTo(sPlayhead, 6);
+  });
 });
 
 describe('degenerate configs', () => {
@@ -97,10 +114,9 @@ describe('degenerate configs', () => {
     const geometry = solveGeometry(flatConfig, { width: 1000, height: 650 });
 
     expect(geometry.rotateXDeg).toBe(0);
-    expect(Number.isNaN(geometry.perspectivePx)).toBe(false);
-    expect(Number.isNaN(geometry.transformOriginY)).toBe(false);
-    expect(Number.isNaN(geometry.horizonY)).toBe(false);
-    expect(Number.isNaN(geometry.farEdgeS)).toBe(false);
+    for (const value of Object.values(geometry)) {
+      expect(Number.isNaN(value)).toBe(false);
+    }
   });
 
   it('produces finite values at a near-edge-on tilt of 89.9deg', () => {
@@ -121,11 +137,109 @@ describe('degenerate configs', () => {
     }
   });
 
+  it('clamps negative tilt to the flat boundary instead of mirroring it', () => {
+    const negativeConfig: RunwayConfig = { ...noteHighway, tiltDeg: -70 };
+    const geometry = solveGeometry(negativeConfig, {
+      width: 1000,
+      height: 650,
+    });
+
+    expect(geometry.rotateXDeg).toBe(0);
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
   it('produces finite values for a tiny 1px container height', () => {
     const geometry = solveGeometry(noteHighway, { width: 1000, height: 1 });
 
     for (const value of Object.values(geometry)) {
       expect(Number.isFinite(value)).toBe(true);
     }
+  });
+
+  it('produces finite values for a zero container height', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: 0 });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('produces finite values for a negative container height', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: -100 });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('produces finite values for a zero playheadWidth instead of Infinity/NaN', () => {
+    const zeroWidthConfig: RunwayConfig = { ...noteHighway, playheadWidth: 0 };
+    const geometry = solveGeometry(zeroWidthConfig, {
+      width: 1000,
+      height: 650,
+    });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it('produces finite values for a zero elevationFraction instead of NaN', () => {
+    const zeroElevationConfig: RunwayConfig = {
+      ...noteHighway,
+      elevationFraction: 0,
+    };
+    const geometry = solveGeometry(zeroElevationConfig, {
+      width: 1000,
+      height: 650,
+    });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+
+    // The zero-elevation degenerate case is exactly where widthAtPlane and
+    // screenYToPlane would previously divide 0/0 — exercise both directly.
+    expect(Number.isFinite(widthAtPlane(0, geometry))).toBe(true);
+    const playheadScreenY = zeroElevationConfig.playheadFraction * 650;
+    expect(Number.isFinite(screenYToPlane(playheadScreenY, geometry))).toBe(
+      true,
+    );
+  });
+
+  it('produces a farEdgeS at or ahead of the playhead for a negative runwayLengthPx', () => {
+    const negativeRunwayConfig: RunwayConfig = {
+      ...noteHighway,
+      runwayLengthPx: -500,
+    };
+    const geometry = solveGeometry(negativeRunwayConfig, {
+      width: 1000,
+      height: 650,
+    });
+
+    for (const value of Object.values(geometry)) {
+      expect(Number.isFinite(value)).toBe(true);
+    }
+    expect(geometry.farEdgeS).toBeGreaterThanOrEqual(geometry.nearEdgeS);
+  });
+
+  it('screenYToPlane at the horizon returns a large finite value instead of Infinity', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: 650 });
+
+    const result = screenYToPlane(geometry.horizonY, geometry);
+
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('widthAtPlane behind the camera returns a large finite value instead of Infinity', () => {
+    const geometry = solveGeometry(noteHighway, { width: 1000, height: 650 });
+    const tiltRad = (geometry.rotateXDeg * Math.PI) / 180;
+    const behindCameraS = -geometry.perspectivePx / Math.sin(tiltRad);
+
+    const result = widthAtPlane(behindCameraS, geometry);
+
+    expect(Number.isFinite(result)).toBe(true);
   });
 });

--- a/src/features/workstation/scrubber/runwayConfig.ts
+++ b/src/features/workstation/scrubber/runwayConfig.ts
@@ -1,0 +1,20 @@
+import type { RunwayConfig } from './runwayProjection';
+
+/**
+ * Guitar Hero-style note highway — the target look pinned from reference
+ * screenshots (see mawimbi#443's decision comment). Values are proportional
+ * (fractions of the visible area), not fixed pixels, so the look holds
+ * across screen sizes.
+ */
+export const noteHighway: RunwayConfig = {
+  tiltDeg: 70,
+  playheadFraction: 0.75,
+  playheadWidth: 0.65,
+  elevationFraction: 0.55,
+  runwayLengthPx: 1800,
+  overhangPx: 320,
+};
+
+// Full preset set (subtleRamp, flat, etc.) lands in #446; this is the one
+// preset #445 needs to wire the projection module into the scrubber.
+export const activeRunwayConfig: RunwayConfig = noteHighway;

--- a/src/features/workstation/scrubber/runwayProjection.ts
+++ b/src/features/workstation/scrubber/runwayProjection.ts
@@ -19,11 +19,16 @@ export type RunwayGeometry = {
   rotateXDeg: number;
   horizonY: number;
   farEdgeS: number;
+  nearEdgeS: number;
 };
 
-// Below this tilt the plane is treated as flat: rotateX(0) is the identity
-// transform, so no perspective/origin math can (or needs to) apply.
-const FLAT_TILT_THRESHOLD_DEG = 0.01;
+// Below this tilt, geometry switches to a distinct flat mode (rotateX(0),
+// no perspective) rather than letting tiltDeg approach 0 through the tilted
+// formula below. This is a deliberate mode switch, not a smooth
+// approximation boundary — see solveGeometry's doc comment for why the two
+// modes don't (and structurally can't) converge, and why this sits well
+// above 0 rather than at some tiny epsilon.
+const FLAT_TILT_THRESHOLD_DEG = 1;
 
 // rotateX approaches an edge-on singularity at 90deg (tan/cot blow up).
 // Clamping keeps the solver finite while still reading as "nearly edge-on".
@@ -32,6 +37,26 @@ const MAX_TILT_DEG = 89.9;
 // Large enough that rotateX(0deg)'s foreshortening is imperceptible, so the
 // flat fallback renders identically to a plane with no perspective at all.
 const FLAT_PERSPECTIVE_PX = 1_000_000;
+
+// playheadWidth and elevationFraction are divisors throughout the tilted
+// solve; exactly 0 (or pathologically close to it) would produce
+// Infinity/NaN geometry. These floors sit far below any sane preset value —
+// they exist purely so a misconfigured RunwayConfig fails safe (an extreme
+// but finite, renderable geometry) instead of propagating NaN into CSS.
+const MIN_PLAYHEAD_WIDTH = 0.01;
+const MIN_ELEVATION_FRACTION = 0.01;
+
+// visible.height is a measured DOM size that can be 0 or briefly negative
+// (e.g. before the first ResizeObserver callback fires, or if a drawer
+// taller than the container is ever configured) — floor it for the same
+// fail-safe reason as the two constants above.
+const MIN_VISIBLE_HEIGHT_PX = 1;
+
+// Below this magnitude, treat a projection denominator as this magnitude
+// instead of the true (near-)zero value, so screenYToPlane/widthAtPlane
+// return a large-but-finite number instead of Infinity/NaN at the horizon
+// or at the "behind the camera" point where perspectivePx + s·sinθ = 0.
+const MIN_DENOMINATOR_MAGNITUDE = 1e-6;
 
 /**
  * Solves the three CSS unknowns (perspective distance, and the shared
@@ -51,22 +76,39 @@ const FLAT_PERSPECTIVE_PX = 1_000_000;
  * the playhead's plane-space distance from that origin `sPlayhead` — solved
  * in closed form from the three anchors. No iteration, no fallback
  * heuristics: the same config always yields the same geometry.
+ *
+ * Below `FLAT_TILT_THRESHOLD_DEG`, geometry comes from `solveFlatGeometry`
+ * instead of the formula above. This is a deliberate mode switch, not a
+ * numerical approximation: as tiltRad → 0 the tilted formula's own
+ * `perspectivePx` → 0 (near-edge-on foreshortening), the opposite extreme
+ * from the flat mode's scale-1-everywhere — so there is no continuous
+ * handoff to protect between the two. The only caller of the flat mode
+ * (`prefers-reduced-motion`) always passes tiltDeg exactly 0, never an
+ * intermediate value.
  */
 export function solveGeometry(
   config: RunwayConfig,
   visible: VisibleBox,
 ): RunwayGeometry {
   const tiltDeg = clampTilt(config.tiltDeg);
-  const playheadScreenY = config.playheadFraction * visible.height;
+  const height = Math.max(visible.height, MIN_VISIBLE_HEIGHT_PX);
+  const playheadScreenY = config.playheadFraction * height;
 
   if (tiltDeg <= FLAT_TILT_THRESHOLD_DEG) {
-    return solveFlatGeometry(playheadScreenY, config.runwayLengthPx);
+    return solveFlatGeometry(
+      playheadScreenY,
+      config.runwayLengthPx,
+      config.overhangPx,
+    );
   }
 
-  return solveTiltedGeometry(config, tiltDeg, playheadScreenY, visible.height);
+  return solveTiltedGeometry(config, tiltDeg, playheadScreenY, height);
 }
 
 function clampTilt(tiltDeg: number): number {
+  // Negative tilt is outside the documented range (0 = flat, 90 = edge-on
+  // road) — clamp to the boundary rather than supporting a "mirrored" tilt
+  // direction that no preset or design reference calls for.
   if (tiltDeg <= 0) return 0;
   return Math.min(tiltDeg, MAX_TILT_DEG);
 }
@@ -74,6 +116,7 @@ function clampTilt(tiltDeg: number): number {
 function solveFlatGeometry(
   playheadScreenY: number,
   runwayLengthPx: number,
+  overhangPx: number,
 ): RunwayGeometry {
   return {
     perspectivePx: FLAT_PERSPECTIVE_PX,
@@ -82,6 +125,7 @@ function solveFlatGeometry(
     rotateXDeg: 0,
     horizonY: playheadScreenY - FLAT_PERSPECTIVE_PX,
     farEdgeS: runwayLengthPx,
+    nearEdgeS: -overhangPx,
   };
 }
 
@@ -92,7 +136,12 @@ function solveTiltedGeometry(
   visibleHeight: number,
 ): RunwayGeometry {
   const tiltRad = degToRad(tiltDeg);
-  const { playheadWidth, elevationFraction, runwayLengthPx } = config;
+  const { runwayLengthPx, overhangPx } = config;
+  const playheadWidth = Math.max(config.playheadWidth, MIN_PLAYHEAD_WIDTH);
+  const elevationFraction = Math.max(
+    config.elevationFraction,
+    MIN_ELEVATION_FRACTION,
+  );
   const elevationPx = elevationFraction * visibleHeight;
 
   // Closed-form solution of the three anchor equations for p, Y0, sPlayhead
@@ -112,7 +161,8 @@ function solveTiltedGeometry(
     transformOriginY: originY,
     rotateXDeg: tiltDeg,
     horizonY,
-    farEdgeS: sPlayhead + runwayLengthPx,
+    farEdgeS: sPlayhead + Math.max(runwayLengthPx, 0),
+    nearEdgeS: sPlayhead - overhangPx,
   };
 }
 
@@ -120,12 +170,19 @@ function degToRad(deg: number): number {
   return (deg * Math.PI) / 180;
 }
 
+/** Clamps a projection denominator away from zero, preserving its sign. */
+function safeDenominator(value: number): number {
+  if (Math.abs(value) >= MIN_DENOMINATOR_MAGNITUDE) return value;
+  return value < 0 ? -MIN_DENOMINATOR_MAGNITUDE : MIN_DENOMINATOR_MAGNITUDE;
+}
+
 /** Scale factor (apparent-width ratio) at plane-space distance `s` from the origin. */
 export function widthAtPlane(s: number, geometry: RunwayGeometry): number {
   const tiltRad = degToRad(geometry.rotateXDeg);
-  return (
-    geometry.perspectivePx / (geometry.perspectivePx + s * Math.sin(tiltRad))
+  const denominator = safeDenominator(
+    geometry.perspectivePx + s * Math.sin(tiltRad),
   );
+  return geometry.perspectivePx / denominator;
 }
 
 /** Forward projection: plane-space distance `s` → screen Y coordinate. */
@@ -149,6 +206,8 @@ export function screenYToPlane(y: number, geometry: RunwayGeometry): number {
     transformOriginY: y0,
     perspectiveOriginY: yo,
   } = geometry;
-  const denominator = p * Math.cos(tiltRad) + (y - yo) * Math.sin(tiltRad);
+  const denominator = safeDenominator(
+    p * Math.cos(tiltRad) + (y - yo) * Math.sin(tiltRad),
+  );
   return (p * (y0 - y)) / denominator;
 }

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -1,121 +1,183 @@
 import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
+import { activeRunwayConfig } from './runwayConfig';
+import {
+  screenYToPlane,
+  solveGeometry,
+  type RunwayConfig,
+  type RunwayGeometry,
+} from './runwayProjection';
 
-// The scrubber bottom sits at this fraction from the top of the visible area
-// (viewport minus drawer). 0.75 = bottom 25% of visible area is empty.
-const SCRUBBER_BOTTOM_FRACTION = 0.75;
-
-// Fallbacks if CSS custom properties are missing or unparseable
-const FALLBACK_PERSPECTIVE = 500;
-const FALLBACK_TILT = 75;
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
 const baseTransformStyle = {
   willChange: 'transform',
   transition: 'transform 0.25s ease-out',
 };
 
+type ContainerSize = {
+  width: number;
+  height: number;
+};
+
 type ScrubberGeometry = {
   containerRef: React.RefObject<HTMLDivElement | null>;
   viewportStyle: CSSProperties;
   tiltStyle: CSSProperties;
+  playheadFraction: number;
+  timelinePaddingTopPx: number;
+  timelinePaddingBottomPx: number;
 };
 
 /**
- * Computes the 3D perspective geometry for the scrubber.
+ * Computes the 3D perspective geometry for the scrubber by delegating to
+ * `runwayProjection.solveGeometry()` — this hook only measures the DOM and
+ * maps the solved geometry onto CSS properties; it holds no geometry math
+ * of its own.
  *
- * Tracks the scroll container's height via ResizeObserver and derives:
- * - `viewportStyle` — perspective-origin + drawer-aware translateY/scaleY
- * - `tiltStyle` — rotateX tilt + foreshortening-compensating scaleY
- *
- * The container height is measured from the scroll container (ScrubberTilt),
- * not the viewport wrapper. This keeps the 3D transform stable when the
- * bottom sheet opens — only the viewport wrapper scales/repositions.
+ * The visible box passed to the solver is the container's size minus the
+ * open drawer's height. When the drawer opens or closes, geometry is
+ * re-solved for the new visible box, so the runway's screen-space anchors
+ * (playhead position, playhead width, horizon) stay true rather than being
+ * patched with ad hoc compensating transforms.
  */
 export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [containerHeight, setContainerHeight] = useState(0);
+  const containerSize = useContainerSize(containerRef);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const visibleHeight = containerSize.height - drawerHeight;
+  const config = getEffectiveConfig(prefersReducedMotion);
+  const geometry = solveGeometry(config, {
+    width: containerSize.width,
+    height: visibleHeight,
+  });
+  const timelinePadding = getTimelinePadding(config, geometry, visibleHeight);
+
+  return {
+    containerRef,
+    viewportStyle: getViewportStyle(
+      geometry.perspectivePx,
+      geometry.perspectiveOriginY,
+    ),
+    tiltStyle: getTiltStyle(geometry.rotateXDeg, geometry.transformOriginY),
+    playheadFraction: activeRunwayConfig.playheadFraction,
+    timelinePaddingTopPx: timelinePadding.top,
+    timelinePaddingBottomPx: timelinePadding.bottom,
+  };
+}
+
+function getEffectiveConfig(prefersReducedMotion: boolean): RunwayConfig {
+  if (!prefersReducedMotion) return activeRunwayConfig;
+  // A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
+  // path — rotateX(0) disables the 3D effect without a separate code path.
+  return { ...activeRunwayConfig, tiltDeg: 0 };
+}
+
+function getViewportStyle(
+  perspectivePx: number,
+  perspectiveOriginY: number,
+): CSSProperties {
+  return {
+    ...baseTransformStyle,
+    perspective: `${perspectivePx}px`,
+    perspectiveOrigin: `center ${perspectiveOriginY}px`,
+  };
+}
+
+function getTiltStyle(
+  rotateXDeg: number,
+  transformOriginY: number,
+): CSSProperties {
+  return {
+    ...baseTransformStyle,
+    transformOrigin: `center ${transformOriginY}px`,
+    transform: `rotateX(${rotateXDeg}deg)`,
+  };
+}
+
+type TimelinePadding = {
+  top: number;
+  bottom: number;
+};
+
+/**
+ * Computes the `.timeline` padding (in px, pre-transform layout space) that
+ * keeps scrolled content aligned with the runway's screen-space anchors.
+ *
+ * The projection is nonlinear, so content laid out at plane-space distance
+ * `playheadFraction × visibleHeight` from the origin does NOT project onto
+ * the playhead line — only content at distance `sPlayhead` does. Padding
+ * must be sized so that when scrolled to time 0 (`scrollTop = maxScrollTop`,
+ * inverted scroll — see useScrubberScroll.ts), the boundary between actual
+ * audio content and this padding sits at the plane-space distance the
+ * geometry solver actually anchored to the playhead line, found via the
+ * inverse projection (`screenYToPlane`).
+ *
+ * Scroll position is driven by the (untransformed) PhantomScroller, whose
+ * clientHeight already equals `visibleHeight` (it shrinks with the drawer
+ * via its own CSS). Given that, the local Y (within the tilt container,
+ * relative to its own — undiminished — box) of content scrolled to time 0
+ * works out to `visibleHeight - paddingBottom`, independent of paddingTop.
+ * Setting that equal to the playhead's own local Y (`transformOriginY -
+ * sPlayhead`) and solving gives the formula below.
+ *
+ * `paddingTop` has no equally strict constraint from this invariant — it
+ * only needs to provide enough scrollable space to see `runwayLengthPx` of
+ * upcoming content before the far edge/fog, which is what it's set to
+ * directly (fog placement itself lands in a later issue).
+ */
+function getTimelinePadding(
+  config: RunwayConfig,
+  geometry: RunwayGeometry,
+  visibleHeight: number,
+): TimelinePadding {
+  const playheadScreenY = config.playheadFraction * visibleHeight;
+  const sPlayhead = screenYToPlane(playheadScreenY, geometry);
+  const playheadLocalY = geometry.transformOriginY - sPlayhead;
+
+  return {
+    top: config.runwayLengthPx,
+    bottom: visibleHeight - playheadLocalY,
+  };
+}
+
+/** Tracks the scrubber tilt container's size via ResizeObserver. */
+function useContainerSize(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+): ContainerSize {
+  const [size, setSize] = useState<ContainerSize>({ width: 0, height: 0 });
 
   useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    const update = () => setContainerHeight(el.offsetHeight);
+    const update = () =>
+      setSize({ width: el.offsetWidth, height: el.offsetHeight });
     update();
 
     const observer = new ResizeObserver(() => update());
     observer.observe(el);
 
     return () => observer.disconnect();
+    // containerRef is a stable ref object
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Using the full height (not visible height) keeps the perspective geometry
-  // stable when the bottom sheet opens — the 3D transform and scaleY
-  // compensation stay constant, preventing the timeline from appearing wider.
-  const scrubberBottomY = SCRUBBER_BOTTOM_FRACTION * containerHeight;
-  const extendFactor = computeExtendFactor(scrubberBottomY);
+  return size;
+}
 
-  const viewportStyle = getViewportStyle(
-    scrubberBottomY,
-    drawerHeight,
-    containerHeight,
+/** Tracks the `prefers-reduced-motion` media query, live. */
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
   );
-  const tiltStyle = getTiltStyle(extendFactor, scrubberBottomY);
 
-  return { containerRef, viewportStyle, tiltStyle };
-}
+  useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const handler = () => setPrefersReducedMotion(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, []);
 
-/**
- * Compensate for perspective foreshortening so the far edge (top) fills
- * the viewport. `scrubberBottomY` is the distance from the top of the
- * container to the tilt origin — content above the origin is the visible
- * scrubber that needs to fill the viewport width after foreshortening.
- */
-function computeExtendFactor(scrubberBottomY: number): number {
-  if (scrubberBottomY <= 0) return 1;
-
-  const tiltRad = (FALLBACK_TILT * Math.PI) / 180;
-  const depth = scrubberBottomY * Math.sin(tiltRad);
-  const projectionRatio = FALLBACK_PERSPECTIVE / (FALLBACK_PERSPECTIVE + depth);
-  return 1 / projectionRatio;
-}
-
-/**
- * Style for the viewport wrapper. Places `perspective-origin` at the
- * scrubber bottom so the vanishing point matches the tilt pivot.
- *
- * When the drawer is open, `translateY` and `scaleY` reposition and shrink
- * the scrubber to fit the visible area above the drawer — without touching
- * the child tilt container's own 3D transform or styling.
- */
-function getViewportStyle(
-  scrubberBottomY: number,
-  drawerHeight: number,
-  containerHeight: number,
-): CSSProperties {
-  const hasDrawer = drawerHeight > 0 && containerHeight > 0;
-  const scaleY = hasDrawer ? 0.5 : 1;
-
-  return {
-    perspectiveOrigin: `center ${scrubberBottomY}px`,
-    ...baseTransformStyle,
-    transform: `translateY(-100px) scaleY(${scaleY})`,
-  };
-}
-
-/**
- * Style for the tilt container. The transform tilts the timeline into a
- * dramatic scrubber perspective:
- * - rotateX tilts the plane around the scrubber bottom
- * - scaleY(extendFactor) compensates for perspective foreshortening so the
- *   far edge (top) fills the viewport regardless of screen size
- * - transformOrigin is placed at the scrubber bottom so the tilt pivots there
- */
-function getTiltStyle(
-  extendFactor: number,
-  scrubberBottomY: number,
-): CSSProperties {
-  return {
-    ...baseTransformStyle,
-    transformOrigin: `center ${scrubberBottomY}px`,
-    transform: `rotateX(var(--timeline-tilt, 0deg)) scaleY(${extendFactor})`,
-  };
+  return prefersReducedMotion;
 }

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -1,7 +1,7 @@
 import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
+import { useMediaQuery } from '../../../shared/hooks/useMediaQuery';
 import { activeRunwayConfig } from './runwayConfig';
 import {
-  screenYToPlane,
   solveGeometry,
   type RunwayConfig,
   type RunwayGeometry,
@@ -9,9 +9,30 @@ import {
 
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
+// A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
+// path — rotateX(0) disables the 3D effect without a separate code path.
+// Defined once so referential equality is stable across renders.
+const REDUCED_MOTION_CONFIG: RunwayConfig = {
+  ...activeRunwayConfig,
+  tiltDeg: 0,
+};
+
+// Measured container height can be 0 (before the first ResizeObserver
+// callback) or, in principle, smaller than drawerHeight — floor it so
+// visibleHeight never goes to or past 0 and produces invalid CSS values.
+const MIN_VISIBLE_HEIGHT_PX = 1;
+
+const TRANSITION_PROPERTIES = [
+  'transform',
+  'transform-origin',
+  'perspective',
+  'perspective-origin',
+];
 const baseTransformStyle = {
   willChange: 'transform',
-  transition: 'transform 0.25s ease-out',
+  transition: TRANSITION_PROPERTIES.map(
+    (prop) => `${prop} 0.25s ease-out`,
+  ).join(', '),
 };
 
 type ContainerSize = {
@@ -24,6 +45,7 @@ type ScrubberGeometry = {
   viewportStyle: CSSProperties;
   tiltStyle: CSSProperties;
   playheadFraction: number;
+  visibleHeight: number;
   timelinePaddingTopPx: number;
   timelinePaddingBottomPx: number;
 };
@@ -43,10 +65,15 @@ type ScrubberGeometry = {
 export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
   const containerRef = useRef<HTMLDivElement>(null);
   const containerSize = useContainerSize(containerRef);
-  const prefersReducedMotion = usePrefersReducedMotion();
+  const prefersReducedMotion = useMediaQuery(REDUCED_MOTION_QUERY);
 
-  const visibleHeight = containerSize.height - drawerHeight;
-  const config = getEffectiveConfig(prefersReducedMotion);
+  const visibleHeight = Math.max(
+    containerSize.height - drawerHeight,
+    MIN_VISIBLE_HEIGHT_PX,
+  );
+  const config = prefersReducedMotion
+    ? REDUCED_MOTION_CONFIG
+    : activeRunwayConfig;
   const geometry = solveGeometry(config, {
     width: containerSize.width,
     height: visibleHeight,
@@ -61,16 +88,10 @@ export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
     ),
     tiltStyle: getTiltStyle(geometry.rotateXDeg, geometry.transformOriginY),
     playheadFraction: activeRunwayConfig.playheadFraction,
+    visibleHeight,
     timelinePaddingTopPx: timelinePadding.top,
     timelinePaddingBottomPx: timelinePadding.bottom,
   };
-}
-
-function getEffectiveConfig(prefersReducedMotion: boolean): RunwayConfig {
-  if (!prefersReducedMotion) return activeRunwayConfig;
-  // A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
-  // path — rotateX(0) disables the 3D effect without a separate code path.
-  return { ...activeRunwayConfig, tiltDeg: 0 };
 }
 
 function getViewportStyle(
@@ -110,8 +131,12 @@ type TimelinePadding = {
  * must be sized so that when scrolled to time 0 (`scrollTop = maxScrollTop`,
  * inverted scroll — see useScrubberScroll.ts), the boundary between actual
  * audio content and this padding sits at the plane-space distance the
- * geometry solver actually anchored to the playhead line, found via the
- * inverse projection (`screenYToPlane`).
+ * geometry solver actually anchored to the playhead line.
+ *
+ * `sPlayhead` is recovered from `geometry.farEdgeS - config.runwayLengthPx`
+ * (farEdgeS already equals `sPlayhead + runwayLengthPx`, computed once by
+ * the solver) rather than re-derived via the inverse projection — same
+ * value, no repeated trig.
  *
  * Scroll position is driven by the (untransformed) PhantomScroller, whose
  * clientHeight already equals `visibleHeight` (it shrinks with the drawer
@@ -131,8 +156,7 @@ function getTimelinePadding(
   geometry: RunwayGeometry,
   visibleHeight: number,
 ): TimelinePadding {
-  const playheadScreenY = config.playheadFraction * visibleHeight;
-  const sPlayhead = screenYToPlane(playheadScreenY, geometry);
+  const sPlayhead = geometry.farEdgeS - config.runwayLengthPx;
   const playheadLocalY = geometry.transformOriginY - sPlayhead;
 
   return {
@@ -151,8 +175,15 @@ function useContainerSize(
     const el = containerRef.current;
     if (!el) return;
 
-    const update = () =>
-      setSize({ width: el.offsetWidth, height: el.offsetHeight });
+    const update = () => {
+      const width = el.offsetWidth;
+      const height = el.offsetHeight;
+      setSize((prev) =>
+        prev.width === width && prev.height === height
+          ? prev
+          : { width, height },
+      );
+    };
     update();
 
     const observer = new ResizeObserver(() => update());
@@ -164,20 +195,4 @@ function useContainerSize(
   }, []);
 
   return size;
-}
-
-/** Tracks the `prefers-reduced-motion` media query, live. */
-function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
-    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
-  );
-
-  useLayoutEffect(() => {
-    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
-    const handler = () => setPrefersReducedMotion(mediaQuery.matches);
-    mediaQuery.addEventListener('change', handler);
-    return () => mediaQuery.removeEventListener('change', handler);
-  }, []);
-
-  return prefersReducedMotion;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -109,14 +109,7 @@ body {
 }
 
 html {
-  /* Timeline layout: the cursor sits at 25% from top of viewport */
-  --cursor-position: 0.5;
   --timeline-margin-top: 40px;
-  /* Perspective tilt: scrubber depth effect on the timeline.
-     Higher perspective = smoother foreshortening. Higher tilt = steeper angle.
-     These two values control the entire scrubber feel. */
-  --timeline-perspective: 500px;
-  --timeline-tilt: 75deg;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -18,6 +18,22 @@ if (!HTMLCanvasElement.prototype.getContext) {
   HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(null);
 }
 
+// jsdom does not implement matchMedia — provide a default stub (no
+// preference matched) so components can query media features without
+// throwing. Tests that need a specific match override it locally.
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
 vi.mock('tone', () => {
   function mockBlob() {
     return { arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(16)) };

--- a/src/shared/hooks/useMediaQuery.ts
+++ b/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,22 @@
+import { useLayoutEffect, useState } from 'react';
+
+/**
+ * Tracks a CSS media query's current match state, live — re-renders when
+ * the user's OS-level preference (or viewport) changes to match or unmatch.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => window.matchMedia(query).matches,
+  );
+
+  useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    setMatches(mediaQuery.matches);
+
+    const handler = () => setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/shared/hooks/useTheme.tsx
+++ b/src/shared/hooks/useTheme.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useMediaQuery } from './useMediaQuery';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -15,6 +16,7 @@ type ThemeContextValue = {
 };
 
 const STORAGE_KEY = 'mawimbi-theme';
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
@@ -29,8 +31,7 @@ function getStoredTheme(): Theme {
 function applyTheme(theme: Theme) {
   const isDark =
     theme === 'dark' ||
-    (theme === 'system' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches);
+    (theme === 'system' && window.matchMedia(DARK_SCHEME_QUERY).matches);
 
   if (isDark) {
     document.documentElement.classList.add('dark');
@@ -41,6 +42,7 @@ function applyTheme(theme: Theme) {
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [theme, setThemeState] = useState<Theme>(getStoredTheme);
+  const systemPrefersDark = useMediaQuery(DARK_SCHEME_QUERY);
 
   const setTheme = useCallback((newTheme: Theme) => {
     localStorage.setItem(STORAGE_KEY, newTheme);
@@ -52,14 +54,15 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
     applyTheme(theme);
   }, [theme]);
 
+  // Re-applies when the OS-level dark/light preference changes while the
+  // user has selected 'system' — the effect above already handles
+  // user-initiated theme changes, so this one intentionally reacts only to
+  // systemPrefersDark, not theme, to avoid a redundant double-apply.
   useEffect(() => {
     if (theme !== 'system') return;
-
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => applyTheme('system');
-    mediaQuery.addEventListener('change', handler);
-    return () => mediaQuery.removeEventListener('change', handler);
-  }, [theme]);
+    applyTheme('system');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [systemPrefersDark]);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>


### PR DESCRIPTION
## Summary

Implements #445 — replaces the accumulated ad hoc runway transforms with values computed by `runwayProjection.solveGeometry()` (#444, merged in #449) against the `noteHighway` config (#446).

- `useScrubberGeometry` measures the visible box (container minus drawer height) and re-solves geometry against it on every render, per the drawer decision from #443 ("re-solve, don't crop/scale"). No more `FALLBACK_PERSPECTIVE`/`FALLBACK_TILT` JS constants silently drifting from the CSS custom properties they were meant to shadow.
- `Timeline.css` padding is now computed via the inverse projection (`screenYToPlane`), not a plain fraction of the container height. The mapping between pre-transform layout position and on-screen position is nonlinear under real perspective — a naive `playheadFraction × height` padding looks correct in the flat/no-drawer case but silently drifts once actual tilt and an open drawer are both in play (discovered and fixed while writing the alignment e2e test below).
- Removed the `extendFactor` scaleY compensation, the magic `translateY(-100px)`/`scaleY(0.5)` drawer hack (#424), and the `--cursor-position`/`--timeline-perspective`/`--timeline-tilt` CSS custom properties.
- `prefers-reduced-motion` is now handled in JS (matching the existing `useTheme.tsx` `matchMedia` pattern) by flattening `tiltDeg` to 0, routing through `solveGeometry`'s own flat-identity branch — a CSS media-query override would have been silently defeated by the new inline-style-driven transforms.

Also files #450: a separate, pre-existing scroll-mechanics bug found while tightening the new e2e test's tolerance (`.scrubber__tilt`'s own `scrollTop` gets silently clamped by the browser short of what `.scrubber__phantom` asks for, whenever the drawer is open) — orthogonal to this issue's scope, so it's tracked separately rather than bundled in here.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` (vitest) — 808/808 passing, including rewritten `Scrubber.test.tsx` geometry assertions (derived from config, not hard-coded values) and a new `prefers-reduced-motion` regression test
- [x] `npm run build` — succeeds
- [x] `npx playwright test e2e/` — 40/40 passing, including two new alignment invariant tests in `e2e/runway-geometry.spec.ts` (content at time 0 renders on the playhead line, drawer closed and open)
- [x] Visual regression snapshots checked — none of the existing screenshot assertions capture the tilted timeline area, so no snapshot updates were needed

Claude-Session: https://claude.ai/code/session_016YATMM9fQqPqB1y2KTPLFu

---
_Generated by [Claude Code](https://claude.ai/code/session_016YATMM9fQqPqB1y2KTPLFu)_