### PR TITLE
Reorder work-issue so KB capture runs after code review

### DIFF
--- a/.claude/skills/kb/SKILL.md
+++ b/.claude/skills/kb/SKILL.md
@@ -16,7 +16,7 @@ The KB lives in `kb/` at the repo root (`INDEX.md` is the map). It compounds: ev
 
 ## /kb write
 
-Run near the end of a session, **before opening a PR** — commit the KB update as its own commit on the same branch/PR as the change it came from (not squashed into that change's commit, and not a follow-up PR — see `work-issue`'s Ship step). For ad hoc sessions with no PR in flight, right after a PR merges also works. Distill what this session learned, then filter hard:
+Run near the end of a session, **after `/code-review` and before opening a PR** — code review often surfaces the mistakes and tradeoffs most worth capturing, so let it run first (see `work-issue`'s Review and Pay back steps). Commit the KB update as its own commit on the same branch/PR as the change it came from (not squashed into that change's commit, and not a follow-up PR — see `work-issue`'s Ship step). For ad hoc sessions with no PR in flight, right after a PR merges also works. Distill what this session learned, then filter hard:
 
 **Include** only entries that are all three of:
 - **Durable** — still true and useful months from now (not "test X was flaky today").

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: <issue number>
 
 # Work an Issue
 
-The delivery loop for one issue. The ordering is the point: **verification exists before implementation**, and **the KB gets paid back before the session ends**.
+The delivery loop for one issue. The ordering is the point: **verification exists before implementation**, **code review runs before the KB gets paid back**, and **the KB gets paid back before the session ends**.
 
 ## 1. Ground
 
@@ -26,11 +26,15 @@ Per CLAUDE.md's Working Defaults, on the session's designated branch. For a genu
 
 Run the issue's verification commands, then verify per CLAUDE.md's Working Defaults (`npm run lint` plus the tests relevant to the change; e2e with `--reporter=list` in headless sessions). Only claim what this session has evidence for. Check acceptance-criteria boxes only when their check actually ran green.
 
-## 5. Pay back
+## 5. Review
 
-- `/kb write` — capture durable learnings from this session, **before shipping**, so the update lands in this PR rather than a follow-up one.
+Run `/code-review` on the diff and address confirmed findings (CLAUDE.md, Working Defaults). Do this before `/kb write` — review often surfaces the mistakes and tradeoffs that are actually worth capturing.
+
+## 6. Pay back
+
+- `/kb write` — capture durable learnings from this session, **before shipping**, so the update lands in this PR rather than a follow-up one. Include anything code review surfaced that's durable and non-derivable, not just narration of the review itself.
 - If this was the spec's last milestone: spec Status → `Delivered`.
 
-## 6. Ship
+## 7. Ship
 
-Follow CLAUDE.md's Pull Requests section: commit the feature code, then commit the KB update **separately** (`kb/*.md`, `CLAUDE.md`, `specs/*.md` changes in their own commit) — same branch and PR, distinct commit — and push both. Run `/code-review` and address confirmed findings, then open the PR with a summary, a test plan listing the commands actually run, and `Closes #<issue-number>` in the body so merging auto-closes the issue. Comment on the issue per CLAUDE.md's Issue Updates format (what was done, recommended next steps). Subscribe to the PR's activity and babysit CI to green. If this was the spec's last milestone, close the parent tracking issue with a summary once the PR merges.
+Follow CLAUDE.md's Pull Requests section: commit the feature code (including any review fixes), then commit the KB update **separately** (`kb/*.md`, `CLAUDE.md`, `specs/*.md` changes in their own commit) — same branch and PR, distinct commit — and push both. Open the PR with a summary, a test plan listing the commands actually run, and `Closes #<issue-number>` in the body so merging auto-closes the issue. Comment on the issue per CLAUDE.md's Issue Updates format (what was done, recommended next steps). Subscribe to the PR's activity and babysit CI to green. If this was the spec's last milestone, close the parent tracking issue with a summary once the PR merges.

--- a/specs/001-agent-harness.md
+++ b/specs/001-agent-harness.md
@@ -20,7 +20,7 @@ A harness that lets an autonomous agent (Fable/Opus/Sonnet session) take a featu
 2. `/spec-to-issues` files a parent tracking issue plus ordered milestone sub-issues matching the repo's established issue style.
 3. `/kb` gives every session a read-before-planning / write-before-finishing protocol over `kb/`, with a clean boundary against CLAUDE.md.
 4. `/council` structures multi-perspective deliberation (parallel adversarial lenses, evidence-based synthesis, recorded dissent) during planning.
-5. `/work-issue` executes an issue end-to-end: ground → verification first → implement → verify → review → ship → pay back the KB.
+5. `/work-issue` executes an issue end-to-end: ground → verification first → implement → verify → review → pay back the KB → ship.
 6. `/harness-audit` detects and fixes KB/CLAUDE.md/spec drift and runs the quality gates.
 
 ## Non-goals


### PR DESCRIPTION
## Summary

- `/work-issue` previously ran `/kb write` (Pay back) before `/code-review` (folded into the old Ship step). Reordered into three distinct steps — **Review** (`/code-review`, address confirmed findings) → **Pay back** (`/kb write`) → **Ship** (commit, push, open PR) — so KB capture happens after review has surfaced whatever's actually worth recording.
- Updated `/kb write`'s trigger condition in the `kb` skill to say "after `/code-review` and before opening a PR", cross-referencing the renumbered `work-issue` steps.
- Updated the abbreviated flow description in `specs/001-agent-harness.md` (`ground → verification first → implement → verify → review → pay back the KB → ship`) to match.

## Test plan

- `bash scripts/check-harness.sh` — passes (pre-existing unrelated warning about `kb/decisions.md` line count).
- `/code-review` on the diff — no findings (docs-only reorder, cross-references verified consistent by hand).


---
_Generated by [Claude Code](https://claude.ai/code/session_011kkj92zMJTREfWntPUfQrW)_