### PR TITLE
Split work-issue's Ship step into three separate commits

### DIFF
--- a/.claude/skills/kb/SKILL.md
+++ b/.claude/skills/kb/SKILL.md
@@ -16,7 +16,7 @@ The KB lives in `kb/` at the repo root (`INDEX.md` is the map). It compounds: ev
 
 ## /kb write
 
-Run near the end of a session, **after `/code-review` and before opening a PR** — code review often surfaces the mistakes and tradeoffs most worth capturing, so let it run first (see `work-issue`'s Review and Pay back steps). Commit the KB update as its own commit on the same branch/PR as the change it came from (not squashed into that change's commit, and not a follow-up PR — see `work-issue`'s Ship step). For ad hoc sessions with no PR in flight, right after a PR merges also works. Distill what this session learned, then filter hard:
+Run near the end of a session, **after `/code-review` and before opening a PR** — code review often surfaces the mistakes and tradeoffs most worth capturing, so let it run first (see `work-issue`'s Review and Pay back steps). Commit the KB update as its own commit on the same branch/PR as the change it came from (not squashed into the feature or review-fix commit, and not a follow-up PR — see `work-issue`'s Pay back step). For ad hoc sessions with no PR in flight, right after a PR merges also works. Distill what this session learned, then filter hard:
 
 **Include** only entries that are all three of:
 - **Durable** — still true and useful months from now (not "test X was flaky today").

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: <issue number>
 
 # Work an Issue
 
-The delivery loop for one issue. The ordering is the point: **verification exists before implementation**, **code review runs before the KB gets paid back**, and **the KB gets paid back before the session ends**.
+The delivery loop for one issue. The ordering is the point: **verification exists before implementation**, **code review runs before the KB gets paid back**, and **the KB gets paid back before the session ends**. Each stage lands its own commit — feature code, then review fixes, then the KB update — so the PR history shows what review actually changed instead of folding it into the original diff.
 
 ## 1. Ground
 
@@ -26,15 +26,19 @@ Per CLAUDE.md's Working Defaults, on the session's designated branch. For a genu
 
 Run the issue's verification commands, then verify per CLAUDE.md's Working Defaults (`npm run lint` plus the tests relevant to the change; e2e with `--reporter=list` in headless sessions). Only claim what this session has evidence for. Check acceptance-criteria boxes only when their check actually ran green.
 
-## 5. Review
+## 5. Commit
 
-Run `/code-review` on the diff and address confirmed findings (CLAUDE.md, Working Defaults). Do this before `/kb write` — review often surfaces the mistakes and tradeoffs that are actually worth capturing.
+Commit the feature code now, before code review runs. Committing first means review's fixes land as their own commit instead of being silently folded into the implementation.
 
-## 6. Pay back
+## 6. Review
 
-- `/kb write` — capture durable learnings from this session, **before shipping**, so the update lands in this PR rather than a follow-up one. Include anything code review surfaced that's durable and non-derivable, not just narration of the review itself.
+Run `/code-review` on the diff and address confirmed findings (CLAUDE.md, Working Defaults). Commit any fixes **separately** from the feature commit. Do this before `/kb write` — review often surfaces the mistakes and tradeoffs that are actually worth capturing.
+
+## 7. Pay back
+
+- `/kb write` — capture durable learnings from this session, **before shipping**, so the update lands in this PR rather than a follow-up one. Include anything code review surfaced that's durable and non-derivable, not just narration of the review itself. Commit the KB update **separately** (`kb/*.md`, `CLAUDE.md`, `specs/*.md` changes in their own commit).
 - If this was the spec's last milestone: spec Status → `Delivered`.
 
-## 7. Ship
+## 8. Ship
 
-Follow CLAUDE.md's Pull Requests section: commit the feature code (including any review fixes), then commit the KB update **separately** (`kb/*.md`, `CLAUDE.md`, `specs/*.md` changes in their own commit) — same branch and PR, distinct commit — and push both. Open the PR with a summary, a test plan listing the commands actually run, and `Closes #<issue-number>` in the body so merging auto-closes the issue. Comment on the issue per CLAUDE.md's Issue Updates format (what was done, recommended next steps). Subscribe to the PR's activity and babysit CI to green. If this was the spec's last milestone, close the parent tracking issue with a summary once the PR merges.
+Push the feature, review-fix, and KB commits — same branch and PR. Open the PR with a summary, a test plan listing the commands actually run, and `Closes #<issue-number>` in the body so merging auto-closes the issue. Comment on the issue per CLAUDE.md's Issue Updates format (what was done, recommended next steps). Subscribe to the PR's activity and babysit CI to green. If this was the spec's last milestone, close the parent tracking issue with a summary once the PR merges.

--- a/kb/decisions.md
+++ b/kb/decisions.md
@@ -2,6 +2,12 @@
 
 Architectural decisions with rationale and provenance, newest first. Entry format: date, decision, why, source. When a decision is reversed, mark the old entry **Superseded** with a pointer — don't delete it; the rationale trail is the point.
 
+## 2026-07-20 — `work-issue` commits feature code, review fixes, and the KB update as three separate commits
+
+**Decision:** `work-issue`'s old combined "Ship" step (commit feature code including any review fixes, then commit the KB update separately) is split into three steps — Commit (feature code, before review runs), Review (`/code-review`, its fixes committed separately), Pay back (`/kb write`, committed separately) — landing three distinct commits per PR instead of two.
+**Why:** Committing the feature code only at Ship time meant `/code-review` ran against an uncommitted diff and its fixes were silently folded into the same commit as the original implementation — the PR history couldn't show what review actually changed. Committing before review makes the fix commit a visible, separate diff.
+**Source:** `.claude/skills/work-issue/SKILL.md`, `.claude/skills/kb/SKILL.md`.
+
 ## 2026-07-20 — `window.__mawimbi` dev-only e2e verification bridge
 
 **Decision:** `AudioService`'s constructor sets `window.__mawimbi = { spectrogramCache }` when `import.meta.env.DEV`; the shape is declared in `src/global.d.ts`. e2e tests read worker-produced state (e.g. transcribed melody notes) directly through it instead of reverse-engineering a DOM/pixel proxy for a data claim.


### PR DESCRIPTION
## Summary

- `work-issue`'s old combined "Ship" step committed the feature code (including any review fixes) as one commit, then the KB update as a second — meaning `/code-review` ran against an uncommitted diff and its fixes were silently folded into the same commit as the original implementation, with no distinct record in the PR history of what review actually changed.
- Splits Ship into three explicit steps: **Commit** (feature code, before review runs), **Review** (`/code-review`, fixes committed separately), **Pay back** (`/kb write`, committed separately) — three distinct commits per PR instead of two.
- Updates `kb/SKILL.md`'s cross-reference from the old "Ship step" to the new "Pay back step" for where the KB commit happens.
- Records the decision and rationale in `kb/decisions.md`.

## Test plan

- `bash scripts/check-harness.sh` — passes (pre-existing `kb/decisions.md` line-count warning, unrelated to this change's content).
- `/code-review` run on the diff — no findings; verified no other file references the old "Ship step" or step numbers that would go stale.
- This PR's own commit history demonstrates the new process: one commit for the feature (skill doc) change, one for the KB write.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K9nCGvsPXqPqahE5Rp5w)_