### PR TITLE
Add runway config presets and reintroduce fog gradient overlay

### DIFF
--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -231,6 +231,32 @@ it('disables the 3D tilt when prefers-reduced-motion is set', () => {
   window.matchMedia = originalMatchMedia;
 });
 
+it('disables the fog overlay when prefers-reduced-motion is set', () => {
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  const restoreOffsetHeight = mockOffsetHeight(650);
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const fog = container.querySelector('.scrubber__fog') as HTMLElement;
+
+  // A flat plane has no horizon to sell depth toward — the fog must be
+  // explicitly disabled rather than merely landing off-screen, since a
+  // future retuning of the flat-geometry constants must not resurrect it.
+  expect(fog.style.backgroundImage).toBe('none');
+
+  restoreOffsetHeight();
+  window.matchMedia = originalMatchMedia;
+});
+
 it('renders a fog overlay gradient anchored to the solved horizon', () => {
   const containerHeight = 650;
   const restoreOffsetHeight = mockOffsetHeight(containerHeight);
@@ -533,4 +559,15 @@ it('shrinks phantom scroller when drawer is open', () => {
   const phantom = container.querySelector('.scrubber__phantom') as HTMLElement;
 
   expect(phantom.style.bottom).toBe(`${drawerHeight}px`);
+});
+
+it('shrinks fog overlay when drawer is open', () => {
+  const drawerHeight = 280;
+  const { container } = render(
+    <Scrubber {...defaultProps} drawerHeight={drawerHeight} />,
+  );
+
+  const fog = container.querySelector('.scrubber__fog') as HTMLElement;
+
+  expect(fog.style.bottom).toBe(`${drawerHeight}px`);
 });

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -56,6 +56,14 @@ function parseOriginY(origin: string): number {
   return parseFloat(origin.split(' ')[1]);
 }
 
+/** Extracts the two `<number>%` gradient stop positions from a `linear-gradient(...)` string. */
+function parseGradientPercents(backgroundImage: string): [number, number] {
+  const matches = [...backgroundImage.matchAll(/(-?[\d.]+)%/g)].map((m) =>
+    parseFloat(m[1]),
+  );
+  return [matches[0], matches[1]];
+}
+
 it('pauses playback when phantom scroller is scrolled while playing', () => {
   playbackService.play();
 
@@ -223,10 +231,30 @@ it('disables the 3D tilt when prefers-reduced-motion is set', () => {
   window.matchMedia = originalMatchMedia;
 });
 
-it('does not render a shade overlay', () => {
-  const { container } = render(<Scrubber {...defaultProps} />);
+it('renders a fog overlay gradient anchored to the solved horizon', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
 
-  expect(container.querySelector('.scrubber__shade')).toBeNull();
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const fog = container.querySelector('.scrubber__fog') as HTMLElement;
+
+  const geometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight,
+  });
+  const playheadPercent = activeRunwayConfig.playheadFraction * 100;
+  const horizonPercent = (geometry.horizonY / containerHeight) * 100;
+  const expectedFogStartPercent =
+    playheadPercent -
+    activeRunwayConfig.fogStartFraction * (playheadPercent - horizonPercent);
+
+  const [actualHorizonPercent, actualFogStartPercent] = parseGradientPercents(
+    fog.style.backgroundImage,
+  );
+  expect(actualHorizonPercent).toBeCloseTo(horizonPercent, 4);
+  expect(actualFogStartPercent).toBeCloseTo(expectedFogStartPercent, 4);
+
+  restoreOffsetHeight();
 });
 
 it('passes drawer-adjusted visible height as CSS variable to playhead for position alignment', () => {

--- a/src/features/workstation/scrubber/Scrubber.css
+++ b/src/features/workstation/scrubber/Scrubber.css
@@ -43,6 +43,14 @@
   display: none;
 }
 
+/* ScrubberFog: atmospheric fog overlay, anchored to the solved horizon */
+
+.scrubber__fog {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
 /* PhantomScroller: invisible scroll overlay for native scroll physics */
 
 .scrubber__phantom {

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -10,6 +10,7 @@ import { useRecordingService } from '../../recording/useRecordingService';
 import { useTimelineZoom } from '../../../shared/hooks/useTimelineZoom';
 import Playhead, { type PlayheadHandle } from './Playhead';
 import PhantomScroller from './PhantomScroller';
+import ScrubberFog from './ScrubberFog';
 import ScrubberTilt from './ScrubberTilt';
 import ScrubberViewport from './ScrubberViewport';
 import ZoomControls from './ZoomControls';
@@ -45,6 +46,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     containerRef,
     viewportStyle,
     tiltStyle,
+    fogStyle,
     playheadFraction,
     visibleHeight,
     timelinePaddingTopPx,
@@ -79,6 +81,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   };
 
   const phantomStyle = getPhantomStyle(drawerHeight);
+  const fogOverlayStyle = getFogOverlayStyle(drawerHeight, fogStyle);
   const zoomControlsStyle = getZoomControlsStyle(drawerHeight);
   const scrubberStyle = getScrubberStyle(
     playheadFraction,
@@ -105,6 +108,7 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
           {props.children}
         </ScrubberTilt>
       </ScrubberViewport>
+      <ScrubberFog style={fogOverlayStyle} />
       <PhantomScroller
         ref={phantomRef}
         spacerHeight={spacerHeight}
@@ -132,6 +136,18 @@ export default Scrubber;
 function getPhantomStyle(drawerHeight: number): CSSProperties | undefined {
   if (drawerHeight <= 0) return undefined;
   return { bottom: `${drawerHeight}px` };
+}
+
+/**
+ * When the drawer is open, shrink the fog overlay to match the same
+ * drawer-adjusted visible area the gradient itself was solved against.
+ */
+function getFogOverlayStyle(
+  drawerHeight: number,
+  fogStyle: CSSProperties,
+): CSSProperties {
+  if (drawerHeight <= 0) return fogStyle;
+  return { ...fogStyle, bottom: `${drawerHeight}px` };
 }
 
 function getZoomControlsStyle(drawerHeight: number): CSSProperties {

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -130,12 +130,22 @@ Scrubber.displayName = 'Scrubber';
 export default Scrubber;
 
 /**
+ * When the drawer is open, shrinks an `inset: 0` overlay's clickable/visible
+ * area to the same drawer-adjusted visible box `useScrubberGeometry` solves
+ * against — shared by every such overlay (phantom scroller, fog) so they
+ * can't drift out of sync with each other or with the geometry itself.
+ */
+function getDrawerBottomStyle(drawerHeight: number): CSSProperties | undefined {
+  if (drawerHeight <= 0) return undefined;
+  return { bottom: `${drawerHeight}px` };
+}
+
+/**
  * When the drawer is open, shrink the phantom scroller's clickable area
  * so it doesn't overlap the drawer controls.
  */
 function getPhantomStyle(drawerHeight: number): CSSProperties | undefined {
-  if (drawerHeight <= 0) return undefined;
-  return { bottom: `${drawerHeight}px` };
+  return getDrawerBottomStyle(drawerHeight);
 }
 
 /**
@@ -146,8 +156,7 @@ function getFogOverlayStyle(
   drawerHeight: number,
   fogStyle: CSSProperties,
 ): CSSProperties {
-  if (drawerHeight <= 0) return fogStyle;
-  return { ...fogStyle, bottom: `${drawerHeight}px` };
+  return { ...fogStyle, ...getDrawerBottomStyle(drawerHeight) };
 }
 
 function getZoomControlsStyle(drawerHeight: number): CSSProperties {

--- a/src/features/workstation/scrubber/ScrubberFog.tsx
+++ b/src/features/workstation/scrubber/ScrubberFog.tsx
@@ -1,0 +1,20 @@
+import { type CSSProperties } from 'react';
+
+type ScrubberFogProps = {
+  style: CSSProperties;
+};
+
+/**
+ * Atmospheric fog overlay that fades the runway into the horizon.
+ *
+ * Positioned in screen space, not tilted — it represents distance fog,
+ * not a physical plane. Its gradient (computed by
+ * `useScrubberGeometry.getFogStyle`) is anchored to the solved `horizonY`
+ * and playhead position, so the fog band tracks the runway's actual
+ * anchors instead of a fixed fraction of the container.
+ */
+function ScrubberFog({ style }: ScrubberFogProps) {
+  return <div className="scrubber__fog" style={style} />;
+}
+
+export default ScrubberFog;

--- a/src/features/workstation/scrubber/__tests__/runwayConfig.test.ts
+++ b/src/features/workstation/scrubber/__tests__/runwayConfig.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { RUNWAY_PRESETS } from '../runwayConfig';
+import {
+  screenYToPlane,
+  solveGeometry,
+  widthAtPlane,
+} from '../runwayProjection';
+
+const VISIBLE_WIDTH_PX = 1000;
+const HEIGHT_SWEEP_PX = [400, 600, 800, 1000, 1200];
+
+describe.each(Object.entries(RUNWAY_PRESETS))('%s preset', (_name, config) => {
+  it.each(HEIGHT_SWEEP_PX)(
+    'solves finite geometry at a %ipx visible height',
+    (height) => {
+      const geometry = solveGeometry(config, {
+        width: VISIBLE_WIDTH_PX,
+        height,
+      });
+
+      for (const value of Object.values(geometry)) {
+        expect(Number.isFinite(value)).toBe(true);
+      }
+    },
+  );
+
+  it('widthAtPlane at the playhead distance equals the configured playheadWidth', () => {
+    const visible = { width: VISIBLE_WIDTH_PX, height: 650 };
+    const geometry = solveGeometry(config, visible);
+    const sPlayhead = screenYToPlane(
+      config.playheadFraction * visible.height,
+      geometry,
+    );
+
+    expect(widthAtPlane(sPlayhead, geometry)).toBeCloseTo(
+      config.playheadWidth,
+      6,
+    );
+  });
+});

--- a/src/features/workstation/scrubber/runwayConfig.ts
+++ b/src/features/workstation/scrubber/runwayConfig.ts
@@ -1,20 +1,74 @@
 import type { RunwayConfig } from './runwayProjection';
 
+export type RunwayPreset = RunwayConfig & {
+  /** Fraction of the playhead→horizon distance where the fog gradient
+   *  begins (0 = fog covers the whole runway, 1 = no fog). */
+  fogStartFraction: number;
+};
+
 /**
  * Guitar Hero-style note highway — the target look pinned from reference
  * screenshots (see mawimbi#443's decision comment). Values are proportional
  * (fractions of the visible area), not fixed pixels, so the look holds
  * across screen sizes.
  */
-export const noteHighway: RunwayConfig = {
+export const noteHighway: RunwayPreset = {
   tiltDeg: 70,
   playheadFraction: 0.75,
   playheadWidth: 0.65,
   elevationFraction: 0.55,
   runwayLengthPx: 1800,
   overhangPx: 320,
+  fogStartFraction: 0.8,
 };
 
-// Full preset set (subtleRamp, flat, etc.) lands in #446; this is the one
-// preset #445 needs to wire the projection module into the scrubber.
-export const activeRunwayConfig: RunwayConfig = noteHighway;
+/**
+ * Beat Saber-style full-bleed track — wider at the playhead and a lower
+ * horizon than noteHighway, so the near edge fills the visible width.
+ */
+export const beatSaber: RunwayPreset = {
+  ...noteHighway,
+  playheadWidth: 0.85,
+  elevationFraction: 0.35,
+};
+
+/**
+ * Shallow ramp, matching the subtler #402-era tilt before the runway
+ * effect was pushed toward the steeper note-highway look.
+ */
+export const subtleRamp: RunwayPreset = {
+  tiltDeg: 30,
+  playheadFraction: 0.6,
+  playheadWidth: 0.9,
+  elevationFraction: 0.2,
+  runwayLengthPx: 1200,
+  overhangPx: 150,
+  fogStartFraction: 0.8,
+};
+
+/**
+ * Identity geometry — no tilt, no perspective. Documents what "flat" looks
+ * like as a preset; `prefers-reduced-motion` does not switch to this fixed
+ * preset, since that would ignore whichever preset is actually active. It
+ * instead derives its own flattened variant of `activeRunwayConfig` (see
+ * `useScrubberGeometry`'s `REDUCED_MOTION_CONFIG`), so reduced motion stays
+ * correct regardless of which preset the dev tuning overlay (#447) selects.
+ */
+export const flat: RunwayPreset = {
+  tiltDeg: 0,
+  playheadFraction: 0.75,
+  playheadWidth: 1,
+  elevationFraction: 0.55,
+  runwayLengthPx: 1800,
+  overhangPx: 320,
+  fogStartFraction: 1,
+};
+
+export const RUNWAY_PRESETS = {
+  noteHighway,
+  beatSaber,
+  subtleRamp,
+  flat,
+} as const;
+
+export const activeRunwayConfig: RunwayPreset = RUNWAY_PRESETS.noteHighway;

--- a/src/features/workstation/scrubber/runwayProjection.ts
+++ b/src/features/workstation/scrubber/runwayProjection.ts
@@ -1,9 +1,21 @@
 export type RunwayConfig = {
+  /** Slope of the road, in degrees (CSS rotateX). Higher = flatter road,
+   *  stronger compression toward the horizon. Range: 0–85. */
   tiltDeg: number;
+  /** Vertical position of the playhead line, as a fraction of visible
+   *  height from the top (0 = top, 1 = bottom). */
   playheadFraction: number;
+  /** Measured width of the runway at the playhead line, as a fraction of
+   *  visible width. Range: 0.4–1.0. */
   playheadWidth: number;
+  /** How high the horizon floats above the playhead, as a fraction of
+   *  visible height; smaller = camera closer to the ground. */
   elevationFraction: number;
+  /** How much upcoming audio is visible (scrollable above the playhead)
+   *  before the fog, in pre-transform px. */
   runwayLengthPx: number;
+  /** Road under your feet — scrollable below the playhead, in
+   *  pre-transform px. */
   overhangPx: number;
 };
 

--- a/src/features/workstation/scrubber/runwayProjection.ts
+++ b/src/features/workstation/scrubber/runwayProjection.ts
@@ -11,8 +11,11 @@ export type RunwayConfig = {
   /** How high the horizon floats above the playhead, as a fraction of
    *  visible height; smaller = camera closer to the ground. */
   elevationFraction: number;
-  /** How much upcoming audio is visible (scrollable above the playhead)
-   *  before the fog, in pre-transform px. */
+  /** How much upcoming audio is scrollable into view above the playhead,
+   *  in pre-transform px. Not tied to where the fog gradient visually
+   *  starts — that's controlled independently by `fogStartFraction`
+   *  (`RunwayPreset`, runwayConfig.ts) against the solved screen-space
+   *  horizon, a different coordinate space from this pre-transform value. */
   runwayLengthPx: number;
   /** Road under your feet — scrollable below the playhead, in
    *  pre-transform px. */

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -9,9 +9,23 @@ import {
 
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
+const FOG_GRADIENT_DIRECTION = 'to bottom';
+const SHADE_COLOR_CSS_VAR = '--shade-color';
+const FRACTION_TO_PERCENT = 100;
+
+// No fog on a flat plane — atmospheric depth cueing has nothing to sell
+// without perspective. Checking the solved rotateXDeg (rather than relying
+// on the flat branch's horizonY landing far outside the gradient's 0-100%
+// range) makes "no fog when flat" a declared outcome instead of an
+// incidental side effect of solveFlatGeometry's internal constants.
+const FLAT_ROTATE_X_DEG = 0;
+const NO_FOG_STYLE: CSSProperties = { backgroundImage: 'none' };
+
 // A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
 // path — rotateX(0) disables the 3D effect without a separate code path.
-// Defined once so referential equality is stable across renders.
+// getFogStyle's own FLAT_ROTATE_X_DEG check disables the fog the same way,
+// so this doesn't need its own fogStartFraction override. Defined once so
+// referential equality is stable across renders.
 const REDUCED_MOTION_CONFIG: RunwayPreset = {
   ...activeRunwayConfig,
   tiltDeg: 0,
@@ -120,29 +134,39 @@ function getTiltStyle(
 
 /**
  * Computes the atmospheric fog overlay as a gradient anchored to the
- * solved `horizonY`, not a fixed fraction of the container — so the fog
- * band tracks wherever the runway's horizon actually lands (which shifts
- * with tilt, elevation, and the drawer-adjusted visible height) instead of
- * drifting out of alignment the way the pre-#410 fixed-percentage gradient
- * did.
+ * solved `horizonY` and playhead position, expressed as percentages of the
+ * visible box (the fog overlay's own rendered height always equals
+ * `visibleHeight` — see `getFogOverlayStyle` in Scrubber.tsx, which shrinks
+ * it to match the drawer-adjusted area the same way `visibleHeight` itself
+ * is derived). Because those percentages are recomputed from the solved
+ * geometry on every call, the fog band tracks wherever the horizon actually
+ * lands (which shifts with tilt, elevation, and the drawer) instead of
+ * drifting the way the pre-#410 gradient — hardcoded to fixed percentages
+ * regardless of geometry — did.
  *
- * The fog fades in over the last `fogStartFraction` of the playhead→horizon
- * distance: opaque from the horizon up, transitioning to fully transparent
- * by `fogStartFraction` of the way back toward the playhead.
+ * `fogStartFraction` is where the fade begins, measured as a fraction of
+ * the playhead→horizon distance starting from the playhead (0 = fog starts
+ * right at the playhead, covering the whole runway; 1 = fog collapses to
+ * the horizon line itself, i.e. no visible fog). The fade band's actual
+ * on-screen width is therefore the remaining `(1 - fogStartFraction)` of
+ * that distance, ending at the horizon.
  */
 function getFogStyle(
   config: RunwayPreset,
   geometry: RunwayGeometry,
   visibleHeight: number,
 ): CSSProperties {
-  const playheadPercent = config.playheadFraction * 100;
-  const horizonPercent = (geometry.horizonY / visibleHeight) * 100;
+  if (geometry.rotateXDeg === FLAT_ROTATE_X_DEG) return NO_FOG_STYLE;
+
+  const playheadPercent = config.playheadFraction * FRACTION_TO_PERCENT;
+  const horizonPercent =
+    (geometry.horizonY / visibleHeight) * FRACTION_TO_PERCENT;
   const fogStartPercent =
     playheadPercent -
     config.fogStartFraction * (playheadPercent - horizonPercent);
 
   return {
-    backgroundImage: `linear-gradient(to bottom, rgb(var(--shade-color)) ${horizonPercent}%, rgba(var(--shade-color), 0) ${fogStartPercent}%)`,
+    backgroundImage: `linear-gradient(${FOG_GRADIENT_DIRECTION}, rgb(var(${SHADE_COLOR_CSS_VAR})) ${horizonPercent}%, rgba(var(${SHADE_COLOR_CSS_VAR}), 0) ${fogStartPercent}%)`,
   };
 }
 
@@ -178,8 +202,14 @@ type TimelinePadding = {
  *
  * `paddingTop` has no equally strict constraint from this invariant — it
  * only needs to provide enough scrollable space to see `runwayLengthPx` of
- * upcoming content before the far edge/fog, which is what it's set to
- * directly.
+ * upcoming content, which is what it's set to directly. `runwayLengthPx` is
+ * a pre-transform (flat) distance, not tied to where the fog gradient
+ * starts on screen (`fogStartFraction`, a fraction of the solved,
+ * screen-space playhead→horizon distance) — the two aren't currently
+ * calibrated to align, so scrolled-to-the-top content can end well short of
+ * (or past) the fog band rather than fading into it. Tuning that alignment
+ * is visual/preset work, not a geometry-correctness concern this function
+ * owns.
  */
 function getTimelinePadding(
   config: RunwayConfig,

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -1,6 +1,6 @@
 import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
 import { useMediaQuery } from '../../../shared/hooks/useMediaQuery';
-import { activeRunwayConfig } from './runwayConfig';
+import { activeRunwayConfig, type RunwayPreset } from './runwayConfig';
 import {
   solveGeometry,
   type RunwayConfig,
@@ -12,7 +12,7 @@ const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 // A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
 // path — rotateX(0) disables the 3D effect without a separate code path.
 // Defined once so referential equality is stable across renders.
-const REDUCED_MOTION_CONFIG: RunwayConfig = {
+const REDUCED_MOTION_CONFIG: RunwayPreset = {
   ...activeRunwayConfig,
   tiltDeg: 0,
 };
@@ -44,6 +44,7 @@ type ScrubberGeometry = {
   containerRef: React.RefObject<HTMLDivElement | null>;
   viewportStyle: CSSProperties;
   tiltStyle: CSSProperties;
+  fogStyle: CSSProperties;
   playheadFraction: number;
   visibleHeight: number;
   timelinePaddingTopPx: number;
@@ -87,6 +88,7 @@ export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
       geometry.perspectiveOriginY,
     ),
     tiltStyle: getTiltStyle(geometry.rotateXDeg, geometry.transformOriginY),
+    fogStyle: getFogStyle(config, geometry, visibleHeight),
     playheadFraction: activeRunwayConfig.playheadFraction,
     visibleHeight,
     timelinePaddingTopPx: timelinePadding.top,
@@ -113,6 +115,34 @@ function getTiltStyle(
     ...baseTransformStyle,
     transformOrigin: `center ${transformOriginY}px`,
     transform: `rotateX(${rotateXDeg}deg)`,
+  };
+}
+
+/**
+ * Computes the atmospheric fog overlay as a gradient anchored to the
+ * solved `horizonY`, not a fixed fraction of the container — so the fog
+ * band tracks wherever the runway's horizon actually lands (which shifts
+ * with tilt, elevation, and the drawer-adjusted visible height) instead of
+ * drifting out of alignment the way the pre-#410 fixed-percentage gradient
+ * did.
+ *
+ * The fog fades in over the last `fogStartFraction` of the playhead→horizon
+ * distance: opaque from the horizon up, transitioning to fully transparent
+ * by `fogStartFraction` of the way back toward the playhead.
+ */
+function getFogStyle(
+  config: RunwayPreset,
+  geometry: RunwayGeometry,
+  visibleHeight: number,
+): CSSProperties {
+  const playheadPercent = config.playheadFraction * 100;
+  const horizonPercent = (geometry.horizonY / visibleHeight) * 100;
+  const fogStartPercent =
+    playheadPercent -
+    config.fogStartFraction * (playheadPercent - horizonPercent);
+
+  return {
+    backgroundImage: `linear-gradient(to bottom, rgb(var(--shade-color)) ${horizonPercent}%, rgba(var(--shade-color), 0) ${fogStartPercent}%)`,
   };
 }
 
@@ -149,7 +179,7 @@ type TimelinePadding = {
  * `paddingTop` has no equally strict constraint from this invariant — it
  * only needs to provide enough scrollable space to see `runwayLengthPx` of
  * upcoming content before the far edge/fog, which is what it's set to
- * directly (fog placement itself lands in a later issue).
+ * directly.
  */
 function getTimelinePadding(
   config: RunwayConfig,


### PR DESCRIPTION
## Summary

Implements #446 — replaces the single `noteHighway`-only config surface from #445 with a full preset system, and reintroduces the atmospheric fog gradient that was removed in #410.

- `runwayConfig.ts` now exports `RUNWAY_PRESETS` (`noteHighway` default, `beatSaber`, `subtleRamp`, `flat`) and a `RunwayPreset` type extending `RunwayConfig` with `fogStartFraction`. `beatSaber`/`subtleRamp`/`flat` aren't wired to app state yet — they're consumed by the dev tuning overlay in #447.
- Every `RunwayConfig`/`RunwayPreset` knob now has a doc comment stating its observable effect and safe range.
- Reintroduces the fog gradient as a new `ScrubberFog` overlay, with its gradient stops computed by `useScrubberGeometry.getFogStyle()` from the solved `horizonY` and playhead position — not a fixed container percentage, so it tracks the runway's actual anchors across tilt, elevation, and drawer state (unlike the pre-#410 version).
- Code review (8-angle finder pass + verification) caught a real bug during implementation: the fog was only invisible under `prefers-reduced-motion` by numerical coincidence (a large internal constant pushing the gradient's stops out of the visible 0–100% range), not by declared contract. Fixed by explicitly disabling fog whenever the solved geometry is flat (`rotateXDeg === 0`), so this holds regardless of future tuning to that constant.
- Also fixed from review: a backwards `fogStartFraction` docstring, a doc caveat about `runwayLengthPx`/fog alignment that was prematurely dropped, duplicated drawer-height-offset logic (extracted into a shared helper), magic-number literals in the gradient string, and added missing test coverage for the fog overlay's drawer-open and reduced-motion behavior.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 848/848 passing, including new `runwayConfig.test.ts` (sweeps every preset across viewport heights 400–1200px for NaN/Infinity) and new `Scrubber.test.tsx` assertions (fog gradient anchored to solved horizon, fog disabled under reduced motion, fog shrinks with the drawer)
- [x] `npm run build` — succeeds
- [x] `npx playwright test e2e/runway-geometry.spec.ts` and `e2e/visual.spec.ts` — all passing, no snapshot updates needed (no existing screenshot assertions capture the tilted timeline area)
- [x] Manually verified in a real browser via Playwright: uploaded audio, confirmed the fog overlay's computed `background-image` gradient stops match the expected values derived from the solved geometry

Claude-Session: https://claude.ai/code/session_01WX2XdWUd663bsSDbMrpBnZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01WX2XdWUd663bsSDbMrpBnZ)_