### PR TITLE
Add dev-only tuning overlay with live sliders for the runway config

### DIFF
--- a/src/features/tracks/__tests__/testUtils.ts
+++ b/src/features/tracks/__tests__/testUtils.ts
@@ -1,6 +1,7 @@
 import AudioService from '../../audio/AudioService';
 import { resetFocusSignals } from '../focusSignals';
 import { resetWorkstationSignals } from '../../workstation/workstationSignals';
+import { resetTuningSignals } from '../../workstation/scrubber/tuningSignals';
 
 export function resetAllSignals(): void {
   const audioService = AudioService.getInstance();
@@ -10,4 +11,5 @@ export function resetAllSignals(): void {
   audioService.classificationService.reset();
   resetFocusSignals();
   resetWorkstationSignals();
+  resetTuningSignals();
 }

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -2,8 +2,13 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { createRef } from 'react';
 import * as Tone from 'tone';
 import AudioService from '../../audio/AudioService';
-import { activeRunwayConfig } from '../scrubber/runwayConfig';
+import { activeRunwayConfig, beatSaber } from '../scrubber/runwayConfig';
 import { solveGeometry } from '../scrubber/runwayProjection';
+import {
+  resetTuningSignals,
+  setTuningValue,
+  toggleTuningOverlay,
+} from '../scrubber/tuningSignals';
 import Scrubber, { type ScrubberHandle } from '../scrubber/Scrubber';
 
 const audioService = AudioService.getInstance();
@@ -22,6 +27,7 @@ afterEach(() => {
   playbackService.reset();
   recordingService.reset();
   Tone.getTransport().seconds = 0;
+  resetTuningSignals();
 });
 
 /**
@@ -174,6 +180,113 @@ it('re-solves perspective geometry for the smaller visible area when the drawer 
   expect(openGeometry.perspectivePx).not.toBeCloseTo(
     closedGeometry.perspectivePx,
     0,
+  );
+
+  restoreOffsetHeight();
+});
+
+it('re-solves geometry from the tuning overlay override when active', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+
+  toggleTuningOverlay(activeRunwayConfig);
+  setTuningValue('tiltDeg', 20);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
+
+  const overriddenGeometry = solveGeometry(
+    { ...activeRunwayConfig, tiltDeg: 20 },
+    { width: 0, height: containerHeight },
+  );
+
+  expect(tilt.style.transform).toBe(
+    `rotateX(${overriddenGeometry.rotateXDeg}deg)`,
+  );
+
+  restoreOffsetHeight();
+});
+
+it('reverts to the active preset once the tuning overlay closes', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+
+  toggleTuningOverlay(activeRunwayConfig);
+  setTuningValue('tiltDeg', 20);
+  // Second toggleTuningOverlay call closes the overlay and clears the override.
+  toggleTuningOverlay(activeRunwayConfig);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
+
+  const activeGeometry = solveGeometry(activeRunwayConfig, {
+    width: 0,
+    height: containerHeight,
+  });
+
+  expect(tilt.style.transform).toBe(`rotateX(${activeGeometry.rotateXDeg}deg)`);
+
+  restoreOffsetHeight();
+});
+
+it('reveals the tuning overlay on a long-press of the zoom controls', () => {
+  vi.useFakeTimers();
+  const restoreOffsetHeight = mockOffsetHeight(650);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  expect(container.querySelector('.tuning-overlay')).toBeNull();
+
+  const zoomControls = container.querySelector('.zoom-controls') as HTMLElement;
+  fireEvent.pointerDown(zoomControls);
+  act(() => {
+    vi.advanceTimersByTime(700);
+  });
+
+  expect(container.querySelector('.tuning-overlay')).not.toBeNull();
+
+  restoreOffsetHeight();
+  vi.useRealTimers();
+});
+
+it('does not reveal the tuning overlay on a short press of the zoom controls', () => {
+  vi.useFakeTimers();
+  const restoreOffsetHeight = mockOffsetHeight(650);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const zoomControls = container.querySelector('.zoom-controls') as HTMLElement;
+  fireEvent.pointerDown(zoomControls);
+  act(() => {
+    vi.advanceTimersByTime(200);
+  });
+  fireEvent.pointerUp(zoomControls);
+  act(() => {
+    vi.advanceTimersByTime(700);
+  });
+
+  expect(container.querySelector('.tuning-overlay')).toBeNull();
+
+  restoreOffsetHeight();
+  vi.useRealTimers();
+});
+
+it('selects beatSaber preset via the tuning overlay and re-solves geometry', () => {
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+
+  toggleTuningOverlay(beatSaber);
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
+
+  const beatSaberGeometry = solveGeometry(beatSaber, {
+    width: 0,
+    height: containerHeight,
+  });
+
+  expect(tilt.style.transform).toBe(
+    `rotateX(${beatSaberGeometry.rotateXDeg}deg)`,
   );
 
   restoreOffsetHeight();

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -27,7 +27,12 @@ afterEach(() => {
   playbackService.reset();
   recordingService.reset();
   Tone.getTransport().seconds = 0;
-  resetTuningSignals();
+  // Wrapped in act() — this writes tuningSignals, which useScrubberGeometry
+  // subscribes to, and RTL's own unmount cleanup (registered before this
+  // afterEach) hasn't necessarily run yet for the current test's tree.
+  act(() => {
+    resetTuningSignals();
+  });
 });
 
 /**
@@ -365,6 +370,42 @@ it('disables the fog overlay when prefers-reduced-motion is set', () => {
   // explicitly disabled rather than merely landing off-screen, since a
   // future retuning of the flat-geometry constants must not resurrect it.
   expect(fog.style.backgroundImage).toBe('none');
+
+  restoreOffsetHeight();
+  window.matchMedia = originalMatchMedia;
+});
+
+it('does not flatten geometry for prefers-reduced-motion while the tuning overlay is active', () => {
+  const originalMatchMedia = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  // Opening the tuning overlay is an explicit request to see the real 3D
+  // effect — without this, every slider would look like a no-op to a
+  // developer who happens to have this OS accessibility preference set.
+  toggleTuningOverlay(activeRunwayConfig);
+  setTuningValue('tiltDeg', 45);
+
+  const containerHeight = 650;
+  const restoreOffsetHeight = mockOffsetHeight(containerHeight);
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const tilt = container.querySelector('.scrubber__tilt') as HTMLElement;
+
+  const tunedGeometry = solveGeometry(
+    { ...activeRunwayConfig, tiltDeg: 45 },
+    { width: 0, height: containerHeight },
+  );
+
+  expect(tilt.style.transform).toBe(`rotateX(${tunedGeometry.rotateXDeg}deg)`);
+  expect(tilt.style.transform).not.toBe('rotateX(0deg)');
 
   restoreOffsetHeight();
   window.matchMedia = originalMatchMedia;

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -58,7 +58,13 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
   } = useScrubberGeometry(drawerHeight);
 
   const isTuningAvailable = useTuningAvailable();
-  const { isOpen: isTuningOpen, toggle: toggleTuning } = useTuningOverlay();
+  const {
+    config: tuningConfig,
+    toggle: toggleTuning,
+    close: closeTuning,
+    selectPreset: selectTuningPreset,
+    setValue: setTuningValue,
+  } = useTuningOverlay();
   const longPressZoomControls = useLongPress(toggleTuning);
 
   const {
@@ -132,8 +138,14 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         style={zoomControlsStyle}
         {...(isTuningAvailable ? longPressZoomControls : undefined)}
       />
-      {isTuningAvailable && isTuningOpen && (
-        <TuningOverlay geometry={geometry} />
+      {isTuningAvailable && tuningConfig && (
+        <TuningOverlay
+          config={tuningConfig}
+          geometry={geometry}
+          close={closeTuning}
+          selectPreset={selectTuningPreset}
+          setValue={setTuningValue}
+        />
       )}
     </div>
   );

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -13,9 +13,12 @@ import PhantomScroller from './PhantomScroller';
 import ScrubberFog from './ScrubberFog';
 import ScrubberTilt from './ScrubberTilt';
 import ScrubberViewport from './ScrubberViewport';
+import TuningOverlay from './TuningOverlay';
 import ZoomControls from './ZoomControls';
+import { useLongPress, useTuningAvailable } from './useTuningActivation';
 import { useScrubberGeometry } from './useScrubberGeometry';
 import { useScrubberScroll, useSpacerHeight } from './useScrubberScroll';
+import { useTuningOverlay } from './useTuningOverlay';
 import './Scrubber.css';
 
 export type ScrubberHandle = {
@@ -47,11 +50,16 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     viewportStyle,
     tiltStyle,
     fogStyle,
+    geometry,
     playheadFraction,
     visibleHeight,
     timelinePaddingTopPx,
     timelinePaddingBottomPx,
   } = useScrubberGeometry(drawerHeight);
+
+  const isTuningAvailable = useTuningAvailable();
+  const { isOpen: isTuningOpen, toggle: toggleTuning } = useTuningOverlay();
+  const longPressZoomControls = useLongPress(toggleTuning);
 
   const {
     handlePointerDown,
@@ -120,7 +128,13 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         onWheel={handleWheel}
       />
       <Playhead ref={playheadRef} visibleHeight={visibleHeight} />
-      <ZoomControls style={zoomControlsStyle} />
+      <ZoomControls
+        style={zoomControlsStyle}
+        {...(isTuningAvailable ? longPressZoomControls : undefined)}
+      />
+      {isTuningAvailable && isTuningOpen && (
+        <TuningOverlay geometry={geometry} />
+      )}
     </div>
   );
 });

--- a/src/features/workstation/scrubber/TuningOverlay.css
+++ b/src/features/workstation/scrubber/TuningOverlay.css
@@ -9,7 +9,7 @@
   width: 260px;
   padding: 12px;
   border-radius: 8px;
-  background: var(--background);
+  background-color: var(--surface);
   border: 1px solid var(--border);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
   font-size: 12px;

--- a/src/features/workstation/scrubber/TuningOverlay.css
+++ b/src/features/workstation/scrubber/TuningOverlay.css
@@ -1,0 +1,70 @@
+.tuning-overlay {
+  position: absolute;
+  right: 16px;
+  top: 48px;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 260px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--background);
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  font-size: 12px;
+}
+
+.tuning-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tuning-overlay__title {
+  font-weight: 600;
+}
+
+.tuning-overlay__preset {
+  align-self: flex-start;
+}
+
+.tuning-overlay__knob {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tuning-overlay__knob-label {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted-foreground);
+}
+
+.tuning-overlay__knob-value {
+  font-variant-numeric: tabular-nums;
+}
+
+.tuning-overlay__readout {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 2px 8px;
+  margin: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+}
+
+.tuning-overlay__readout dt {
+  font-weight: 400;
+}
+
+.tuning-overlay__readout dd {
+  margin: 0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.tuning-overlay__copy {
+  align-self: stretch;
+}

--- a/src/features/workstation/scrubber/TuningOverlay.tsx
+++ b/src/features/workstation/scrubber/TuningOverlay.tsx
@@ -8,19 +8,12 @@ import {
 } from '../../../shared/ui/dropdown-menu';
 import { Slider } from '../../../shared/ui/slider';
 import useMessage from '../../../shared/message';
-import { type RunwayPreset } from './runwayConfig';
-import { type RunwayGeometry } from './runwayProjection';
-import { useTuningOverlay } from './useTuningOverlay';
+import { RUNWAY_PRESETS, type RunwayPreset } from './runwayConfig';
+import { type RunwayConfig, type RunwayGeometry } from './runwayProjection';
 import './TuningOverlay.css';
 
 type KnobSpec = {
-  key:
-    | 'tiltDeg'
-    | 'playheadFraction'
-    | 'playheadWidth'
-    | 'elevationFraction'
-    | 'runwayLengthPx'
-    | 'overhangPx';
+  key: keyof RunwayConfig;
   label: string;
   min: number;
   max: number;
@@ -78,7 +71,11 @@ const KNOBS: readonly KnobSpec[] = [
 const SERIALIZE_PRECISION = 4;
 
 type TuningOverlayProps = {
+  config: RunwayPreset;
   geometry: RunwayGeometry;
+  close: () => void;
+  selectPreset: (preset: RunwayPreset) => void;
+  setValue: (key: keyof RunwayPreset, value: number) => void;
 };
 
 /**
@@ -86,20 +83,28 @@ type TuningOverlayProps = {
  * "tune by PR" cycle six prior PRs went through, each requiring a commit
  * and deploy just to see the result of one parameter change.
  *
- * Every control writes through `tuningSignals`' config-override signal,
- * which `useScrubberGeometry` composes over `activeRunwayConfig` — this
- * overlay never touches CSS directly, so what you tune here is exactly
+ * Every control writes through `tuningSignals`' config-override signal
+ * (via the callbacks passed down from Scrubber.tsx's single `useTuningOverlay()`
+ * subscription), which `useScrubberGeometry` composes over `activeRunwayConfig`
+ * — this overlay never touches CSS directly, so what you tune here is exactly
  * what a preset (runwayConfig.ts) can persist.
  */
-function TuningOverlay({ geometry }: TuningOverlayProps) {
-  const { config, presets, close, selectPreset, setValue } = useTuningOverlay();
+function TuningOverlay({
+  config,
+  geometry,
+  close,
+  selectPreset,
+  setValue,
+}: TuningOverlayProps) {
   const message = useMessage();
 
-  if (!config) return null;
-
   const handleCopyPreset = async () => {
-    await navigator.clipboard.writeText(serializePreset(config));
-    message('Preset copied to clipboard', { type: 'success' });
+    try {
+      await navigator.clipboard.writeText(serializePreset(config));
+      message('Preset copied to clipboard', { type: 'success' });
+    } catch {
+      message('Could not copy preset to clipboard', { type: 'error' });
+    }
   };
 
   return (
@@ -127,7 +132,7 @@ function TuningOverlay({ geometry }: TuningOverlayProps) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="start">
-          {Object.entries(presets).map(([name, preset]) => (
+          {Object.entries(RUNWAY_PRESETS).map(([name, preset]) => (
             <DropdownMenuItem key={name} onSelect={() => selectPreset(preset)}>
               {name}
             </DropdownMenuItem>

--- a/src/features/workstation/scrubber/TuningOverlay.tsx
+++ b/src/features/workstation/scrubber/TuningOverlay.tsx
@@ -1,0 +1,200 @@
+import { Copy, X } from 'lucide-react';
+import { Button } from '../../../shared/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../../shared/ui/dropdown-menu';
+import { Slider } from '../../../shared/ui/slider';
+import useMessage from '../../../shared/message';
+import { type RunwayPreset } from './runwayConfig';
+import { type RunwayGeometry } from './runwayProjection';
+import { useTuningOverlay } from './useTuningOverlay';
+import './TuningOverlay.css';
+
+type KnobSpec = {
+  key:
+    | 'tiltDeg'
+    | 'playheadFraction'
+    | 'playheadWidth'
+    | 'elevationFraction'
+    | 'runwayLengthPx'
+    | 'overhangPx';
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+};
+
+// One slider per RunwayConfig knob (mawimbi#447) — ranges follow the safe
+// ranges documented on RunwayConfig itself (runwayProjection.ts), widened
+// slightly where a shipped preset's value sits at the documented edge.
+const KNOBS: readonly KnobSpec[] = [
+  { key: 'tiltDeg', label: 'Tilt', min: 0, max: 85, step: 1, unit: 'deg' },
+  {
+    key: 'playheadFraction',
+    label: 'Playhead position',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    unit: '',
+  },
+  {
+    key: 'playheadWidth',
+    label: 'Playhead width',
+    min: 0.4,
+    max: 1,
+    step: 0.01,
+    unit: '',
+  },
+  {
+    key: 'elevationFraction',
+    label: 'Elevation',
+    min: 0.05,
+    max: 1,
+    step: 0.01,
+    unit: '',
+  },
+  {
+    key: 'runwayLengthPx',
+    label: 'Runway length',
+    min: 200,
+    max: 4000,
+    step: 50,
+    unit: 'px',
+  },
+  {
+    key: 'overhangPx',
+    label: 'Overhang',
+    min: 0,
+    max: 1000,
+    step: 10,
+    unit: 'px',
+  },
+];
+
+const SERIALIZE_PRECISION = 4;
+
+type TuningOverlayProps = {
+  geometry: RunwayGeometry;
+};
+
+/**
+ * Dev-only overlay for tuning `RunwayConfig` live (mawimbi#447) — ends the
+ * "tune by PR" cycle six prior PRs went through, each requiring a commit
+ * and deploy just to see the result of one parameter change.
+ *
+ * Every control writes through `tuningSignals`' config-override signal,
+ * which `useScrubberGeometry` composes over `activeRunwayConfig` — this
+ * overlay never touches CSS directly, so what you tune here is exactly
+ * what a preset (runwayConfig.ts) can persist.
+ */
+function TuningOverlay({ geometry }: TuningOverlayProps) {
+  const { config, presets, close, selectPreset, setValue } = useTuningOverlay();
+  const message = useMessage();
+
+  if (!config) return null;
+
+  const handleCopyPreset = async () => {
+    await navigator.clipboard.writeText(serializePreset(config));
+    message('Preset copied to clipboard', { type: 'success' });
+  };
+
+  return (
+    <div className="tuning-overlay">
+      <div className="tuning-overlay__header">
+        <span className="tuning-overlay__title">Runway tuning</span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          title="Close tuning overlay"
+          onClick={close}
+        >
+          <X />
+        </Button>
+      </div>
+
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="tuning-overlay__preset"
+          >
+            Preset
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="start">
+          {Object.entries(presets).map(([name, preset]) => (
+            <DropdownMenuItem key={name} onSelect={() => selectPreset(preset)}>
+              {name}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {KNOBS.map((knob) => (
+        <label key={knob.key} className="tuning-overlay__knob">
+          <span className="tuning-overlay__knob-label">
+            {knob.label}
+            <span className="tuning-overlay__knob-value">
+              {formatKnobValue(config[knob.key], knob.unit)}
+            </span>
+          </span>
+          <Slider
+            value={[config[knob.key]]}
+            min={knob.min}
+            max={knob.max}
+            step={knob.step}
+            onValueChange={([value]) => setValue(knob.key, value)}
+          />
+        </label>
+      ))}
+
+      <dl className="tuning-overlay__readout">
+        <dt>perspectivePx</dt>
+        <dd>{formatReadoutValue(geometry.perspectivePx)}</dd>
+        <dt>perspectiveOriginY</dt>
+        <dd>{formatReadoutValue(geometry.perspectiveOriginY)}</dd>
+        <dt>transformOriginY</dt>
+        <dd>{formatReadoutValue(geometry.transformOriginY)}</dd>
+        <dt>horizonY</dt>
+        <dd>{formatReadoutValue(geometry.horizonY)}</dd>
+      </dl>
+
+      <Button
+        variant="outline"
+        size="sm"
+        className="tuning-overlay__copy"
+        onClick={handleCopyPreset}
+      >
+        <Copy />
+        Copy preset
+      </Button>
+    </div>
+  );
+}
+
+function formatKnobValue(value: number, unit: string): string {
+  return unit ? `${value}${unit}` : `${value}`;
+}
+
+function formatReadoutValue(value: number): string {
+  return `${value.toFixed(1)}px`;
+}
+
+/** Serializes the current config as a `runwayConfig.ts`-shaped preset snippet. */
+function serializePreset(config: RunwayPreset): string {
+  const fields = Object.entries(config)
+    .map(([key, value]) => `  ${key}: ${roundForExport(value)},`)
+    .join('\n');
+  return `export const custom: RunwayPreset = {\n${fields}\n};`;
+}
+
+function roundForExport(value: number): number {
+  return Number(value.toFixed(SERIALIZE_PRECISION));
+}
+
+export default TuningOverlay;

--- a/src/features/workstation/scrubber/ZoomControls.tsx
+++ b/src/features/workstation/scrubber/ZoomControls.tsx
@@ -38,6 +38,9 @@ const ZoomControls = ({
         className="button zoom-controls__button"
         title="Zoom in"
         onClick={zoomIn}
+        // Stops the long-press reveal gesture (mawimbi#447) from firing when
+        // a normal press-and-hold on the button itself runs past its delay.
+        onPointerDown={(e) => e.stopPropagation()}
         disabled={isMaxZoom || isRecording}
       >
         <Plus />
@@ -48,6 +51,7 @@ const ZoomControls = ({
         className="button zoom-controls__button"
         title="Zoom out"
         onClick={zoomOut}
+        onPointerDown={(e) => e.stopPropagation()}
         disabled={isMinZoom || isRecording}
       >
         <Minus />

--- a/src/features/workstation/scrubber/ZoomControls.tsx
+++ b/src/features/workstation/scrubber/ZoomControls.tsx
@@ -1,20 +1,37 @@
 import { Minus, Plus } from 'lucide-react';
 import { Button } from '../../../shared/ui/button';
-import { type CSSProperties } from 'react';
+import { type CSSProperties, type PointerEventHandler } from 'react';
 import { useRecordingService } from '../../recording/useRecordingService';
 import { useWorkstation } from '../useWorkstation';
 import './ZoomControls.css';
 
 type ZoomControlsProps = {
   style?: CSSProperties;
+  // Forwarded to the root element as-is — currently used by the dev tuning
+  // overlay (mawimbi#447) to attach its long-press reveal gesture, without
+  // coupling this component to tuning specifics.
+  onPointerDown?: PointerEventHandler;
+  onPointerUp?: PointerEventHandler;
+  onPointerLeave?: PointerEventHandler;
 };
 
-const ZoomControls = ({ style }: ZoomControlsProps) => {
+const ZoomControls = ({
+  style,
+  onPointerDown,
+  onPointerUp,
+  onPointerLeave,
+}: ZoomControlsProps) => {
   const { isRecording } = useRecordingService();
   const { isMaxZoom, isMinZoom, zoomIn, zoomOut } = useWorkstation();
 
   return (
-    <div className="zoom-controls" style={style}>
+    <div
+      className="zoom-controls"
+      style={style}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerLeave={onPointerLeave}
+    >
       <Button
         variant="ghost"
         size="icon-sm"

--- a/src/features/workstation/scrubber/__tests__/TuningOverlay.test.tsx
+++ b/src/features/workstation/scrubber/__tests__/TuningOverlay.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { activeRunwayConfig, beatSaber } from '../runwayConfig';
+import { solveGeometry } from '../runwayProjection';
+import {
+  getConfigOverride,
+  resetTuningSignals,
+  toggleTuningOverlay,
+} from '../tuningSignals';
+import TuningOverlay from '../TuningOverlay';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const geometry = solveGeometry(activeRunwayConfig, {
+  width: 1000,
+  height: 650,
+});
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  resetTuningSignals();
+  vi.clearAllMocks();
+});
+
+it('renders nothing when the overlay has not been opened', () => {
+  const { container } = render(<TuningOverlay geometry={geometry} />);
+
+  expect(container.querySelector('.tuning-overlay')).toBeNull();
+});
+
+it('renders a slider per RunwayConfig knob showing the current override value', () => {
+  toggleTuningOverlay(activeRunwayConfig);
+
+  render(<TuningOverlay geometry={geometry} />);
+
+  expect(screen.getByText('70deg')).toBeInTheDocument(); // tiltDeg
+  expect(screen.getByText('0.65')).toBeInTheDocument(); // playheadWidth
+  expect(screen.getByText('1800px')).toBeInTheDocument(); // runwayLengthPx
+});
+
+it('renders a readout of the solved geometry', () => {
+  toggleTuningOverlay(activeRunwayConfig);
+
+  render(<TuningOverlay geometry={geometry} />);
+
+  expect(
+    screen.getByText(`${geometry.horizonY.toFixed(1)}px`),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(`${geometry.perspectivePx.toFixed(1)}px`),
+  ).toBeInTheDocument();
+});
+
+it('replaces the override when a preset is selected from the dropdown', async () => {
+  const user = userEvent.setup();
+  toggleTuningOverlay(activeRunwayConfig);
+
+  render(<TuningOverlay geometry={geometry} />);
+
+  await user.click(screen.getByRole('button', { name: 'Preset' }));
+  const beatSaberOption = await screen.findByText('beatSaber');
+  await user.click(beatSaberOption);
+
+  expect(getConfigOverride()).toEqual(beatSaber);
+});
+
+it('copies the serialized preset to the clipboard', async () => {
+  toggleTuningOverlay(activeRunwayConfig);
+
+  render(<TuningOverlay geometry={geometry} />);
+
+  // fireEvent (not userEvent) here — userEvent.setup() installs its own
+  // clipboard stub that would shadow the beforeEach spy above.
+  fireEvent.click(screen.getByRole('button', { name: /Copy preset/ }));
+
+  await waitFor(() => {
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('tiltDeg: 70'),
+    );
+  });
+  expect(toast.success).toHaveBeenCalled();
+});
+
+it('closes the overlay when the close button is clicked', async () => {
+  const user = userEvent.setup();
+  toggleTuningOverlay(activeRunwayConfig);
+
+  render(<TuningOverlay geometry={geometry} />);
+
+  await user.click(screen.getByTitle('Close tuning overlay'));
+
+  expect(getConfigOverride()).toBeNull();
+});

--- a/src/features/workstation/scrubber/__tests__/TuningOverlay.test.tsx
+++ b/src/features/workstation/scrubber/__tests__/TuningOverlay.test.tsx
@@ -1,13 +1,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { type ComponentProps } from 'react';
 import { toast } from 'sonner';
 import { activeRunwayConfig, beatSaber } from '../runwayConfig';
 import { solveGeometry } from '../runwayProjection';
-import {
-  getConfigOverride,
-  resetTuningSignals,
-  toggleTuningOverlay,
-} from '../tuningSignals';
 import TuningOverlay from '../TuningOverlay';
 
 vi.mock('sonner', () => ({
@@ -25,6 +21,25 @@ const geometry = solveGeometry(activeRunwayConfig, {
   height: 650,
 });
 
+function renderOverlay(
+  overrides: Partial<ComponentProps<typeof TuningOverlay>> = {},
+) {
+  const close = vi.fn();
+  const selectPreset = vi.fn();
+  const setValue = vi.fn();
+  const utils = render(
+    <TuningOverlay
+      config={activeRunwayConfig}
+      geometry={geometry}
+      close={close}
+      selectPreset={selectPreset}
+      setValue={setValue}
+      {...overrides}
+    />,
+  );
+  return { ...utils, close, selectPreset, setValue };
+}
+
 beforeEach(() => {
   Object.defineProperty(navigator, 'clipboard', {
     value: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -33,20 +48,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  resetTuningSignals();
   vi.clearAllMocks();
 });
 
-it('renders nothing when the overlay has not been opened', () => {
-  const { container } = render(<TuningOverlay geometry={geometry} />);
-
-  expect(container.querySelector('.tuning-overlay')).toBeNull();
-});
-
-it('renders a slider per RunwayConfig knob showing the current override value', () => {
-  toggleTuningOverlay(activeRunwayConfig);
-
-  render(<TuningOverlay geometry={geometry} />);
+it('renders a slider per RunwayConfig knob showing the current config value', () => {
+  renderOverlay();
 
   expect(screen.getByText('70deg')).toBeInTheDocument(); // tiltDeg
   expect(screen.getByText('0.65')).toBeInTheDocument(); // playheadWidth
@@ -54,9 +60,7 @@ it('renders a slider per RunwayConfig knob showing the current override value', 
 });
 
 it('renders a readout of the solved geometry', () => {
-  toggleTuningOverlay(activeRunwayConfig);
-
-  render(<TuningOverlay geometry={geometry} />);
+  renderOverlay();
 
   expect(
     screen.getByText(`${geometry.horizonY.toFixed(1)}px`),
@@ -66,23 +70,31 @@ it('renders a readout of the solved geometry', () => {
   ).toBeInTheDocument();
 });
 
-it('replaces the override when a preset is selected from the dropdown', async () => {
+it('calls selectPreset when a preset is chosen from the dropdown', async () => {
   const user = userEvent.setup();
-  toggleTuningOverlay(activeRunwayConfig);
+  const { selectPreset, container } = renderOverlay();
 
-  render(<TuningOverlay geometry={geometry} />);
-
-  await user.click(screen.getByRole('button', { name: 'Preset' }));
+  const presetTrigger = container.querySelector(
+    '.tuning-overlay__preset',
+  ) as HTMLElement;
+  await user.click(presetTrigger);
   const beatSaberOption = await screen.findByText('beatSaber');
   await user.click(beatSaberOption);
 
-  expect(getConfigOverride()).toEqual(beatSaber);
+  expect(selectPreset).toHaveBeenCalledWith(beatSaber);
+});
+
+it('calls setValue when a slider is dragged', () => {
+  const { setValue } = renderOverlay();
+
+  const tiltSlider = screen.getAllByRole('slider')[0];
+  fireEvent.keyDown(tiltSlider, { key: 'ArrowRight' });
+
+  expect(setValue).toHaveBeenCalledWith('tiltDeg', expect.any(Number));
 });
 
 it('copies the serialized preset to the clipboard', async () => {
-  toggleTuningOverlay(activeRunwayConfig);
-
-  render(<TuningOverlay geometry={geometry} />);
+  renderOverlay();
 
   // fireEvent (not userEvent) here — userEvent.setup() installs its own
   // clipboard stub that would shadow the beforeEach spy above.
@@ -96,13 +108,26 @@ it('copies the serialized preset to the clipboard', async () => {
   expect(toast.success).toHaveBeenCalled();
 });
 
-it('closes the overlay when the close button is clicked', async () => {
-  const user = userEvent.setup();
-  toggleTuningOverlay(activeRunwayConfig);
+it('shows an error toast when the clipboard write fails', async () => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    configurable: true,
+  });
+  renderOverlay();
 
-  render(<TuningOverlay geometry={geometry} />);
+  fireEvent.click(screen.getByRole('button', { name: /Copy preset/ }));
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalled();
+  });
+  expect(toast.success).not.toHaveBeenCalled();
+});
+
+it('calls close when the close button is clicked', async () => {
+  const user = userEvent.setup();
+  const { close } = renderOverlay();
 
   await user.click(screen.getByTitle('Close tuning overlay'));
 
-  expect(getConfigOverride()).toBeNull();
+  expect(close).toHaveBeenCalled();
 });

--- a/src/features/workstation/scrubber/__tests__/tuningSignals.test.ts
+++ b/src/features/workstation/scrubber/__tests__/tuningSignals.test.ts
@@ -5,7 +5,6 @@ import {
   resetTuningSignals,
   selectTuningPreset,
   setTuningValue,
-  signals,
   toggleTuningOverlay,
 } from '../tuningSignals';
 
@@ -17,7 +16,6 @@ describe('toggleTuningOverlay', () => {
   it('opens the overlay and seeds the override from the given preset', () => {
     toggleTuningOverlay(activeRunwayConfig);
 
-    expect(signals.isOverlayOpen.value).toBe(true);
     expect(getConfigOverride()).toEqual(activeRunwayConfig);
     // A copy, not the same reference — mutating the override must not
     // mutate the preset it was seeded from.
@@ -29,7 +27,6 @@ describe('toggleTuningOverlay', () => {
 
     toggleTuningOverlay(activeRunwayConfig);
 
-    expect(signals.isOverlayOpen.value).toBe(false);
     expect(getConfigOverride()).toBeNull();
   });
 });
@@ -72,7 +69,6 @@ describe('closeTuningOverlay', () => {
 
     closeTuningOverlay();
 
-    expect(signals.isOverlayOpen.value).toBe(false);
     expect(getConfigOverride()).toBeNull();
     // The "compose over the active preset" contract useScrubberGeometry
     // relies on: `override ?? activeRunwayConfig`.

--- a/src/features/workstation/scrubber/__tests__/tuningSignals.test.ts
+++ b/src/features/workstation/scrubber/__tests__/tuningSignals.test.ts
@@ -1,0 +1,81 @@
+import { activeRunwayConfig, beatSaber } from '../runwayConfig';
+import {
+  closeTuningOverlay,
+  getConfigOverride,
+  resetTuningSignals,
+  selectTuningPreset,
+  setTuningValue,
+  signals,
+  toggleTuningOverlay,
+} from '../tuningSignals';
+
+afterEach(() => {
+  resetTuningSignals();
+});
+
+describe('toggleTuningOverlay', () => {
+  it('opens the overlay and seeds the override from the given preset', () => {
+    toggleTuningOverlay(activeRunwayConfig);
+
+    expect(signals.isOverlayOpen.value).toBe(true);
+    expect(getConfigOverride()).toEqual(activeRunwayConfig);
+    // A copy, not the same reference — mutating the override must not
+    // mutate the preset it was seeded from.
+    expect(getConfigOverride()).not.toBe(activeRunwayConfig);
+  });
+
+  it('closes the overlay and clears the override on a second call', () => {
+    toggleTuningOverlay(activeRunwayConfig);
+
+    toggleTuningOverlay(activeRunwayConfig);
+
+    expect(signals.isOverlayOpen.value).toBe(false);
+    expect(getConfigOverride()).toBeNull();
+  });
+});
+
+describe('setTuningValue', () => {
+  it('composes the override over the active preset, leaving other fields untouched', () => {
+    toggleTuningOverlay(activeRunwayConfig);
+
+    setTuningValue('tiltDeg', 45);
+
+    const override = getConfigOverride();
+    expect(override?.tiltDeg).toBe(45);
+    expect(override?.playheadFraction).toBe(
+      activeRunwayConfig.playheadFraction,
+    );
+  });
+
+  it('is a no-op when the overlay has never been opened', () => {
+    setTuningValue('tiltDeg', 45);
+
+    expect(getConfigOverride()).toBeNull();
+  });
+});
+
+describe('selectTuningPreset', () => {
+  it('replaces the override with a fresh copy of the selected preset', () => {
+    toggleTuningOverlay(activeRunwayConfig);
+    setTuningValue('tiltDeg', 12);
+
+    selectTuningPreset(beatSaber);
+
+    expect(getConfigOverride()).toEqual(beatSaber);
+  });
+});
+
+describe('closeTuningOverlay', () => {
+  it('reverts cleanly: override composes back to null, restoring activeRunwayConfig as the effective config', () => {
+    toggleTuningOverlay(activeRunwayConfig);
+    setTuningValue('tiltDeg', 12);
+
+    closeTuningOverlay();
+
+    expect(signals.isOverlayOpen.value).toBe(false);
+    expect(getConfigOverride()).toBeNull();
+    // The "compose over the active preset" contract useScrubberGeometry
+    // relies on: `override ?? activeRunwayConfig`.
+    expect(getConfigOverride() ?? activeRunwayConfig).toBe(activeRunwayConfig);
+  });
+});

--- a/src/features/workstation/scrubber/__tests__/useTuningActivation.test.ts
+++ b/src/features/workstation/scrubber/__tests__/useTuningActivation.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from '@testing-library/react';
+import { useLongPress, useTuningAvailable } from '../useTuningActivation';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe('useTuningAvailable', () => {
+  it('is available in dev builds', () => {
+    vi.stubEnv('DEV', true);
+
+    const { result } = renderHook(() => useTuningAvailable());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('is unavailable in non-dev builds without the ?tune query param', () => {
+    vi.stubEnv('DEV', false);
+
+    const { result } = renderHook(() => useTuningAvailable());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is available in non-dev builds with the ?tune query param', () => {
+    vi.stubEnv('DEV', false);
+    const originalLocation = window.location.href;
+    window.history.pushState({}, '', '/project/test-id?tune');
+
+    const { result } = renderHook(() => useTuningAvailable());
+
+    expect(result.current).toBe(true);
+
+    window.history.pushState({}, '', originalLocation);
+  });
+});
+
+describe('useLongPress', () => {
+  it('fires onLongPress after a sustained pointer-down', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => result.current.onPointerDown());
+    act(() => vi.advanceTimersByTime(700));
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire before the delay elapses', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => result.current.onPointerDown());
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointer-up before the delay elapses', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => result.current.onPointerDown());
+    act(() => vi.advanceTimersByTime(200));
+    act(() => result.current.onPointerUp());
+    act(() => vi.advanceTimersByTime(700));
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels on pointer-leave before the delay elapses', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    act(() => result.current.onPointerDown());
+    act(() => vi.advanceTimersByTime(200));
+    act(() => result.current.onPointerLeave());
+    act(() => vi.advanceTimersByTime(700));
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/workstation/scrubber/runwayConfig.ts
+++ b/src/features/workstation/scrubber/runwayConfig.ts
@@ -49,10 +49,11 @@ export const subtleRamp: RunwayPreset = {
 /**
  * Identity geometry — no tilt, no perspective. Documents what "flat" looks
  * like as a preset; `prefers-reduced-motion` does not switch to this fixed
- * preset, since that would ignore whichever preset is actually active. It
- * instead derives its own flattened variant of `activeRunwayConfig` (see
- * `useScrubberGeometry`'s `REDUCED_MOTION_CONFIG`), so reduced motion stays
- * correct regardless of which preset the dev tuning overlay (#447) selects.
+ * preset, since that would ignore whichever preset (or dev tuning overlay
+ * override, #447) is actually active. It instead derives its own flattened
+ * variant of that active config (see `useScrubberGeometry`'s
+ * `getFlatVariant`), so reduced motion stays correct regardless of what's
+ * currently selected.
  */
 export const flat: RunwayPreset = {
   tiltDeg: 0,

--- a/src/features/workstation/scrubber/runwayProjection.ts
+++ b/src/features/workstation/scrubber/runwayProjection.ts
@@ -97,9 +97,11 @@ const MIN_DENOMINATOR_MAGNITUDE = 1e-6;
  * numerical approximation: as tiltRad → 0 the tilted formula's own
  * `perspectivePx` → 0 (near-edge-on foreshortening), the opposite extreme
  * from the flat mode's scale-1-everywhere — so there is no continuous
- * handoff to protect between the two. The only caller of the flat mode
- * (`prefers-reduced-motion`) always passes tiltDeg exactly 0, never an
- * intermediate value.
+ * handoff to protect between the two. `prefers-reduced-motion` always passes
+ * tiltDeg exactly 0; the dev tuning overlay's tilt slider (#447) can also
+ * land in this band by direct user input, but never at an intermediate
+ * value straddling the two modes — the threshold is crossed as a discrete
+ * step, same as any other slider move.
  */
 export function solveGeometry(
   config: RunwayConfig,

--- a/src/features/workstation/scrubber/tuningSignals.ts
+++ b/src/features/workstation/scrubber/tuningSignals.ts
@@ -1,12 +1,10 @@
 import { signal, type ReadonlySignal } from '@preact/signals-react';
 import { type RunwayPreset } from './runwayConfig';
 
-const _isOverlayOpen = signal(false);
 const _configOverride = signal<RunwayPreset | null>(null);
 
 // Narrow channel for reactive consumers (hooks)
 export const signals = {
-  isOverlayOpen: _isOverlayOpen as ReadonlySignal<boolean>,
   configOverride: _configOverride as ReadonlySignal<RunwayPreset | null>,
 };
 
@@ -17,19 +15,19 @@ export function getConfigOverride(): RunwayPreset | null {
 
 /**
  * Opens the overlay and seeds the override from `preset`, or closes it and
- * clears the override, reverting the scrubber to `activeRunwayConfig`.
+ * clears the override, reverting the scrubber to `activeRunwayConfig`. The
+ * override being non-null IS the overlay's open state — there is no separate
+ * open flag to keep in sync with it.
  */
 export function toggleTuningOverlay(preset: RunwayPreset): void {
-  if (_isOverlayOpen.value) {
+  if (_configOverride.value) {
     closeTuningOverlay();
     return;
   }
-  _isOverlayOpen.value = true;
   _configOverride.value = { ...preset };
 }
 
 export function closeTuningOverlay(): void {
-  _isOverlayOpen.value = false;
   _configOverride.value = null;
 }
 
@@ -44,6 +42,5 @@ export function setTuningValue(key: keyof RunwayPreset, value: number): void {
 }
 
 export function resetTuningSignals(): void {
-  _isOverlayOpen.value = false;
   _configOverride.value = null;
 }

--- a/src/features/workstation/scrubber/tuningSignals.ts
+++ b/src/features/workstation/scrubber/tuningSignals.ts
@@ -1,0 +1,49 @@
+import { signal, type ReadonlySignal } from '@preact/signals-react';
+import { type RunwayPreset } from './runwayConfig';
+
+const _isOverlayOpen = signal(false);
+const _configOverride = signal<RunwayPreset | null>(null);
+
+// Narrow channel for reactive consumers (hooks)
+export const signals = {
+  isOverlayOpen: _isOverlayOpen as ReadonlySignal<boolean>,
+  configOverride: _configOverride as ReadonlySignal<RunwayPreset | null>,
+};
+
+// Plain getter for non-reactive consumers (tests, workflows)
+export function getConfigOverride(): RunwayPreset | null {
+  return _configOverride.value;
+}
+
+/**
+ * Opens the overlay and seeds the override from `preset`, or closes it and
+ * clears the override, reverting the scrubber to `activeRunwayConfig`.
+ */
+export function toggleTuningOverlay(preset: RunwayPreset): void {
+  if (_isOverlayOpen.value) {
+    closeTuningOverlay();
+    return;
+  }
+  _isOverlayOpen.value = true;
+  _configOverride.value = { ...preset };
+}
+
+export function closeTuningOverlay(): void {
+  _isOverlayOpen.value = false;
+  _configOverride.value = null;
+}
+
+/** Resets the override to a fresh copy of `preset`, discarding tuned values. */
+export function selectTuningPreset(preset: RunwayPreset): void {
+  _configOverride.value = { ...preset };
+}
+
+export function setTuningValue(key: keyof RunwayPreset, value: number): void {
+  if (!_configOverride.value) return;
+  _configOverride.value = { ..._configOverride.value, [key]: value };
+}
+
+export function resetTuningSignals(): void {
+  _isOverlayOpen.value = false;
+  _configOverride.value = null;
+}

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -1,3 +1,4 @@
+import { useSignals } from '@preact/signals-react/runtime';
 import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
 import { useMediaQuery } from '../../../shared/hooks/useMediaQuery';
 import { activeRunwayConfig, type RunwayPreset } from './runwayConfig';
@@ -6,6 +7,7 @@ import {
   type RunwayConfig,
   type RunwayGeometry,
 } from './runwayProjection';
+import { signals as tuningSignals } from './tuningSignals';
 
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
@@ -20,16 +22,6 @@ const FRACTION_TO_PERCENT = 100;
 // incidental side effect of solveFlatGeometry's internal constants.
 const FLAT_ROTATE_X_DEG = 0;
 const NO_FOG_STYLE: CSSProperties = { backgroundImage: 'none' };
-
-// A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
-// path — rotateX(0) disables the 3D effect without a separate code path.
-// getFogStyle's own FLAT_ROTATE_X_DEG check disables the fog the same way,
-// so this doesn't need its own fogStartFraction override. Defined once so
-// referential equality is stable across renders.
-const REDUCED_MOTION_CONFIG: RunwayPreset = {
-  ...activeRunwayConfig,
-  tiltDeg: 0,
-};
 
 // Measured container height can be 0 (before the first ResizeObserver
 // callback) or, in principle, smaller than drawerHeight — floor it so
@@ -59,6 +51,7 @@ type ScrubberGeometry = {
   viewportStyle: CSSProperties;
   tiltStyle: CSSProperties;
   fogStyle: CSSProperties;
+  geometry: RunwayGeometry;
   playheadFraction: number;
   visibleHeight: number;
   timelinePaddingTopPx: number;
@@ -76,19 +69,28 @@ type ScrubberGeometry = {
  * re-solved for the new visible box, so the runway's screen-space anchors
  * (playhead position, playhead width, horizon) stay true rather than being
  * patched with ad hoc compensating transforms.
+ *
+ * The base config is `activeRunwayConfig`, composed with the dev tuning
+ * overlay's override signal when one is active (mawimbi#447) — a slider
+ * tweak re-solves geometry the same way a drawer resize does, through this
+ * one function, never by writing CSS directly. Subscribing to that signal
+ * via `useSignals()` is the only reactive cost this hot-path hook takes on;
+ * when the overlay has never been opened the override stays `null` and this
+ * behaves exactly as before.
  */
 export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
+  useSignals();
   const containerRef = useRef<HTMLDivElement>(null);
   const containerSize = useContainerSize(containerRef);
   const prefersReducedMotion = useMediaQuery(REDUCED_MOTION_QUERY);
+  const configOverride = tuningSignals.configOverride.value;
 
   const visibleHeight = Math.max(
     containerSize.height - drawerHeight,
     MIN_VISIBLE_HEIGHT_PX,
   );
-  const config = prefersReducedMotion
-    ? REDUCED_MOTION_CONFIG
-    : activeRunwayConfig;
+  const baseConfig = configOverride ?? activeRunwayConfig;
+  const config = prefersReducedMotion ? getFlatVariant(baseConfig) : baseConfig;
   const geometry = solveGeometry(config, {
     width: containerSize.width,
     height: visibleHeight,
@@ -103,11 +105,20 @@ export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
     ),
     tiltStyle: getTiltStyle(geometry.rotateXDeg, geometry.transformOriginY),
     fogStyle: getFogStyle(config, geometry, visibleHeight),
-    playheadFraction: activeRunwayConfig.playheadFraction,
+    geometry,
+    playheadFraction: baseConfig.playheadFraction,
     visibleHeight,
     timelinePaddingTopPx: timelinePadding.top,
     timelinePaddingBottomPx: timelinePadding.bottom,
   };
+}
+
+// A flat plane (tiltDeg 0) makes solveGeometry take its identity-geometry
+// path — rotateX(0) disables the 3D effect without a separate code path.
+// getFogStyle's own FLAT_ROTATE_X_DEG check disables the fog the same way,
+// so this doesn't need its own fogStartFraction override.
+function getFlatVariant(config: RunwayPreset): RunwayPreset {
+  return { ...config, tiltDeg: 0 };
 }
 
 function getViewportStyle(

--- a/src/features/workstation/scrubber/useScrubberGeometry.ts
+++ b/src/features/workstation/scrubber/useScrubberGeometry.ts
@@ -77,6 +77,11 @@ type ScrubberGeometry = {
  * via `useSignals()` is the only reactive cost this hot-path hook takes on;
  * when the overlay has never been opened the override stays `null` and this
  * behaves exactly as before.
+ *
+ * `prefers-reduced-motion` flattens the tilt for regular playback, but not
+ * while actively tuning — opening the overlay is an explicit request to see
+ * the real 3D effect, which would otherwise make every slider look like a
+ * no-op for a developer who happens to have that OS preference set.
  */
 export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
   useSignals();
@@ -90,7 +95,10 @@ export function useScrubberGeometry(drawerHeight: number): ScrubberGeometry {
     MIN_VISIBLE_HEIGHT_PX,
   );
   const baseConfig = configOverride ?? activeRunwayConfig;
-  const config = prefersReducedMotion ? getFlatVariant(baseConfig) : baseConfig;
+  const shouldFlattenForReducedMotion = prefersReducedMotion && !configOverride;
+  const config = shouldFlattenForReducedMotion
+    ? getFlatVariant(baseConfig)
+    : baseConfig;
   const geometry = solveGeometry(config, {
     width: containerSize.width,
     height: visibleHeight,

--- a/src/features/workstation/scrubber/useTuningActivation.ts
+++ b/src/features/workstation/scrubber/useTuningActivation.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const TUNE_QUERY_PARAM = 'tune';
 const LONG_PRESS_MS = 600;
@@ -34,6 +34,12 @@ export function useLongPress(onLongPress: () => void): LongPressHandlers {
     clearTimeout(timerRef.current);
     timerRef.current = null;
   };
+
+  // A pending timer left running past unmount (e.g. navigating away mid-press)
+  // would fire later against the module-level tuningSignals singleton with no
+  // component left to display the result, silently opening the overlay on a
+  // future mount instead.
+  useEffect(() => cancel, []);
 
   return {
     onPointerDown: () => {

--- a/src/features/workstation/scrubber/useTuningActivation.ts
+++ b/src/features/workstation/scrubber/useTuningActivation.ts
@@ -1,0 +1,46 @@
+import { useRef, useState } from 'react';
+
+const TUNE_QUERY_PARAM = 'tune';
+const LONG_PRESS_MS = 600;
+
+/**
+ * The tuning overlay is a hidden dev tool — available in dev builds, and on
+ * deployed previews via `?tune` so the owner can tune without a local
+ * checkout. Read once per mount: query params don't change without a full
+ * navigation in this app's routing model.
+ */
+export function useTuningAvailable(): boolean {
+  const [isAvailable] = useState(() => isTuningAvailable());
+  return isAvailable;
+}
+
+function isTuningAvailable(): boolean {
+  if (import.meta.env.DEV) return true;
+  return new URLSearchParams(window.location.search).has(TUNE_QUERY_PARAM);
+}
+
+type LongPressHandlers = {
+  onPointerDown: () => void;
+  onPointerUp: () => void;
+  onPointerLeave: () => void;
+};
+
+/** Fires `onLongPress` after a sustained pointer-down, the overlay's reveal gesture. */
+export function useLongPress(onLongPress: () => void): LongPressHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancel = () => {
+    if (timerRef.current === null) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  };
+
+  return {
+    onPointerDown: () => {
+      cancel();
+      timerRef.current = setTimeout(onLongPress, LONG_PRESS_MS);
+    },
+    onPointerUp: cancel,
+    onPointerLeave: cancel,
+  };
+}

--- a/src/features/workstation/scrubber/useTuningOverlay.ts
+++ b/src/features/workstation/scrubber/useTuningOverlay.ts
@@ -1,0 +1,39 @@
+import { useSignals } from '@preact/signals-react/runtime';
+import {
+  activeRunwayConfig,
+  RUNWAY_PRESETS,
+  type RunwayPreset,
+} from './runwayConfig';
+import {
+  closeTuningOverlay,
+  selectTuningPreset,
+  setTuningValue,
+  signals as tuningSignals,
+  toggleTuningOverlay,
+} from './tuningSignals';
+
+export function useTuningOverlay() {
+  useSignals();
+
+  return {
+    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
+
+    get isOpen(): boolean {
+      return tuningSignals.isOverlayOpen.value;
+    },
+    get config(): RunwayPreset | null {
+      return tuningSignals.configOverride.value;
+    },
+
+    // --- Constants ---
+
+    presets: RUNWAY_PRESETS,
+
+    // --- Actions ---
+
+    toggle: () => toggleTuningOverlay(activeRunwayConfig),
+    close: closeTuningOverlay,
+    selectPreset: selectTuningPreset,
+    setValue: setTuningValue,
+  };
+}

--- a/src/features/workstation/scrubber/useTuningOverlay.ts
+++ b/src/features/workstation/scrubber/useTuningOverlay.ts
@@ -1,9 +1,5 @@
 import { useSignals } from '@preact/signals-react/runtime';
-import {
-  activeRunwayConfig,
-  RUNWAY_PRESETS,
-  type RunwayPreset,
-} from './runwayConfig';
+import { activeRunwayConfig, type RunwayPreset } from './runwayConfig';
 import {
   closeTuningOverlay,
   selectTuningPreset,
@@ -16,18 +12,13 @@ export function useTuningOverlay() {
   useSignals();
 
   return {
-    // --- Reactive state (getters → lazy signal subscription via signals accessor) ---
+    // --- Reactive state (getter → lazy signal subscription via signals accessor) ---
 
-    get isOpen(): boolean {
-      return tuningSignals.isOverlayOpen.value;
-    },
+    // Non-null IS the overlay's open state (tuningSignals.ts) — there is no
+    // separate open flag to read.
     get config(): RunwayPreset | null {
       return tuningSignals.configOverride.value;
     },
-
-    // --- Constants ---
-
-    presets: RUNWAY_PRESETS,
 
     // --- Actions ---
 


### PR DESCRIPTION
## Summary

Implements #447 — ends the "tune by PR" cycle six prior PRs (#393, #397, #402, #406, #408, #424) went through, each requiring a commit and deploy just to see the result of one parameter change.

- `tuningSignals.ts` owns a single config-override signal (its non-null-ness *is* the overlay's open state — no separate flag to keep in sync). `useScrubberGeometry` composes it over `activeRunwayConfig` (`override ?? activeRunwayConfig`), so a slider tweak re-solves geometry through the same path a drawer resize does — the overlay never writes CSS directly.
- `TuningOverlay` renders one slider per `RunwayConfig` knob (tilt, playhead fraction, playhead width, elevation, runway length, overhang), a preset selector, a readout of the solved geometry (`perspectivePx`, origins, `horizonY`), and a "copy preset" button that serializes the current config as a `runwayConfig.ts` snippet.
- Available in dev builds, or on deployed previews via `?tune`; revealed by a long-press on the zoom controls.

Code review (8-angle finder pass + verification) caught several real bugs, all fixed in the second commit:
- The overlay appeared completely broken for developers with `prefers-reduced-motion` enabled — geometry was always flattened regardless of slider values. Opening the overlay is now an explicit request to see the real 3D effect and bypasses that flattening.
- The long-press pointerdown handler bubbled up from the Zoom In/Out buttons, so an ordinary held button press could unexpectedly toggle the overlay.
- An unhandled clipboard-write rejection gave no feedback on failure.
- An orphaned long-press timer could fire after unmount, silently reopening the overlay on a later mount.
- A duplicate signal subscription (`TuningOverlay` now receives its data as props from `Scrubber`'s single `useTuningOverlay()` call, instead of calling the hook a second time itself).
- Stale doc comments referencing a constant removed earlier in this same diff, and a CSS background token that diverged from other floating panels.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 874/874 passing, including new `tuningSignals.test.ts` (override composes over the active preset and reverts cleanly, per the issue's verification requirement), `useTuningActivation.test.ts` (dev/`?tune` gating, long-press timing), `TuningOverlay.test.tsx`, and new `Scrubber.test.tsx` assertions (tuning re-solves geometry live, reverts on close, long-press reveals/doesn't-reveal on short press, and — the regression test for the reduced-motion fix — does not flatten geometry while the overlay is active)
- [x] `npm run build` — succeeds
- [x] Manually verified in a real browser via Playwright: uploaded audio, long-pressed the zoom controls to reveal the overlay, dragged the tilt slider from 70° to 30° and confirmed the runway visibly flattened and the geometry readout updated, switched to the `beatSaber` preset and confirmed all slider values updated to match, and closed the overlay

Claude-Session: https://claude.ai/code/session_01WX2XdWUd663bsSDbMrpBnZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01WX2XdWUd663bsSDbMrpBnZ)_