### PR TITLE
Fix EffectsChain nodes binding to the wrong Tone context during playback

### DIFF
--- a/src/features/tracks/EffectsChain.ts
+++ b/src/features/tracks/EffectsChain.ts
@@ -126,11 +126,29 @@ class EffectsChain {
     // The reverb's impulse response generates asynchronously (silent until
     // its `ready` resolves, #489). Wiring immediately is fine live: the
     // dry portion of the crossfade keeps sounding while the IR renders.
+    //
+    // `context: this.source.context` is required, not cosmetic: without it
+    // a bare `new Tone.Reverb(...)` binds to whatever Tone.getContext()
+    // (the process-global current context) happens to be at this exact
+    // moment. renderTrackOffline's Tone.Offline() calls (effects refresh +
+    // live preview, both can be in flight while dragging during playback)
+    // synchronously swap that global context for the full duration of their
+    // callback, including a real `await reverb.ready` gap — see
+    // node_modules/tone/Tone/core/context/Offline.ts. A live-chain node
+    // constructed during that window binds to the throwaway
+    // OfflineContext; rewire()'s subsequent source.chain(...) then throws
+    // (native "cannot connect to an AudioNode belonging to a different
+    // audio context"), and since source.disconnect() already ran, the
+    // track is left silently disconnected from the destination bus for the
+    // rest of the session — confirmed via a real-Tone.js repro, not
+    // speculative (session notes, not yet in kb/).
+    const context = this.source.context;
     switch (effectId) {
       case 'space':
         this.nodes.space = new Tone.Reverb({
           decay: SPACE_DECAY_SECONDS,
           wet: 0,
+          context,
         });
         break;
       case 'echo':
@@ -138,12 +156,14 @@ class EffectsChain {
           delayTime: ECHO_DELAY_SECONDS,
           feedback: ECHO_MIN_FEEDBACK,
           wet: 0,
+          context,
         });
         break;
       case 'tone':
         this.nodes.tone = new Tone.Filter({
           frequency: TONE_MAX_CUTOFF_HZ,
           type: 'lowpass',
+          context,
         });
         break;
     }

--- a/src/features/tracks/__tests__/EffectsChain.test.ts
+++ b/src/features/tracks/__tests__/EffectsChain.test.ts
@@ -16,6 +16,7 @@ type MockNode = {
   disconnect: Mock;
   chain: Mock;
   dispose: Mock;
+  context: object;
 };
 
 function makeMockNode(): MockNode {
@@ -24,6 +25,10 @@ function makeMockNode(): MockNode {
     disconnect: vi.fn().mockReturnThis(),
     chain: vi.fn().mockReturnThis(),
     dispose: vi.fn(),
+    // A unique marker object, not a real Tone context — only used to
+    // assert identity (`toHaveBeenCalledWith({ context: source.context })`)
+    // in the "binds new effect nodes to the source's own context" test.
+    context: {},
   };
 }
 
@@ -135,6 +140,34 @@ describe('EffectsChain wiring', () => {
 
     expect(chain.getAmount('space')).toBe(MIN_EFFECT_AMOUNT);
     expect(source.chain).toHaveBeenLastCalledWith(destination);
+  });
+
+  // Regression test: EffectsChain.ensureNode() used to construct effect
+  // nodes with no explicit `context`, so they bound to whatever
+  // Tone.getContext() (the process-global current context) happened to be
+  // at that moment. Tone.Offline() (renderTrackOffline, used by the
+  // effects-refresh/preview pipeline) swaps that global context for the
+  // duration of its callback, so a live effect activated while an offline
+  // render was in flight would silently bind to the wrong, throwaway
+  // context — confirmed via a real-Tone.js repro to throw on the
+  // subsequent source.chain(...) call and leave the track permanently
+  // disconnected from the destination bus. Passing the source node's own
+  // context explicitly makes this immune to whatever the ambient global
+  // context is doing.
+  it("binds new effect nodes to the source node's own context, not the ambient global one", () => {
+    chain.setAmount('space', 40);
+    chain.setAmount('echo', 40);
+    chain.setAmount('tone', 40);
+
+    expect(Tone.Reverb).toHaveBeenCalledWith(
+      expect.objectContaining({ context: source.context }),
+    );
+    expect(Tone.FeedbackDelay).toHaveBeenCalledWith(
+      expect.objectContaining({ context: source.context }),
+    );
+    expect(Tone.Filter).toHaveBeenCalledWith(
+      expect.objectContaining({ context: source.context }),
+    );
   });
 
   it('reports amounts through the plain getter', () => {


### PR DESCRIPTION
## Summary

Continuing the investigation from a handover on "spectrogram rendering direction reversed after an effect commit" (sporadic, only during playback, no repro yet) plus a one-off report of the playhead frequency-visualizer bars disappearing mid-session while testing effects during playback.

Found and fixed a **confirmed** race condition in `EffectsChain`, discovered while chasing those symptoms:

- `Tone.Offline()` (used by `renderTrackOffline`/`renderTrackOfflineWindow` — the effects-refresh and live-preview pipelines) swaps the **process-global** Tone.js context for the entire duration of its callback, including a real `await reverb.ready` gap (`node_modules/tone/Tone/core/context/Offline.ts`).
- `EffectsChain.ensureNode()` constructed live-chain effect nodes (`new Tone.Reverb/FeedbackDelay/Filter`) with no explicit `context`, so a Space/Echo/Tone effect first activated (e.g. via a live slider drag) while an offline render was in flight would silently bind to that throwaway offline context instead of the real one.
- Verified with a real-Tone.js repro (not the app's mocked test harness): the subsequent `source.chain(...)` in `rewire()` throws (`cannot connect to an AudioNode belonging to a different audio context`), and since `source.disconnect()` already ran just before that, the track is left **permanently disconnected** from the destination bus for the rest of the session — silencing that track and starving any destination-tapped node (e.g. the playhead frequency visualizer's `WorkletAnalyser`, tapped at `Tone.getDestination()`) of its audio.

This is the strongest lead found so far for "effects + playback" races in this feature, and independently explains the frequency-visualizer symptom. It is **not** a certain, proven explanation of the spectrogram-direction-reversal symptom specifically — no repro for that one has been obtained yet — but it's a real, confirmed defect in the exact same window (effect changes racing offline renders during playback) and worth shipping regardless.

**Fix:** pass `context: this.source.context` explicitly when constructing effect nodes, so they're immune to whatever the ambient global Tone context is doing at construction time.

## Test plan

- [x] Added a regression test (`EffectsChain.test.ts`) asserting `Tone.Reverb`/`FeedbackDelay`/`Filter` are constructed with the source node's own `context` — confirmed it fails without the fix (`git stash` the source change, rerun) and passes with it.
- [x] `npm run lint` — clean
- [x] `npx vitest run src/features/tracks src/features/workstation` — 537/537 passing
- [x] Standalone real-Tone.js Playwright repro (throwaway, not committed) confirmed the underlying `Tone.Offline()` global-context race and the resulting `chain()` failure mode described above

## Next steps

- Still need a concrete repro for the spectrogram-direction-reversal symptom itself (which effect, track length, live-drag vs. post-commit, single vs. repeated commits, device) to confirm or rule out this fix as the root cause.


---
_Generated by [Claude Code](https://claude.ai/code/session_013RDWGnSCj9sBTMYYV2UR4K)_