### PR TITLE
Replace scrubber scroll-source heuristics with an input-driven gesture state machine

### DIFF
--- a/e2e/playback-toggle.spec.ts
+++ b/e2e/playback-toggle.spec.ts
@@ -14,9 +14,11 @@ import {
  * Reproductions for the playback/scrub bugs identified in spec 002 (issue
  * #472): a timeline tap during playback restarts playback instead of
  * staying paused (G1), and pressing play after a paused touch-swipe enters
- * a play/pause stutter loop (G2). Both are annotated `test.fail()` per
- * CLAUDE.md's bug-fix rule — they must fail against current behavior before
- * milestone 2's gesture-model fix flips them green.
+ * a play/pause stutter loop (G2). Fixed in milestone 2 (issue #474) by
+ * replacing the scrubber's heuristic scroll-source attribution with the
+ * input-driven gesture state machine in `scrubGesture.ts` — these were
+ * committed `test.fail()`-annotated in milestone 1 (issue #473) per
+ * CLAUDE.md's bug-fix rule and flipped green here.
  *
  * Assertions count play/pause button *transitions* via the flap tracer
  * rather than polling visibility at one instant. A visibility poll can
@@ -52,7 +54,7 @@ test.describe('Playback toggle stability', () => {
   });
 
   for (const holdMs of TAP_HOLD_DURATIONS_MS) {
-    test.fail(
+    test(
       `tapping the timeline during playback pauses and stays paused (${holdMs}ms hold)`,
       async ({ page }) => {
         await page.getByTitle('Play').click();
@@ -68,7 +70,7 @@ test.describe('Playback toggle stability', () => {
     );
   }
 
-  test.fail(
+  test(
     'pressing play after a paused touch-swipe yields stable playback',
     async ({ page }) => {
       await expect(page.getByTitle('Play')).toBeVisible();

--- a/src/features/playback/PlaybackService.ts
+++ b/src/features/playback/PlaybackService.ts
@@ -181,10 +181,13 @@ class PlaybackService {
     this.transport.pause();
   }
 
+  // Raw numeric comparison, not toFixed(1) string equality: a frame that
+  // steps over the 0.1s rounding bucket (e.g. transportTime 10.06 vs
+  // totalTime 10.0 — "10.1" !== "10.0") could miss the end entirely.
   private isAtEndOfTimeline(): boolean {
     return (
-      this._transportTime.value.toFixed(1) ===
-        this._totalTime.value.toFixed(1) && this._totalTime.value > 0
+      this._totalTime.value > 0 &&
+      this._transportTime.value >= this._totalTime.value
     );
   }
 }

--- a/src/features/playback/__tests__/PlaybackService.test.ts
+++ b/src/features/playback/__tests__/PlaybackService.test.ts
@@ -199,6 +199,22 @@ describe('PlaybackService', () => {
       expect(service.playbackState).toBe('stopped');
       expect(service.transportTime).toBe(10.04);
     });
+
+    // A toFixed(1)-string comparison can miss the end when a frame steps
+    // over the rounding bucket (10.06 rounds to "10.1", never equal to
+    // "10.0"). Sweeping small overshoots past a non-round totalTime confirms
+    // the raw numeric comparison catches all of them.
+    it.each([0.01, 0.02, 0.04, 0.06, 0.09])(
+      'stops for a %s s frame-step overshoot past a non-round totalTime',
+      (overshoot) => {
+        service.setTotalTime(10.03);
+        service.play();
+
+        service.setTransportTime(10.03 + overshoot);
+
+        expect(service.playbackState).toBe('stopped');
+      },
+    );
   });
 
   describe('stop', () => {

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -414,6 +414,34 @@ it('does not stop playback at end of scroll during recording', () => {
   expect(playbackService.transportTime).toBe(1.5);
 });
 
+it('stops playback via the end-of-scroll fallback when totalTime is 0 mid-playback', () => {
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(2.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+  // totalTime is left at its default 0 (e.g. the last track was removed
+  // mid-playback) — isAtEndOfTimeline's `totalTime > 0` guard means the
+  // primary end-of-timeline mechanism inside setTransportTime can never
+  // fire, so the end-of-scroll fallback must stop playback on its own
+  // rather than leaving the loop reporting "playing" forever.
+
+  render(<Scrubber {...defaultProps} />);
+
+  // jsdom's scrollHeight === clientHeight (no overflow), so the end-of-scroll
+  // fallback's `scrollTop <= 0` condition is trivially satisfied.
+  act(() => {
+    rafCallback(0);
+  });
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
 it('stops recording when phantom scroller is clicked during recording', () => {
   playbackService.play();
   recordingService.arm();
@@ -527,6 +555,168 @@ it('does not pause playback for a resting pointerdown with no movement (G4)', ()
   fireEvent.scroll(phantom);
 
   expect(playbackService.isPlaying).toBe(true);
+});
+
+it('does not pause playback during a two-finger touch (pinch groundwork, G5)', () => {
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  act(() => {
+    rafCallback(0);
+  });
+
+  // A pinch's two touches each generate their own pointer events on the
+  // phantom (useTimelineZoom.ts's touchmove preventDefault() suppresses the
+  // native scroll, but not the parallel pointermove events) — a second
+  // pointer joining must suppress gesture entry entirely, or pinching would
+  // spuriously pause playback.
+  fireEvent.pointerDown(phantom, { clientY: 0, pointerId: 1 });
+  fireEvent.pointerDown(phantom, { clientY: 0, pointerId: 2 });
+  fireEvent.pointerMove(phantom, { clientY: 30, pointerId: 1 });
+  fireEvent.scroll(phantom);
+
+  expect(playbackService.isPlaying).toBe(true);
+});
+
+it('recognizes a single-finger drag again once a two-finger touch fully lifts', () => {
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  act(() => {
+    rafCallback(0);
+  });
+
+  // Both touches lift (pinch ends) — the pointer count must not stay
+  // wedged above zero, or every future single-finger drag would be
+  // silently ignored as "still multi-touch".
+  fireEvent.pointerDown(phantom, { clientY: 0, pointerId: 1 });
+  fireEvent.pointerDown(phantom, { clientY: 0, pointerId: 2 });
+  fireEvent.pointerUp(phantom, { pointerId: 2 });
+  fireEvent.pointerUp(phantom, { pointerId: 1 });
+
+  fireEvent.pointerDown(phantom, { clientY: 0, pointerId: 3 });
+  fireEvent.pointerMove(phantom, { clientY: 30, pointerId: 3 });
+  fireEvent.scroll(phantom);
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
+it('does not toggle playback via click after a tap that crossed the scrub threshold', () => {
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  // A "tap" with a few pixels of incidental finger movement crosses the
+  // scrub threshold and pauses playback — a real gesture, not misattributed
+  // scroll. The browser's own click-vs-drag tolerance doesn't match
+  // SCRUB_MOVEMENT_THRESHOLD_PX, so a native click can still follow; it
+  // must not also toggle playback (that would restart it, reproducing the
+  // G1 tap-misfire class via an 8+px tap instead of a misread scroll event).
+  fireEvent.pointerDown(phantom, { clientY: 0 });
+  fireEvent.pointerMove(phantom, { clientY: 20 });
+  fireEvent.pointerUp(phantom);
+  expect(playbackService.isPlaying).toBe(false);
+
+  fireEvent.click(phantom);
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
+it('does not permanently stick the gesture state if recording starts before a scroll event schedules the debounce', () => {
+  vi.useFakeTimers();
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  // A drag enters the gesture and pauses playback...
+  fireEvent.pointerDown(phantom, { clientY: 0 });
+  fireEvent.pointerMove(phantom, { clientY: 20 });
+  expect(playbackService.isPlaying).toBe(false);
+
+  // ...then recording starts and the finger lifts before any `scroll` event
+  // has fired for this gesture (a fast flick can outrun the browser's own
+  // scroll dispatch, and handleScroll would refuse to commit while actively
+  // recording anyway). Without handlePointerEnd scheduling its own commit,
+  // nothing would ever fire 'seekCommitted', leaving scrubStateRef stuck at
+  // 'pendingSeek' forever.
+  recordingService.arm();
+  recordingService.startRecording();
+  fireEvent.pointerUp(phantom);
+  recordingService.stopRecording();
+
+  act(() => {
+    vi.advanceTimersByTime(250);
+  });
+  vi.useRealTimers();
+
+  // A stuck gesture state would silently swallow this fresh drag — the
+  // idle-only guard in handlePointerMove never lets it re-enter, so
+  // playback would never pause here if the earlier gesture never unstuck.
+  playbackService.play();
+  fireEvent.pointerDown(phantom, { clientY: 100 });
+  fireEvent.pointerMove(phantom, { clientY: 130 });
+
+  expect(playbackService.isPlaying).toBe(false);
 });
 
 it('does not pause playback when phantom scroller is scrolled during recording', () => {

--- a/src/features/workstation/__tests__/Scrubber.test.tsx
+++ b/src/features/workstation/__tests__/Scrubber.test.tsx
@@ -67,7 +67,23 @@ function parseOriginY(origin: string): number {
   return parseFloat(origin.split(' ')[1]);
 }
 
-it('pauses playback when phantom scroller is scrolled while playing', () => {
+it('pauses playback on a real wheel scrub while playing', () => {
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+  fireEvent.wheel(phantom, { deltaY: 100 });
+
+  expect(playbackService.isPlaying).toBe(false);
+});
+
+// A bare `scroll` event with no preceding wheel/pointer-drag input is
+// exactly what the animation loop's own scrollTop writes generate — the
+// gesture model (scrubGesture.ts) must never infer a scrub from it alone,
+// or playback would misread its own writes as a user scrub (mawimbi#472's
+// stutter loop).
+it('does not pause playback on a bare scroll event with no preceding gesture input', () => {
   playbackService.play();
 
   const { container } = render(<Scrubber {...defaultProps} />);
@@ -75,7 +91,7 @@ it('pauses playback when phantom scroller is scrolled while playing', () => {
   const phantom = container.querySelector('.scrubber__phantom')!;
   fireEvent.scroll(phantom);
 
-  expect(playbackService.isPlaying).toBe(false);
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('does not pause playback when phantom scroller is scrolled while paused', () => {
@@ -459,18 +475,58 @@ it('pauses playback when pointer-dragging the phantom scroller during playback a
     configurable: true,
   });
 
-  // The animation loop sets isProgrammaticScrollRef = true when updating
-  // scroll position. Without pointer-down tracking, a subsequent user drag
-  // scroll event would be mistaken for a programmatic scroll and ignored.
+  // The animation loop writes scrollTop every frame; the gesture model must
+  // not mistake that write's own `scroll` event for the user's drag.
   act(() => {
     rafCallback(0);
   });
 
-  // Simulate a pointer drag: pointerdown → scroll
-  fireEvent.pointerDown(phantom);
+  // Simulate a pointer drag: pointerdown → movement past the gesture
+  // threshold → scroll. A resting pointerdown with no movement (G4) must
+  // not enter a gesture — see the companion "resting finger" test below.
+  fireEvent.pointerDown(phantom, { clientY: 0 });
+  fireEvent.pointerMove(phantom, { clientY: 20 });
   fireEvent.scroll(phantom);
 
   expect(playbackService.isPlaying).toBe(false);
+});
+
+it('does not pause playback for a resting pointerdown with no movement (G4)', () => {
+  vi.spyOn(playbackService, 'getEngineTime').mockReturnValue(1.0);
+  vi.spyOn(trackService, 'getLoudness').mockReturnValue(0);
+
+  let rafCallback: FrameRequestCallback = () => {};
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    rafCallback = cb;
+    return 1;
+  });
+
+  playbackService.play();
+
+  const { container } = render(<Scrubber {...defaultProps} />);
+
+  const phantom = container.querySelector('.scrubber__phantom')!;
+
+  Object.defineProperty(phantom, 'scrollHeight', {
+    value: 2000,
+    configurable: true,
+  });
+  Object.defineProperty(phantom, 'clientHeight', {
+    value: 500,
+    configurable: true,
+  });
+
+  act(() => {
+    rafCallback(0);
+  });
+
+  // A tap holds the pointer down for a frame or two with no movement — the
+  // animation loop's own scroll writes during that window must not be
+  // misread as a scrub (this was the tap-misfire's root cause, mawimbi#472).
+  fireEvent.pointerDown(phantom, { clientY: 0 });
+  fireEvent.scroll(phantom);
+
+  expect(playbackService.isPlaying).toBe(true);
 });
 
 it('does not pause playback when phantom scroller is scrolled during recording', () => {
@@ -624,10 +680,12 @@ it('does not resync scroll to a stale transport time while a user scrub is in fl
     configurable: true,
   });
 
-  // A user drags the timeline: the scroll lands at a new position while
-  // the debounced seek (and thus transportTime) has not yet committed.
+  // A user drags the timeline: pointerdown, movement past the gesture
+  // threshold, then the scroll lands at a new position while the debounced
+  // seek (and thus transportTime) has not yet committed.
   phantom.scrollTop = 700;
-  fireEvent.pointerDown(phantom);
+  fireEvent.pointerDown(phantom, { clientY: 0 });
+  fireEvent.pointerMove(phantom, { clientY: 20 });
   fireEvent.scroll(phantom);
 
   // Mid-drag, the geometry changes (e.g. the drag collapses the mobile

--- a/src/features/workstation/scrubber/PhantomScroller.tsx
+++ b/src/features/workstation/scrubber/PhantomScroller.tsx
@@ -4,8 +4,9 @@ type PhantomScrollerProps = PropsWithChildren<{
   spacerHeight: number;
   style?: CSSProperties;
   onClick: () => void;
-  onPointerDown: () => void;
-  onPointerUp: () => void;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerEnd: () => void;
   onScroll: () => void;
   onWheel: (e: React.WheelEvent) => void;
 }>;
@@ -29,7 +30,8 @@ const PhantomScroller = forwardRef<HTMLDivElement, PhantomScrollerProps>(
       style,
       onClick,
       onPointerDown,
-      onPointerUp,
+      onPointerMove,
+      onPointerEnd,
       onScroll,
       onWheel,
     },
@@ -42,7 +44,10 @@ const PhantomScroller = forwardRef<HTMLDivElement, PhantomScrollerProps>(
         style={style}
         onClick={onClick}
         onPointerDown={onPointerDown}
-        onPointerUp={onPointerUp}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerEnd}
+        onPointerCancel={onPointerEnd}
+        onLostPointerCapture={onPointerEnd}
         onScroll={onScroll}
         onWheel={onWheel}
       >

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -112,7 +112,13 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
     syncScrollToTime,
   ]);
 
+  // A native click can still fire after movement crosses the scrub
+  // threshold (the browser's own click-vs-drag tolerance doesn't match
+  // SCRUB_MOVEMENT_THRESHOLD_PX) — once that movement has registered as a
+  // gesture, this is no longer "a tap" per this app's own model (C4: tap
+  // toggles, drags seek), so it must not also toggle playback.
   const handleTimelineClick = () => {
+    if (isUserScrubbing()) return;
     if (recording.isCountingIn || recording.isActivelyRecording) {
       onStopRecording();
       return;

--- a/src/features/workstation/scrubber/Scrubber.tsx
+++ b/src/features/workstation/scrubber/Scrubber.tsx
@@ -68,7 +68,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
 
   const {
     handlePointerDown,
-    handlePointerUp,
+    handlePointerMove,
+    handlePointerEnd,
     handleWheel,
     handleScroll,
     isUserScrubbing,
@@ -146,7 +147,8 @@ const Scrubber = forwardRef<ScrubberHandle, ScrubberProps>((props, ref) => {
         style={phantomStyle}
         onClick={handleTimelineClick}
         onPointerDown={handlePointerDown}
-        onPointerUp={handlePointerUp}
+        onPointerMove={handlePointerMove}
+        onPointerEnd={handlePointerEnd}
         onScroll={handleScroll}
         onWheel={handleWheel}
       />

--- a/src/features/workstation/scrubber/__tests__/scrubGesture.test.ts
+++ b/src/features/workstation/scrubber/__tests__/scrubGesture.test.ts
@@ -65,14 +65,6 @@ describe('nextScrubState', () => {
     });
   });
 
-  describe('scroll', () => {
-    const states: ScrubState[] = ['idle', 'gestureActive', 'pendingSeek'];
-
-    it.each(states)('never changes state on its own (from %s)', (state) => {
-      expect(nextScrubState(state, { type: 'scroll' })).toBe(state);
-    });
-  });
-
   describe('seekCommitted', () => {
     const states: ScrubState[] = ['idle', 'gestureActive', 'pendingSeek'];
 

--- a/src/features/workstation/scrubber/__tests__/scrubGesture.test.ts
+++ b/src/features/workstation/scrubber/__tests__/scrubGesture.test.ts
@@ -1,0 +1,94 @@
+import {
+  isGestureInProgress,
+  nextScrubState,
+  SCRUB_MOVEMENT_THRESHOLD_PX,
+  type ScrubState,
+} from '../scrubGesture';
+
+describe('nextScrubState', () => {
+  describe('pointerMove', () => {
+    it('stays idle below the movement threshold (G4 — a resting finger never scrubs)', () => {
+      const state = nextScrubState('idle', {
+        type: 'pointerMove',
+        distancePx: SCRUB_MOVEMENT_THRESHOLD_PX - 1,
+      });
+
+      expect(state).toBe('idle');
+    });
+
+    it('enters gestureActive at the movement threshold', () => {
+      const state = nextScrubState('idle', {
+        type: 'pointerMove',
+        distancePx: SCRUB_MOVEMENT_THRESHOLD_PX,
+      });
+
+      expect(state).toBe('gestureActive');
+    });
+
+    it('enters gestureActive past the movement threshold', () => {
+      const state = nextScrubState('idle', {
+        type: 'pointerMove',
+        distancePx: SCRUB_MOVEMENT_THRESHOLD_PX + 50,
+      });
+
+      expect(state).toBe('gestureActive');
+    });
+  });
+
+  describe('wheel', () => {
+    it('enters gestureActive from idle', () => {
+      expect(nextScrubState('idle', { type: 'wheel' })).toBe('gestureActive');
+    });
+
+    it('re-enters gestureActive from pendingSeek (a new wheel tick before the debounce fires)', () => {
+      expect(nextScrubState('pendingSeek', { type: 'wheel' })).toBe(
+        'gestureActive',
+      );
+    });
+  });
+
+  describe('pointerEnd', () => {
+    it('transitions gestureActive to pendingSeek', () => {
+      expect(nextScrubState('gestureActive', { type: 'pointerEnd' })).toBe(
+        'pendingSeek',
+      );
+    });
+
+    it('is a no-op from idle (a tap that never crossed the threshold)', () => {
+      expect(nextScrubState('idle', { type: 'pointerEnd' })).toBe('idle');
+    });
+
+    it('is a no-op from pendingSeek', () => {
+      expect(nextScrubState('pendingSeek', { type: 'pointerEnd' })).toBe(
+        'pendingSeek',
+      );
+    });
+  });
+
+  describe('scroll', () => {
+    const states: ScrubState[] = ['idle', 'gestureActive', 'pendingSeek'];
+
+    it.each(states)('never changes state on its own (from %s)', (state) => {
+      expect(nextScrubState(state, { type: 'scroll' })).toBe(state);
+    });
+  });
+
+  describe('seekCommitted', () => {
+    const states: ScrubState[] = ['idle', 'gestureActive', 'pendingSeek'];
+
+    it.each(states)('resolves %s to idle', (state) => {
+      expect(nextScrubState(state, { type: 'seekCommitted' })).toBe('idle');
+    });
+  });
+});
+
+describe('isGestureInProgress', () => {
+  it('is false when idle', () => {
+    expect(isGestureInProgress('idle')).toBe(false);
+  });
+
+  it('is true when gestureActive or pendingSeek', () => {
+    expect(isGestureInProgress('gestureActive')).toBe(true);
+    expect(isGestureInProgress('pendingSeek')).toBe(true);
+  });
+});

--- a/src/features/workstation/scrubber/scrubGesture.ts
+++ b/src/features/workstation/scrubber/scrubGesture.ts
@@ -9,9 +9,17 @@
  * Scrub state is entered only from real input events — a wheel tick, or
  * pointer movement past `SCRUB_MOVEMENT_THRESHOLD_PX` — never inferred from
  * `scroll` events. A resting finger (pointerdown with no movement) never
- * enters a gesture (G4). `scroll` events carry no state transition of their
- * own; they only extend the seek debounce while a gesture is already
- * active or settling (handled by the caller, not this reducer).
+ * enters a gesture (G4). `scroll` events never reach this reducer at all —
+ * the caller (useScrubberScroll.ts) only uses them to sync visuals and, via
+ * `isGestureInProgress`, to extend the seek debounce while a gesture is
+ * already active or settling.
+ *
+ * `gestureActive` and `pendingSeek` are currently treated identically by
+ * every consumer (both are "in progress" per `isGestureInProgress`) — the
+ * distinction exists for the council-decided design (spec 002) and for
+ * milestone 3's command epoch (issue #475), which needs to tell "a gesture
+ * is live" apart from "a gesture ended, resume still armed" when deciding
+ * whether an intervening explicit command should cancel it.
  */
 
 export type ScrubState = 'idle' | 'gestureActive' | 'pendingSeek';
@@ -23,8 +31,6 @@ export type ScrubEvent =
   | { type: 'wheel' }
   /** Pointer released, cancelled, or lost capture (up/cancel/lostpointercapture). */
   | { type: 'pointerEnd' }
-  /** A native `scroll` event — never drives a transition on its own. */
-  | { type: 'scroll' }
   /** The debounced seek fired and (if armed) playback resumed. */
   | { type: 'seekCommitted' };
 
@@ -43,8 +49,6 @@ export function nextScrubState(
       return 'gestureActive';
     case 'pointerEnd':
       return state === 'gestureActive' ? 'pendingSeek' : state;
-    case 'scroll':
-      return state;
     case 'seekCommitted':
       return 'idle';
   }

--- a/src/features/workstation/scrubber/scrubGesture.ts
+++ b/src/features/workstation/scrubber/scrubGesture.ts
@@ -1,0 +1,58 @@
+/**
+ * Input-driven scrub gesture state machine (spec 002, Design).
+ *
+ * Replaces the scrubber's former heuristic scroll-source attribution
+ * (`isProgrammaticScrollRef` / `isPointerDownRef` booleans), which inferred
+ * "user scrub" from `scroll` events and could misclassify the playback
+ * animation loop's own `scrollTop` writes as user input (mawimbi#472).
+ *
+ * Scrub state is entered only from real input events — a wheel tick, or
+ * pointer movement past `SCRUB_MOVEMENT_THRESHOLD_PX` — never inferred from
+ * `scroll` events. A resting finger (pointerdown with no movement) never
+ * enters a gesture (G4). `scroll` events carry no state transition of their
+ * own; they only extend the seek debounce while a gesture is already
+ * active or settling (handled by the caller, not this reducer).
+ */
+
+export type ScrubState = 'idle' | 'gestureActive' | 'pendingSeek';
+
+export type ScrubEvent =
+  /** Pointer/touch movement, measured as cumulative distance from pointerdown. */
+  | { type: 'pointerMove'; distancePx: number }
+  /** A wheel tick not used for zoom (no Ctrl/Meta modifier). */
+  | { type: 'wheel' }
+  /** Pointer released, cancelled, or lost capture (up/cancel/lostpointercapture). */
+  | { type: 'pointerEnd' }
+  /** A native `scroll` event — never drives a transition on its own. */
+  | { type: 'scroll' }
+  /** The debounced seek fired and (if armed) playback resumed. */
+  | { type: 'seekCommitted' };
+
+export const SCRUB_MOVEMENT_THRESHOLD_PX = 8;
+
+export function nextScrubState(
+  state: ScrubState,
+  event: ScrubEvent,
+): ScrubState {
+  switch (event.type) {
+    case 'pointerMove':
+      return event.distancePx >= SCRUB_MOVEMENT_THRESHOLD_PX
+        ? 'gestureActive'
+        : state;
+    case 'wheel':
+      return 'gestureActive';
+    case 'pointerEnd':
+      return state === 'gestureActive' ? 'pendingSeek' : state;
+    case 'scroll':
+      return state;
+    case 'seekCommitted':
+      return 'idle';
+  }
+}
+
+/** True while a gesture is live or settling — the window in which the
+ * geometry-change resync guard must not fire (Scrubber.tsx) and in which
+ * `scroll` events should extend the seek debounce. */
+export function isGestureInProgress(state: ScrubState): boolean {
+  return state !== 'idle';
+}

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -63,6 +63,7 @@ export function useScrubberScroll({
   const scrubStateRef = useRef<ScrubState>('idle');
   const shouldResumeRef = useRef(false);
   const pointerDownPosRef = useRef<PointerPosition | null>(null);
+  const activePointerCountRef = useRef(0);
 
   /**
    * Ensure the phantom scroller's spacer height matches the offset stage's
@@ -172,6 +173,14 @@ export function useScrubberScroll({
           const isEndOfScroll = phantomRef.current.scrollTop <= 0;
           if (isEndOfScroll) {
             playback.setTransportTime(playback.totalTime);
+            if (playback.isPlaying) {
+              // isAtEndOfTimeline requires totalTime > 0 (PlaybackService),
+              // so the call above is a no-op when totalTime just dropped to
+              // 0 (e.g. the last track was removed mid-playback). Stop
+              // directly so this loop doesn't die mid-"playing" — the old
+              // rewind()-based fallback stopped unconditionally here.
+              playback.pause();
+            }
             return;
           }
         }
@@ -198,18 +207,27 @@ export function useScrubberScroll({
     // Hook objects reference stable service singletons via getters
   }, [playbackState, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Always clears the gesture state and the armed-resume flag, even if the
+  // seek/resume below is skipped — otherwise a debounce that commits while
+  // actively recording (C9: scroll-to-seek is disabled during active
+  // recording) would leave scrubStateRef/shouldResumeRef stuck armed with
+  // no further scroll event ever scheduled to retry them.
   const setTransportTimeFromScroll = () => {
     scrubStateRef.current = nextScrubState(scrubStateRef.current, {
       type: 'seekCommitted',
     });
+    const shouldResume = shouldResumeRef.current;
+    shouldResumeRef.current = false;
+
+    if (recording.isActivelyRecording) return;
+
     const el = phantomRef.current;
     if (el) {
       const maxScrollTop = el.scrollHeight - el.clientHeight;
       const time = (maxScrollTop - el.scrollTop) / pixelsPerSecond;
       playback.seekTo(time);
     }
-    if (shouldResumeRef.current) {
-      shouldResumeRef.current = false;
+    if (shouldResume) {
       playback.play();
     }
   };
@@ -226,24 +244,36 @@ export function useScrubberScroll({
   };
 
   // A gesture is entered only from real input events (below), never
-  // inferred from `scroll` events — see scrubGesture.ts. Recording position
-  // is tracked so a subsequent pointermove can measure cumulative movement
-  // against it (G4: a resting finger never scrubs).
+  // inferred from `scroll` events — see scrubGesture.ts. Pointer position is
+  // tracked so a subsequent pointermove can measure cumulative movement
+  // against it (G4: a resting finger never scrubs). A second pointer
+  // joining (e.g. a pinch's first two touches) clears the origin: pinch is
+  // multi-touch, never a single-finger scrub, so it must never reach the
+  // movement-threshold check below (G5 groundwork — full pinch integration
+  // is #476, but a two-finger touch was never meant to read as a drag).
   const handlePointerDown = (e: React.PointerEvent) => {
-    pointerDownPosRef.current = { x: e.clientX, y: e.clientY };
+    activePointerCountRef.current += 1;
+    pointerDownPosRef.current =
+      activePointerCountRef.current === 1
+        ? { x: e.clientX, y: e.clientY }
+        : null;
   };
 
   const handlePointerMove = (e: React.PointerEvent) => {
+    // Once a gesture is active, further movement no longer changes the
+    // outcome (see scrubGesture.ts's pointerMove case) — skip the distance
+    // calculation for the remainder of the drag, not just its result.
+    if (scrubStateRef.current !== 'idle') return;
+    if (activePointerCountRef.current !== 1) return;
     const origin = pointerDownPosRef.current;
     if (!origin || recording.isActivelyRecording) return;
 
     const distancePx = Math.hypot(e.clientX - origin.x, e.clientY - origin.y);
-    const wasIdle = scrubStateRef.current === 'idle';
     scrubStateRef.current = nextScrubState(scrubStateRef.current, {
       type: 'pointerMove',
       distancePx,
     });
-    if (wasIdle && scrubStateRef.current !== 'idle') {
+    if (scrubStateRef.current !== 'idle') {
       pauseForUserScroll();
     }
   };
@@ -255,11 +285,27 @@ export function useScrubberScroll({
   // instead). The gesture may still be settling (momentum scroll events
   // extending the debounce), so this only ends the *pointer*, not the
   // gesture — pendingSeek is exited by the debounced seek committing.
+  //
+  // A real gesture always schedules that commit itself, rather than
+  // depending on a `scroll` event to schedule it: on a fast flick the
+  // pointer can release before the browser has dispatched even one native
+  // scroll event, and recording can start mid-gesture and make handleScroll
+  // stop scheduling (see setTransportTimeFromScroll) — either way, with
+  // nothing scheduled, scrubStateRef would stay stuck at 'pendingSeek'
+  // forever, permanently blocking the geometry-resync guard.
   const handlePointerEnd = () => {
+    activePointerCountRef.current = Math.max(
+      0,
+      activePointerCountRef.current - 1,
+    );
     pointerDownPosRef.current = null;
+    const wasActive = scrubStateRef.current === 'gestureActive';
     scrubStateRef.current = nextScrubState(scrubStateRef.current, {
       type: 'pointerEnd',
     });
+    if (wasActive) {
+      debouncedSetTransportTime();
+    }
   };
 
   const handleWheel = (e: React.WheelEvent) => {
@@ -278,13 +324,15 @@ export function useScrubberScroll({
   // inferring intent from them is exactly what misclassified them as user
   // scrubs). They only sync visuals, and — while a gesture is already
   // active or settling — extend the seek debounce, which is what keeps
-  // touch momentum seeking working after the finger lifts.
+  // touch momentum seeking working after the finger lifts. Recording is not
+  // checked here: setTransportTimeFromScroll already skips the seek/resume
+  // side effects while actively recording, and gating scheduling here too
+  // risks a debounce that never gets re-armed once recording ends.
   const handleScroll = () => {
     syncSpacerHeight();
     syncOffset();
 
     if (!isGestureInProgress(scrubStateRef.current)) return;
-    if (recording.isActivelyRecording) return;
     debouncedSetTransportTime();
   };
 

--- a/src/features/workstation/scrubber/useScrubberScroll.ts
+++ b/src/features/workstation/scrubber/useScrubberScroll.ts
@@ -13,8 +13,15 @@ import { useTrackService } from '../../tracks/useTrackService';
 import useDebounced from '../../../shared/hooks/useDebounced';
 import FrequencyVisualizer from '../../spectrogram/FrequencyVisualizer';
 import { type PlayheadHandle } from './Playhead';
+import {
+  isGestureInProgress,
+  nextScrubState,
+  type ScrubState,
+} from './scrubGesture';
 
 const SCROLL_DEBOUNCE_MS = 200;
+
+type PointerPosition = { x: number; y: number };
 
 type UseScrubberScrollOptions = {
   phantomRef: RefObject<HTMLDivElement | null>;
@@ -53,10 +60,9 @@ export function useScrubberScroll({
   const playing = playback.isPlaying;
   const playbackState = playback.playbackState;
 
-  const isProgrammaticScrollRef = useRef(false);
+  const scrubStateRef = useRef<ScrubState>('idle');
   const shouldResumeRef = useRef(false);
-  const isPointerDownRef = useRef(false);
-  const isUserScrubbingRef = useRef(false);
+  const pointerDownPosRef = useRef<PointerPosition | null>(null);
 
   /**
    * Ensure the phantom scroller's spacer height matches the offset stage's
@@ -95,7 +101,6 @@ export function useScrubberScroll({
         const scrollPosition =
           maxScrollTop - Math.trunc(time * pixelsPerSecond);
         if (phantom.scrollTop !== scrollPosition) {
-          isProgrammaticScrollRef.current = true;
           phantom.scrollTop = scrollPosition;
         }
         syncOffset();
@@ -150,11 +155,23 @@ export function useScrubberScroll({
         // can momentarily equal clientHeight before new content is laid out.
         // Stopping playback here would freeze transportTime updates and halt
         // the live spectrogram scroll.
-        // In inverted scroll, end of track is at scrollTop=0 (top of scroll area)
-        if (phantomRef.current && !recording.isActivelyRecording) {
+        // In inverted scroll, end of track is at scrollTop=0 (top of scroll area).
+        // This is a safety net for the primary end-of-timeline detection
+        // above (setTransportTime's isAtEndOfTimeline check): if that
+        // already stopped playback this frame, isPlaying is false here and
+        // this block is skipped. If it hasn't (a rare rounding disagreement
+        // between the scroll-position and transport-time math), route
+        // through the same setTransportTime path so both mechanisms agree
+        // on "stop at end, preserving position" — not rewind()'s
+        // reset-to-0, which would contradict it (spec 002, Open questions).
+        if (
+          phantomRef.current &&
+          !recording.isActivelyRecording &&
+          playback.isPlaying
+        ) {
           const isEndOfScroll = phantomRef.current.scrollTop <= 0;
           if (isEndOfScroll) {
-            playback.rewind();
+            playback.setTransportTime(playback.totalTime);
             return;
           }
         }
@@ -182,7 +199,9 @@ export function useScrubberScroll({
   }, [playbackState, setScrollPosition]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const setTransportTimeFromScroll = () => {
-    isUserScrubbingRef.current = false;
+    scrubStateRef.current = nextScrubState(scrubStateRef.current, {
+      type: 'seekCommitted',
+    });
     const el = phantomRef.current;
     if (el) {
       const maxScrollTop = el.scrollHeight - el.clientHeight;
@@ -206,57 +225,66 @@ export function useScrubberScroll({
     }
   };
 
-  // Pointer-down indicates a touch/mouse drag is starting. While the
-  // pointer is down, all scroll events are user-initiated — the
-  // programmatic flag from the animation loop must be ignored.
-  const handlePointerDown = () => {
-    isPointerDownRef.current = true;
+  // A gesture is entered only from real input events (below), never
+  // inferred from `scroll` events — see scrubGesture.ts. Recording position
+  // is tracked so a subsequent pointermove can measure cumulative movement
+  // against it (G4: a resting finger never scrubs).
+  const handlePointerDown = (e: React.PointerEvent) => {
+    pointerDownPosRef.current = { x: e.clientX, y: e.clientY };
   };
 
-  const handlePointerUp = () => {
-    isPointerDownRef.current = false;
+  const handlePointerMove = (e: React.PointerEvent) => {
+    const origin = pointerDownPosRef.current;
+    if (!origin || recording.isActivelyRecording) return;
+
+    const distancePx = Math.hypot(e.clientX - origin.x, e.clientY - origin.y);
+    const wasIdle = scrubStateRef.current === 'idle';
+    scrubStateRef.current = nextScrubState(scrubStateRef.current, {
+      type: 'pointerMove',
+      distancePx,
+    });
+    if (wasIdle && scrubStateRef.current !== 'idle') {
+      pauseForUserScroll();
+    }
   };
 
-  // Wheel events always indicate user interaction — clear the programmatic
-  // flag so the subsequent onscroll handler treats it as a user scroll.
-  // Without this, the animation loop's programmatic flag could race with
-  // a user wheel event and swallow it.
+  // Pointer released, cancelled, or lost capture — every route a native
+  // touch scroll can end through (mawimbi#472's stutter loop traced to
+  // PhantomScroller only handling pointerup, leaving a stuck pointer-down
+  // flag when the browser took over the gesture and fired pointercancel
+  // instead). The gesture may still be settling (momentum scroll events
+  // extending the debounce), so this only ends the *pointer*, not the
+  // gesture — pendingSeek is exited by the debounced seek committing.
+  const handlePointerEnd = () => {
+    pointerDownPosRef.current = null;
+    scrubStateRef.current = nextScrubState(scrubStateRef.current, {
+      type: 'pointerEnd',
+    });
+  };
+
   const handleWheel = (e: React.WheelEvent) => {
     // Ctrl/Meta+wheel is zoom, not scroll
     if (e.ctrlKey || e.metaKey) return;
     if (recording.isActivelyRecording) return;
-    isProgrammaticScrollRef.current = false;
-    isUserScrubbingRef.current = true;
+    scrubStateRef.current = nextScrubState(scrubStateRef.current, {
+      type: 'wheel',
+    });
     pauseForUserScroll();
     debouncedSetTransportTime();
   };
 
+  // `scroll` events never drive a gesture transition themselves (that's the
+  // fix: the loop's own scrollTop writes reach this handler too, and
+  // inferring intent from them is exactly what misclassified them as user
+  // scrubs). They only sync visuals, and — while a gesture is already
+  // active or settling — extend the seek debounce, which is what keeps
+  // touch momentum seeking working after the finger lifts.
   const handleScroll = () => {
     syncSpacerHeight();
     syncOffset();
 
-    // When a pointer is down, the user is dragging — override the
-    // programmatic flag so the scroll is treated as user-initiated. Only a
-    // genuine drag (or wheel, above) raises the scrubbing flag: scroll
-    // events the browser generates itself (e.g. scrollTop clamping after a
-    // layout change) reach this handler too, and marking those as scrubs
-    // would wrongly suppress the geometry-change resync.
-    if (isPointerDownRef.current) {
-      isProgrammaticScrollRef.current = false;
-      // Not during active recording: the early return below would skip the
-      // debounced seek that clears the flag, leaving it stuck.
-      if (!recording.isActivelyRecording) {
-        isUserScrubbingRef.current = true;
-      }
-    }
-
-    if (isProgrammaticScrollRef.current) {
-      isProgrammaticScrollRef.current = false;
-      return;
-    }
-
+    if (!isGestureInProgress(scrubStateRef.current)) return;
     if (recording.isActivelyRecording) return;
-    pauseForUserScroll();
     debouncedSetTransportTime();
   };
 
@@ -268,18 +296,23 @@ export function useScrubberScroll({
     [setScrollPosition, playheadRef],
   );
 
-  // True from a user-initiated scroll until its debounced seek commits.
-  // Geometry-change resyncs must not fire in this window: they would snap
-  // scrollTop back to the stale pre-scrub transport time, yanking the
-  // timeline out from under an active drag (e.g. when the drag itself
-  // collapses the mobile address bar and resizes the viewport). Skipping
-  // is safe — the pending seek re-derives the time from the final scroll
-  // position against the then-current mapping.
-  const isUserScrubbing = useCallback(() => isUserScrubbingRef.current, []);
+  // True from a user-initiated gesture until its debounced seek commits
+  // (gestureActive or pendingSeek — see scrubGesture.ts). Geometry-change
+  // resyncs must not fire in this window: they would snap scrollTop back to
+  // the stale pre-scrub transport time, yanking the timeline out from under
+  // an active drag (e.g. when the drag itself collapses the mobile address
+  // bar and resizes the viewport). Skipping is safe — the pending seek
+  // re-derives the time from the final scroll position against the
+  // then-current mapping.
+  const isUserScrubbing = useCallback(
+    () => isGestureInProgress(scrubStateRef.current),
+    [],
+  );
 
   return {
     handlePointerDown,
-    handlePointerUp,
+    handlePointerMove,
+    handlePointerEnd,
     handleWheel,
     handleScroll,
     isUserScrubbing,


### PR DESCRIPTION
## Summary

Milestone 2 of spec 002 (issue #474, part of tracking issue #472): fixes the tap-misfire and play/pause stutter loop bugs by replacing the scrubber's heuristic scroll-source attribution with an input-driven gesture state machine, per the council-decided design in `specs/002-playback-scrub-contract.md`.

- **New gesture state machine** (`src/features/workstation/scrubber/scrubGesture.ts`): a pure `idle → gestureActive → pendingSeek → idle` reducer. Scrub state is entered **only** from real input events — a wheel tick, or pointer movement past an 8px threshold (`SCRUB_MOVEMENT_THRESHOLD_PX`) — never inferred from `scroll` events. This eliminates the ambiguity that let the playback animation loop's own `scrollTop` writes be misread as user scrubs.
- **`useScrubberScroll.ts` rewritten** around the new state machine, replacing `isProgrammaticScrollRef`/`isPointerDownRef`/`isUserScrubbingRef` with a single `scrubStateRef`.
- **`PhantomScroller.tsx`** now handles `pointercancel`/`lostpointercapture` alongside `pointerup` — the missing-`pointercancel` stuck-pointer-down flag was the primary cause of the stutter loop on real touch scrolling.
- **`PlaybackService.isAtEndOfTimeline()`** fixed from `toFixed(1)` string equality to a raw numeric `>=` comparison, which could miss the end of the timeline when a frame stepped over the rounding bucket.
- The animation loop's end-of-scroll rewind fallback now routes through the same "stop at end, preserving position" mechanism as the primary detection, instead of a conflicting reset-to-0 `rewind()` (spec 002's "dual end-of-track mechanisms" open question).
- The G1/G2 e2e reproductions from #473 (`e2e/playback-toggle.spec.ts`) now pass without their `test.fail()` annotations.

An 8-angle `/code-review` pass surfaced and fixed four real bugs in the initial gesture-model rewrite before this was ready to ship:
- A two-finger touch (pinch) generated `pointermove` events the gesture threshold could misread as a single-finger scrub, spuriously pausing playback during pinch-zoom. Gesture entry now requires exactly one active pointer.
- `handlePointerEnd` could leave the gesture stuck at `pendingSeek` forever if no `scroll` event had scheduled a debounce commit yet (a fast flick, or recording starting mid-gesture) — it now always schedules one, and the debounce commit itself skips the seek/resume side effects while actively recording instead of skipping its own scheduling.
- The animation loop's end-of-scroll fallback could die while still reporting `isPlaying=true` if `totalTime` dropped to 0 mid-playback (e.g. the last track removed during playback) — it now falls back to a direct `pause()` when the primary mechanism doesn't stop playback.
- A tap with a few incidental pixels of movement could cross the scrub threshold, pause playback, and then have its trailing native click resume it — the same tap-misfire class this milestone fixes, just via an 8+px tap. `handleTimelineClick` now defers to an in-flight gesture.

Also removed the `scroll` `ScrubEvent` variant, which no production code ever dispatched into the reducer (simplification finding from review).

## Test plan

All commands run this session, all green:

```bash
npx tsc -b
npm run lint
npx vitest run                                            # 896 passed
npx playwright test e2e/ --reporter=list                  # 51 passed
npm run build
```

Specifically for this change:
- `src/features/workstation/scrubber/__tests__/scrubGesture.test.ts` (new) — pure state-machine unit tests: G4 (sub-threshold movement stays idle), wheel/drag transitions, pointerEnd/seekCommitted transitions.
- `src/features/workstation/__tests__/Scrubber.test.tsx` — updated existing tests to reflect the new contract (a bare `scroll` event no longer pauses playback on its own) plus new tests for pinch/multi-touch suppression, the tap-after-jiggle click guard, the stuck-`pendingSeek` fix, and the `totalTime=0` end-of-scroll fallback.
- `src/features/playback/__tests__/PlaybackService.test.ts` — sweep test for the `isAtEndOfTimeline` frame-step-overshoot fix.
- `e2e/playback-toggle.spec.ts` — G1/G2 reproductions from #473 now pass without `test.fail()`.
- Existing `e2e/scrubber-seek.spec.ts`, `e2e/swipe-playback.spec.ts`, `e2e/recording.spec.ts` stay green.

## Acceptance criteria (from #474)

- [x] `test.fail()` annotations removed from the G1/G2 reproductions in `e2e/playback-toggle.spec.ts`; both pass
- [x] Gesture-machine unit tests: sub-threshold pointer + scroll events stay `idle` (G4); wheel/drag transitions; resume-never-re-seeks
- [x] `pointercancel`/`lostpointercapture` handled on PhantomScroller
- [x] Existing `scrubber-seek.spec.ts`, `swipe-playback.spec.ts`, `recording.spec.ts` stay green (G6/G7)
- [x] End-of-timeline unit test added; behavior consistent
- [x] Build succeeds, lint passes

Milestone 3 (#475, command epoch) and milestone 4 (#476, full pinch integration) remain as follow-up work; this PR's multi-touch guard is groundwork for #476, not the full integration.


---
_Generated by [Claude Code](https://claude.ai/code/session_0112RsTQ1euZMFmuJ57rfwcc)_